### PR TITLE
Bugfix/fixed segfault on drm if mode not chosen

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -4,7 +4,8 @@ extern crate wlroots;
 use std::time::Instant;
 
 use wlroots::{Compositor, InputDevice, KeyEvent};
-use wlroots::{InputManagerHandler, KeyboardHandler, OutputHandler, OutputManagerHandler};
+use wlroots::{InputManagerHandler, KeyboardHandler, OutputBuilder, OutputBuilderResult,
+              OutputHandler, OutputManagerHandler};
 use wlroots::extensions::server_decoration::ServerDecorationMode;
 use wlroots::types::{KeyboardHandle, OutputHandle};
 use wlroots::wlroots_sys::gl;
@@ -45,13 +46,14 @@ impl InputManagerHandler for InputManager {
 }
 
 impl OutputManagerHandler for OutputManager {
-    fn output_added(&mut self, output: &mut OutputHandle) -> Option<Box<OutputHandler>> {
-        output.choose_best_mode();
-        Some(Box::new(Output {
-                          color: [0.0, 0.0, 0.0],
-                          dec: 0,
-                          last_frame: Instant::now()
-                      }))
+    fn output_added<'output>(&mut self,
+                             builder: OutputBuilder<'output>)
+                             -> Option<OutputBuilderResult<'output>> {
+        Some(builder.build_best_mode(Output {
+                                         color: [0.0, 0.0, 0.0],
+                                         dec: 0,
+                                         last_frame: Instant::now()
+                                     }))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,8 +44,8 @@ mod utils;
 pub use self::compositor::{Compositor, terminate};
 pub use self::events::key_events::*;
 pub use self::events::pointer_events::*;
-pub use self::manager::{InputManagerHandler, KeyboardHandler, OutputHandler, OutputManagerHandler,
-                        PointerHandler};
+pub use self::manager::{InputManagerHandler, KeyboardHandler, OutputBuilder, OutputBuilderResult,
+                        OutputHandler, OutputManagerHandler, PointerHandler};
 pub use self::types::cursor::*;
 pub use self::types::input_device::*;
 pub use self::types::keyboard::*;

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -6,6 +6,7 @@ mod user_output;
 
 pub use self::input_manager::{InputManager, InputManagerHandler};
 pub use self::keyboard_handler::{KeyboardHandler, KeyboardWrapper};
-pub use self::output_manager::{OutputManager, OutputManagerHandler};
+pub use self::output_manager::{OutputBuilder, OutputBuilderResult, OutputManager,
+                               OutputManagerHandler};
 pub use self::pointer_handler::{PointerHandler, PointerWrapper};
 pub use self::user_output::{OutputHandler, UserOutput};

--- a/src/manager/output_manager.rs
+++ b/src/manager/output_manager.rs
@@ -41,10 +41,6 @@ pub trait OutputManagerHandler {
     fn output_removed(&mut self, OutputDestruction) {
         // TODO
     }
-    /// Called every time the output frame is updated.
-    fn output_frame(&mut self, &mut OutputHandle) {}
-    /// Called every time the output resolution is updated.
-    fn output_resolution(&mut self, &mut OutputHandle) {}
 }
 
 

--- a/src/manager/output_manager.rs
+++ b/src/manager/output_manager.rs
@@ -26,7 +26,13 @@ impl<'output> OutputBuilder<'output> {
     pub fn build_best_mode<T: OutputHandler + 'static>(self,
                                                        data: T)
                                                        -> OutputBuilderResult<'output> {
-        self.output.choose_best_mode();
+        // NOTE Rationale for why this is safe:
+        // * The builder is only constructed in output_added callback
+        // * Can't be copied or otherwise escape (due to the lifetime constraints)
+        // * Is only called once per output because this function consumes
+        unsafe {
+            self.output.choose_best_mode();
+        }
         OutputBuilderResult {
             output: self.output,
             result: Box::new(data)

--- a/src/manager/output_manager.rs
+++ b/src/manager/output_manager.rs
@@ -48,13 +48,7 @@ impl<'output> OutputBuilder<'output> {
     pub fn build_best_mode<T: OutputHandler + 'static>(self,
                                                        data: T)
                                                        -> OutputBuilderResult<'output> {
-        // NOTE Rationale for why this is safe:
-        // * The builder is only constructed in output_added callback
-        // * Can't be copied or otherwise escape (due to the lifetime constraints)
-        // * Is only called once per output because this function consumes
-        unsafe {
-            self.output.choose_best_mode();
-        }
+        self.output.choose_best_mode();
         OutputBuilderResult {
             output: self.output,
             result: Box::new(data)

--- a/src/types/output.rs
+++ b/src/types/output.rs
@@ -75,7 +75,12 @@ impl OutputHandle {
     }
 
     /// Sets the best modesetting for an output.
-    pub fn choose_best_mode(&mut self) {
+    ///
+    /// NOTE You _cannot_ call this when the output will be removed.
+    /// It must only be called at startup.
+    /// For this reason, it's only public to the crate and is marked
+    /// `unsafe`.
+    pub(crate) unsafe fn choose_best_mode(&mut self) {
         unsafe {
             let length = ffi_dispatch!(WAYLAND_SERVER_HANDLE, wl_list_length, self.modes() as _);
             if length > 0 {

--- a/src/types/output.rs
+++ b/src/types/output.rs
@@ -78,9 +78,11 @@ impl OutputHandle {
     ///
     /// NOTE You _cannot_ call this when the output will be removed.
     /// It must only be called at startup.
-    /// For this reason, it's only public to the crate and is marked
-    /// `unsafe`.
-    pub(crate) unsafe fn choose_best_mode(&mut self) {
+    ///
+    /// I'm still marking it as safe though because we protect against that
+    /// action
+    /// in the output destruction callback.
+    pub fn choose_best_mode(&mut self) {
         unsafe {
             let length = ffi_dispatch!(WAYLAND_SERVER_HANDLE, wl_list_length, self.modes() as _);
             if length > 0 {


### PR DESCRIPTION
Fixes #52 

* Changes the output construction callback to take a builder and return an optional result from that builder. This is to ensure the mode is set on the output before anything else happens.
* Changes the output destruction callback so it takes a "locked down" `OutputHandle` so that you can't call methods that will cause unsafety (e.g mode setting)