### PR TITLE
Clean up output data when an output is removed

### DIFF
--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -44,7 +44,7 @@ impl Compositor {
                 panic!("Could not auto-create backend");
             }
             let mut input_manager = InputManager::new(input_manager_handler);
-            let mut output_manager = OutputManager::new(output_manager_handler);
+            let mut output_manager = OutputManager::new((vec![], output_manager_handler));
             wl_signal_add(&mut (*backend).events.input_add as *mut _ as _,
                           input_manager.add_listener() as *mut _ as _);
             wl_signal_add(&mut (*backend).events.input_remove as *mut _ as _,

--- a/src/manager/output.rs
+++ b/src/manager/output.rs
@@ -12,11 +12,19 @@ pub trait OutputHandler {
     fn output_resolution(&mut self, &mut output::Output) {}
 }
 
-wayland_listener!(Output, Box<OutputHandler>, [
+wayland_listener!(Output, (*mut wlr_output, Box<OutputHandler>), [
     frame_listener => frame_notify: |this: &mut Output, data: *mut libc::c_void,| unsafe {
-        this.data.output_frame(&mut output::Output::from_ptr(data as *mut wlr_output))
+        let manager = &mut this.data.1;
+        manager.output_frame(&mut output::Output::from_ptr(data as *mut wlr_output))
     };
     resolution_listener => resolution_notify: |this: &mut Output, data: *mut libc::c_void,| unsafe {
-        this.data.output_resolution(&mut output::Output::from_ptr(data as *mut wlr_output))
+        let manager = &mut this.data.1;
+        manager.output_resolution(&mut output::Output::from_ptr(data as *mut wlr_output))
     };
 ]);
+
+impl Output {
+    pub unsafe fn output_ptr(&self) -> *mut wlr_output {
+        self.data.0
+    }
+}

--- a/src/types/output.rs
+++ b/src/types/output.rs
@@ -155,11 +155,10 @@ impl Output {
 
 impl Drop for Output {
     fn drop(&mut self) {
-        // TODO Implement
-        // Also need to make sure it's not dropped except in the remove callback,
-        // since right now there's actually a lot of Output destruction which we don't
-        // want
-        // e.g need to make the from_ptr return ManuallyDrop<Output> now
+        // NOTE
+        // We do _not_ need to call wlr_output_destroy for the output
+        // That is handled by the backend automatically
+        // This is left here so no one does this in the future.
     }
 }
 


### PR DESCRIPTION
Fixes #11 
This also fixes an issue where the output would "flicker" once plugged back in due to re-used state/callbacks.

Lots of data being flung around though, better check if I can unify how
I store it / reduce the amount of data passed around.