### PR TITLE
Wrapped wlr_seat

### DIFF
--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -154,6 +154,14 @@ impl Compositor {
             ffi_dispatch!(WAYLAND_SERVER_HANDLE, wl_display_terminate, self.display);
         }
     }
+
+    pub unsafe fn display(&self) -> *mut wl_display {
+        self.display
+    }
+
+    pub unsafe fn event_loop(&self) -> *mut wl_event_loop {
+        self.event_loop
+    }
 }
 
 /// Terminates the compositor.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,3 +54,4 @@ pub use self::types::cursor::*;
 pub use self::types::input_device::*;
 pub use self::types::keyboard::*;
 pub use self::types::output::*;
+pub use self::types::seat::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,3 +55,4 @@ pub use self::types::input_device::*;
 pub use self::types::keyboard::*;
 pub use self::types::output::*;
 pub use self::types::seat::*;
+pub use self::types::surface::*;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -4,6 +4,7 @@ pub mod input_device;
 pub mod keyboard;
 pub mod output;
 pub mod area;
+pub mod seat;
 
 pub use self::area::*;
 pub use self::cursor::*;
@@ -11,3 +12,4 @@ pub use self::input_device::*;
 pub use self::keyboard::*;
 pub use self::output::*;
 pub use self::pointer::*;
+pub use self::seat::*;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -5,6 +5,7 @@ pub mod keyboard;
 pub mod output;
 pub mod area;
 pub mod seat;
+pub mod surface;
 
 pub use self::area::*;
 pub use self::cursor::*;
@@ -13,3 +14,4 @@ pub use self::keyboard::*;
 pub use self::output::*;
 pub use self::pointer::*;
 pub use self::seat::*;
+pub use self::surface::*;

--- a/src/types/seat/grab.rs
+++ b/src/types/seat/grab.rs
@@ -1,0 +1,43 @@
+use wlroots_sys::{wlr_seat_keyboard_grab, wlr_seat_pointer_grab, wlr_seat_touch_grab};
+
+pub struct PointerGrab {
+    grab: *mut wlr_seat_pointer_grab
+}
+
+pub struct KeyboardGrab {
+    grab: *mut wlr_seat_keyboard_grab
+}
+
+pub struct TouchGrab {
+    grab: *mut wlr_seat_touch_grab
+}
+
+impl PointerGrab {
+    pub unsafe fn as_ptr(&self) -> *mut wlr_seat_pointer_grab {
+        self.grab
+    }
+
+    pub unsafe fn from_ptr(grab: *mut wlr_seat_pointer_grab) -> Self {
+        PointerGrab { grab }
+    }
+}
+
+impl KeyboardGrab {
+    pub unsafe fn as_ptr(&self) -> *mut wlr_seat_keyboard_grab {
+        self.grab
+    }
+
+    pub unsafe fn from_ptr(grab: *mut wlr_seat_keyboard_grab) -> Self {
+        KeyboardGrab { grab }
+    }
+}
+
+impl TouchGrab {
+    pub unsafe fn as_ptr(&self) -> *mut wlr_seat_touch_grab {
+        self.grab
+    }
+
+    pub unsafe fn from_ptr(grab: *mut wlr_seat_touch_grab) -> Self {
+        TouchGrab { grab }
+    }
+}

--- a/src/types/seat/mod.rs
+++ b/src/types/seat/mod.rs
@@ -1,2 +1,3 @@
 pub mod seat_client;
 pub mod seat;
+pub mod grab;

--- a/src/types/seat/mod.rs
+++ b/src/types/seat/mod.rs
@@ -1,3 +1,4 @@
 pub mod seat_client;
 pub mod seat;
 pub mod grab;
+pub mod touch_point;

--- a/src/types/seat/mod.rs
+++ b/src/types/seat/mod.rs
@@ -1,0 +1,2 @@
+pub mod seat_client;
+pub mod seat;

--- a/src/types/seat/seat.rs
+++ b/src/types/seat/seat.rs
@@ -1,5 +1,7 @@
 //! Wrapper for wlr_seat. For more information about what a seat is, please
 //! consult the Wayland documentation ([libinput docs](https://wayland.freedesktop.org/libinput/doc/latest/seats.html), [wayland docs](https://wayland.freedesktop.org/docs/html/apa.html#protocol-spec-wl_seat))
+//!
+//! TODO This module could really use some examples, as the API surface is huge.
 
 use std::time::Duration;
 

--- a/src/types/seat/seat.rs
+++ b/src/types/seat/seat.rs
@@ -94,7 +94,7 @@ impl Seat {
     //
     // Coordinates for the enter event are surface-local.
     //
-    // Compositor should use `Seat::notify_enter` to
+    // Compositor should use `Seat::pointer_notify_enter` to
     // change pointer focus to respect pointer grabs.
     pub fn pointer_enter(&mut self, surface: Surface, sx: f64, sy: f64) {
         unsafe {
@@ -176,6 +176,17 @@ impl Seat {
     /// surfaces.
     pub fn pointer_clear_focus(&mut self) {
         unsafe { wlr_seat_pointer_clear_focus(self.seat) }
+    }
+
+    /// Send a keyboard enter event to the given surface and consider it to be the
+    /// focused surface for the keyboard.
+    ///
+    /// This will send a leave event to the last surface that was entered.
+    ///
+    /// Compositors should use `Seat::keyboard_notify_enter()` to
+    /// change keyboard focus to respect keyboard grabs.
+    pub fn keyboard_enter(&mut self, surface: Surface) {
+        unsafe { wlr_seat_keyboard_enter(self.seat, surface.as_ptr()) }
     }
 
     /// Start a grab of the keyboard of this seat. The grabber is responsible for

--- a/src/types/seat/seat.rs
+++ b/src/types/seat/seat.rs
@@ -213,6 +213,34 @@ impl Seat {
         unsafe { wlr_seat_keyboard_clear_focus(self.seat) }
     }
 
+    /// Notify the seat that the modifiers for the keyboard have changed.
+    ///
+    /// Defers to any keyboard grabs.
+    pub fn keyboard_notify_modifiers(&mut self) {
+        unsafe { wlr_seat_keyboard_notify_modifiers(self.seat) }
+    }
+
+    /// Notify the seat that the keyboard focus has changed and request it to be the
+    /// focused surface for this keyboard.
+    ///
+    /// Defers to any current grab of the seat's keyboard.
+    pub fn keyboard_notify_enter(&mut self, surface: Surface) {
+        unsafe { wlr_seat_keyboard_notify_enter(self.seat, surface.as_ptr()) }
+    }
+
+    // TODO Wrapper type for Key and State
+
+    /// Notify the seat that a key has been pressed on the keyboard.
+    ///
+    /// Defers to any keyboard grabs.
+    pub fn keyboard_notify_key(&mut self, time: Duration, key: u32, state: u32) {
+        // TODO Is this the correct amount of time to pass?
+        let seconds_delta = time.as_secs() as u32;
+        let nano_delta = time.subsec_nanos();
+        let ms = (seconds_delta * 1000) + nano_delta / 1000000;
+        unsafe { wlr_seat_keyboard_notify_key(self.seat, ms, key, state) }
+    }
+
     /// Start a grab of the touch device of this seat. The grabber is responsible for
     /// handling all touch events until the grab ends.
     pub fn touch_start_grab(&mut self, grab: TouchGrab) {

--- a/src/types/seat/seat.rs
+++ b/src/types/seat/seat.rs
@@ -28,6 +28,7 @@ use compositor::Compositor;
 use utils::{c_to_rust_string, safe_as_cstring};
 
 use super::grab::{KeyboardGrab, PointerGrab, TouchGrab};
+use super::touch_point::{TouchId, TouchPoint};
 use types::surface::Surface;
 
 /// A wrapper around `wlr_seat`.

--- a/src/types/seat/seat.rs
+++ b/src/types/seat/seat.rs
@@ -1,0 +1,154 @@
+//! Wrapper for wlr_seat. For more information about what a seat is, please
+//! consult the Wayland documentation ([libinput docs](https://wayland.freedesktop.org/libinput/doc/latest/seats.html), [wayland docs](https://wayland.freedesktop.org/docs/html/apa.html#protocol-spec-wl_seat))
+
+use std::time::Duration;
+
+use compositor::Compositor;
+use utils::{c_to_rust_string, safe_as_cstring};
+use wlroots_sys::{wlr_axis_orientation, wlr_seat, wlr_seat_create, wlr_seat_destroy,
+                  wlr_seat_pointer_clear_focus, wlr_seat_pointer_send_axis,
+                  wlr_seat_pointer_send_button, wlr_seat_pointer_send_motion,
+                  wlr_seat_set_capabilities, wlr_seat_set_name};
+use wlroots_sys::wayland_server::protocol::wl_seat::Capability;
+
+/// A wrapper around `wlr_seat`.
+pub struct Seat {
+    seat: *mut wlr_seat
+}
+
+impl Seat {
+    /// Allocates a new `wlr_seat` and adds a wl_seat global to the display.
+    pub fn create(compositor: &mut Compositor, name: String) -> Option<Self> {
+        unsafe {
+            let name = safe_as_cstring(name);
+            let seat = wlr_seat_create(compositor.display() as _, name.as_ptr());
+            if seat.is_null() {
+                None
+            } else {
+                Some(Seat { seat })
+            }
+        }
+    }
+
+    /// Get the name of the seat.
+    pub fn name(&self) -> Option<String> {
+        unsafe {
+            let name_ptr = (*self.seat).name;
+            if name_ptr.is_null() {
+                return None
+            }
+            c_to_rust_string(name_ptr)
+        }
+    }
+
+    /// Updates the name of this seat.
+    /// Will automatically send it to all clients.
+    pub fn set_name(&mut self, name: String) {
+        let name = safe_as_cstring(name);
+        unsafe {
+            wlr_seat_set_name(self.seat, name.as_ptr());
+        }
+    }
+
+    /// Gets the capabilities of this seat.
+    pub fn capabilities(&self) -> Capability {
+        unsafe {
+            Capability::from_raw((*self.seat).capabilities).expect("Invalid capabilities")
+        }
+    }
+
+    /// Updates the capabilities available on this seat.
+    /// Will automatically send it to all clients.
+    pub fn set_capabilities(&mut self, capabilities: Capability) {
+        unsafe { wlr_seat_set_capabilities(self.seat, capabilities.bits()) }
+    }
+
+    // TODO Need to wrap wlr_surface first
+    //
+    // // Determines if the surface has pointer focus.
+    // pub fn pointer_surface_has_focus(&mut self, surface: Surface) -> bool {
+    //    unsafe {
+    //        wlr_seat_pointer_surface_has_focus(self.seat, surface.as_ptr())
+    //    }
+    // }
+    //
+    // // Sends a pointer enter event to the given surface and considers it to be
+    // // the focused surface for the pointer.
+    // //
+    // // This will send a leave event to the last surface that was entered.
+    // //
+    // // Coordinates for the enter event are surface-local.
+    // //
+    // // Compositor should use `Seat::notify_enter` to
+    // // change pointer focus to respect pointer grabs.
+    // pub fn pointer_enter(&mut self, surface: Surface, sx: f64, sy: f64) {
+    //    unsafe {
+    //        wlr_seat_pointer_enter(surface.as_ptr(), sx, sy);
+    //    }
+    // }
+
+    /// Clears the focused surface for the pointer and leaves all entered
+    /// surfaces.
+    pub fn clear_focus(&mut self) {
+        unsafe { wlr_seat_pointer_clear_focus(self.seat) }
+    }
+
+    /// Sends a motion event to the surface with pointer focus.
+    ///
+    /// Coordinates for the motion event are surface-local.
+    ///
+    /// Compositors should use `Seat::notify_motion` to
+    /// send motion events to the respect pointer grabs.
+    pub fn send_motion(&mut self, time: Duration, sx: f64, sy: f64) {
+        let seconds_delta = time.as_secs() as u32;
+        let nano_delta = time.subsec_nanos();
+        let ms = (seconds_delta * 1000) + nano_delta / 1000000;
+        unsafe {
+            // TODO FIXME what kind of time? ms? s?
+            // I'm just guessing it's ms, there's no documentation on this.
+            wlr_seat_pointer_send_motion(self.seat, ms, sx, sy)
+        }
+    }
+
+    // TODO Button and State should probably be wrapped in some sort of type...
+
+    /// Send a button event to the surface with pointer focus.
+    ///
+    /// Coordinates for the button event are surface-local.
+    ///
+    /// Returns the serial.
+    ///
+    /// Compositors should use `Seat::notify_button` to
+    /// send button events to respect pointer grabs.
+    pub fn send_button(&mut self, time: Duration, button: u32, state: u32) -> u32 {
+        let seconds_delta = time.as_secs() as u32;
+        let nano_delta = time.subsec_nanos();
+        let ms = (seconds_delta * 1000) + nano_delta / 1000000;
+        unsafe { wlr_seat_pointer_send_button(self.seat, ms, button, state) }
+    }
+
+    /// Send an axis event to the surface with pointer focus.
+    ///
+    /// Compositors should use `Seat::notify_axis` to
+    /// send axis events to respect pointer grabs.
+    pub fn send_axis(&mut self, time: Duration, orientation: wlr_axis_orientation, value: f64) {
+        let seconds_delta = time.as_secs() as u32;
+        let nano_delta = time.subsec_nanos();
+        let ms = (seconds_delta * 1000) + nano_delta / 1000000;
+        unsafe {
+            wlr_seat_pointer_send_axis(self.seat, ms, orientation, value);
+        }
+    }
+
+    pub unsafe fn to_ptr(&self) -> *mut wlr_seat {
+        self.seat
+    }
+
+    // TODO grab, notify, and some other specific input misc functions
+}
+
+impl Drop for Seat {
+    fn drop(&mut self) {
+        unsafe { wlr_seat_destroy(self.seat) }
+    }
+}

--- a/src/types/seat/seat.rs
+++ b/src/types/seat/seat.rs
@@ -3,15 +3,25 @@
 
 use std::time::Duration;
 
-use wlroots_sys::{wlr_axis_orientation, wlr_seat, wlr_seat_create, wlr_seat_destroy,
-                  wlr_seat_keyboard_end_grab, wlr_seat_keyboard_has_grab,
-                  wlr_seat_keyboard_start_grab, wlr_seat_pointer_clear_focus,
-                  wlr_seat_pointer_end_grab, wlr_seat_pointer_enter, wlr_seat_pointer_has_grab,
-                  wlr_seat_pointer_send_axis, wlr_seat_pointer_send_button,
-                  wlr_seat_pointer_send_motion, wlr_seat_pointer_start_grab,
-                  wlr_seat_pointer_surface_has_focus, wlr_seat_set_capabilities,
-                  wlr_seat_set_name, wlr_seat_touch_end_grab, wlr_seat_touch_has_grab,
-                  wlr_seat_touch_start_grab};
+use wlroots_sys::{wlr_axis_orientation, wlr_seat, wlr_seat_client, wlr_seat_create,
+                  wlr_seat_destroy, wlr_seat_keyboard_clear_focus, wlr_seat_keyboard_end_grab,
+                  wlr_seat_keyboard_enter, wlr_seat_keyboard_has_grab,
+                  wlr_seat_keyboard_notify_enter, wlr_seat_keyboard_notify_key,
+                  wlr_seat_keyboard_notify_modifiers, wlr_seat_keyboard_send_key,
+                  wlr_seat_keyboard_send_modifiers, wlr_seat_keyboard_start_grab,
+                  wlr_seat_pointer_clear_focus, wlr_seat_pointer_end_grab, wlr_seat_pointer_enter,
+                  wlr_seat_pointer_has_grab, wlr_seat_pointer_notify_axis,
+                  wlr_seat_pointer_notify_button, wlr_seat_pointer_notify_enter,
+                  wlr_seat_pointer_notify_motion, wlr_seat_pointer_send_axis,
+                  wlr_seat_pointer_send_button, wlr_seat_pointer_send_motion,
+                  wlr_seat_pointer_start_grab, wlr_seat_pointer_surface_has_focus,
+                  wlr_seat_set_capabilities, wlr_seat_set_keyboard, wlr_seat_set_name,
+                  wlr_seat_touch_end_grab, wlr_seat_touch_has_grab, wlr_seat_touch_notify_down,
+                  wlr_seat_touch_notify_motion, wlr_seat_touch_notify_up,
+                  wlr_seat_touch_num_points, wlr_seat_touch_point_clear_focus,
+                  wlr_seat_touch_point_focus, wlr_seat_touch_send_down,
+                  wlr_seat_touch_send_motion, wlr_seat_touch_send_up, wlr_seat_touch_start_grab,
+                  wlr_touch_point};
 use wlroots_sys::wayland_server::protocol::wl_seat::Capability;
 
 use compositor::Compositor;

--- a/src/types/seat/seat.rs
+++ b/src/types/seat/seat.rs
@@ -172,6 +172,12 @@ impl Seat {
         unsafe { wlr_seat_pointer_has_grab(self.seat) }
     }
 
+    /// Clear the focused surface for the pointer and leave all entered
+    /// surfaces.
+    pub fn pointer_clear_focus(&mut self) {
+        unsafe { wlr_seat_pointer_clear_focus(self.seat) }
+    }
+
     /// Start a grab of the keyboard of this seat. The grabber is responsible for
     /// handling all keyboard events until the grab ends.
     pub fn keyboard_start_grab(&mut self, grab: KeyboardGrab) {
@@ -187,6 +193,12 @@ impl Seat {
     /// Whether or not the keyboard has a grab other than the default grab
     pub fn keyboard_has_grab(&self) -> bool {
         unsafe { wlr_seat_keyboard_has_grab(self.seat) }
+    }
+
+    /// Clear the focused surface for the keyboard and leave all entered
+    /// surfaces.
+    pub fn keyboard_clear_focus(&mut self) {
+        unsafe { wlr_seat_keyboard_clear_focus(self.seat) }
     }
 
     /// Start a grab of the touch device of this seat. The grabber is responsible for

--- a/src/types/seat/seat.rs
+++ b/src/types/seat/seat.rs
@@ -179,6 +179,50 @@ impl Seat {
         unsafe { wlr_seat_pointer_clear_focus(self.seat) }
     }
 
+    /// Notify the seat of a pointer enter event to the given surface and request it
+    /// to be the focused surface for the pointer.
+    ///
+    /// Pass surface-local coordinates where the enter occurred.
+    pub fn pointer_notify_enter(&mut self, surface: Surface, sx: f64, sy: f64) {
+        unsafe { wlr_seat_pointer_notify_enter(self.seat, surface.as_ptr(), sx, sy) }
+    }
+
+    /// Notify the seat of motion over the given surface.
+    ///
+    /// Pass surface-local coordinates where the pointer motion occurred.
+    pub fn pointer_notify_motion(&mut self, time: Duration, sx: f64, sy: f64) {
+        // TODO Is this the correct amount of time to pass?
+        let seconds_delta = time.as_secs() as u32;
+        let nano_delta = time.subsec_nanos();
+        let ms = (seconds_delta * 1000) + nano_delta / 1000000;
+        unsafe { wlr_seat_pointer_notify_motion(self.seat, ms, sx, sy) }
+    }
+
+    // TODO Wrapper type around Button and State
+
+    /// Notify the seat that a button has been pressed.
+    ///
+    /// Returns the serial of the button press or zero if no button press was sent.
+    pub fn pointer_notify_button(&mut self, time: Duration, button: u32, state: u32) -> u32 {
+        // TODO Is this the correct amount of time to pass?
+        let seconds_delta = time.as_secs() as u32;
+        let nano_delta = time.subsec_nanos();
+        let ms = (seconds_delta * 1000) + nano_delta / 1000000;
+        unsafe { wlr_seat_pointer_notify_button(self.seat, ms, button, state) }
+    }
+
+    /// Notify the seat of an axis event.
+    pub fn pointer_notify_axis(&mut self,
+                               time: Duration,
+                               orientation: wlr_axis_orientation,
+                               value: f64) {
+        // TODO Is this the correct amount of time to pass?
+        let seconds_delta = time.as_secs() as u32;
+        let nano_delta = time.subsec_nanos();
+        let ms = (seconds_delta * 1000) + nano_delta / 1000000;
+        unsafe { wlr_seat_pointer_notify_axis(self.seat, ms, orientation, value) }
+    }
+
     /// Send a keyboard enter event to the given surface and consider it to be the
     /// focused surface for the keyboard.
     ///

--- a/src/types/seat/seat.rs
+++ b/src/types/seat/seat.rs
@@ -273,6 +273,12 @@ impl Seat {
         unsafe { wlr_seat_touch_notify_up(self.seat, ms, touch_id.into()) }
     }
 
+    /// Notify the seat that the touch point given by `touch_id` has moved.
+    ///
+    /// Defers to any grab of the touch device.
+    ///
+    /// The seat should be notified of touch motion even if the surface is
+    /// not the owner of the touch point for processing by grabs.
     pub fn touch_notify_motion(&mut self, time: Duration, touch_id: TouchId, sx: f64, sy: f64) {
         // TODO Is this the correct amount of time to pass?
         let seconds_delta = time.as_secs() as u32;
@@ -280,7 +286,6 @@ impl Seat {
         let ms = (seconds_delta * 1000) + nano_delta / 1000000;
         unsafe { wlr_seat_touch_notify_motion(self.seat, ms, touch_id.into(), sx, sy) }
     }
-    // TODO notify and some other specific input misc functions
 
     pub unsafe fn to_ptr(&self) -> *mut wlr_seat {
         self.seat

--- a/src/types/seat/seat.rs
+++ b/src/types/seat/seat.rs
@@ -172,26 +172,36 @@ impl Seat {
         unsafe { wlr_seat_pointer_has_grab(self.seat) }
     }
 
+    /// Start a grab of the keyboard of this seat. The grabber is responsible for
+    /// handling all keyboard events until the grab ends.
     pub fn keyboard_start_grab(&mut self, grab: KeyboardGrab) {
         unsafe { wlr_seat_keyboard_start_grab(self.seat, grab.as_ptr()) }
     }
 
+    /// End the grab of the keyboard of this seat. This reverts the grab back to the
+    /// default grab for the keyboard.
     pub fn keyboard_end_grab(&mut self) {
         unsafe { wlr_seat_keyboard_end_grab(self.seat) }
     }
 
+    /// Whether or not the keyboard has a grab other than the default grab
     pub fn keyboard_has_grab(&self) -> bool {
         unsafe { wlr_seat_keyboard_has_grab(self.seat) }
     }
 
+    /// Start a grab of the touch device of this seat. The grabber is responsible for
+    /// handling all touch events until the grab ends.
     pub fn touch_start_grab(&mut self, grab: TouchGrab) {
         unsafe { wlr_seat_touch_start_grab(self.seat, grab.as_ptr()) }
     }
 
+    /// End the grab of the touch device of this seat. This reverts the grab back to
+    /// the default grab for the touch device.
     pub fn touch_end_grab(&mut self) {
         unsafe { wlr_seat_touch_end_grab(self.seat) }
     }
 
+    /// Whether or not the seat has a touch grab other than the default grab.
     pub fn touch_has_grab(&self) -> bool {
         unsafe { wlr_seat_touch_has_grab(self.seat) }
     }

--- a/src/types/seat/seat_client.rs
+++ b/src/types/seat/seat_client.rs
@@ -1,0 +1,60 @@
+//! Wrapper for wlr_seat_client, a manager for handling seats to an individual
+//! client.
+//!
+//! This struct is very unsafe, and probably will not be used directly by the
+//! compositor author. Instead, this is used internally by various wlr seat
+//! state structs (e.g `wlr_seat_keyboard_state`, `wlr_seat_pointer_state`)
+
+use std::marker::PhantomData;
+
+use super::seat::Seat;
+
+use wlroots_sys::{wl_client, wlr_seat_client, wlr_seat_client_for_wl_client};
+
+/// Contains state for a single client's bound wl_seat resource.
+/// It can be used to issue input events to the client.
+///
+/// The lifetime of this object is managed by `Seat`.
+pub struct SeatClient<'wlr_seat> {
+    client: *mut wlr_seat_client,
+    _phantom: PhantomData<&'wlr_seat Seat>
+}
+
+impl<'wlr_seat> SeatClient<'wlr_seat> {
+    /// Gets a SeatClient for the specified client,
+    /// if there is one bound for that client.
+    ///
+    /// # Unsafety
+    /// Since this just is a wrapper for checking if the wlr_seat pointer matches
+    /// the provided wl_client pointer, this function is unsafe.
+    ///
+    /// Please only pass a valid pointer to a wl_client to this function.
+    pub unsafe fn client_for_wl_client(seat: &'wlr_seat mut Seat,
+                                       client: *mut wl_client)
+                                       -> Option<SeatClient<'wlr_seat>> {
+        let client = wlr_seat_client_for_wl_client(seat.to_ptr(), client);
+        if client.is_null() {
+            None
+        } else {
+            Some(SeatClient { client,
+                              _phantom: PhantomData })
+        }
+    }
+
+    /// Recreates a `SeatClient` from a raw `wlr_seat_client`.
+    ///
+    /// # Unsafety
+    /// The pointer must point to a valid `wlr_seat_client`.
+    ///
+    /// Note also that the struct has an *boundless lifetime*. You _must_ ensure
+    /// this struct does not live longer than the `Seat` that manages it.
+    pub unsafe fn from_ptr<'unbound_seat>(client: *mut wlr_seat_client)
+                                          -> SeatClient<'unbound_seat> {
+        SeatClient { client,
+                     _phantom: PhantomData }
+    }
+
+    pub unsafe fn to_ptr(&self) -> *mut wlr_seat_client {
+        self.client
+    }
+}

--- a/src/types/seat/touch_point.rs
+++ b/src/types/seat/touch_point.rs
@@ -1,0 +1,33 @@
+use wlroots_sys::wlr_touch_point;
+
+#[derive(Clone)]
+pub struct TouchPoint {
+    touch_point: *mut wlr_touch_point
+}
+
+/// Wrapper around a touch id. It is valid, as it is only returned from wlroots.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct TouchId(i32);
+
+// Note that we implement `Into` here because we _don't_ want to be able to
+// convert from any i32 into a `TouchId`
+impl Into<i32> for TouchId {
+    fn into(self) -> i32 {
+        self.0
+    }
+}
+
+impl TouchPoint {
+    /// Get the touch id associated for this point.
+    pub fn touch_id(&self) -> TouchId {
+        unsafe { TouchId((*self.touch_point).touch_id) }
+    }
+
+    pub unsafe fn as_ptr(&self) -> *mut wlr_touch_point {
+        self.touch_point
+    }
+
+    pub unsafe fn from_ptr(touch_point: *mut wlr_touch_point) -> Self {
+        TouchPoint { touch_point }
+    }
+}

--- a/src/types/surface.rs
+++ b/src/types/surface.rs
@@ -1,0 +1,17 @@
+//! TODO
+
+use wlroots_sys::wlr_surface;
+
+pub struct Surface {
+    surface: *mut wlr_surface
+}
+
+impl Surface {
+    pub unsafe fn as_ptr(&self) -> *mut wlr_surface {
+        self.surface
+    }
+
+    pub unsafe fn from_ptr(surface: *mut wlr_surface) -> Self {
+        Surface { surface }
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,7 +2,24 @@
 
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
+use std::time::Duration;
 use std::process::exit;
+
+/// Trait to convert something to mili seconds.
+///
+/// Used primarily to convert a `std::time::Duration` into
+/// something usable by wlroots
+pub trait ToMS {
+    fn to_ms(self) -> u32;
+}
+
+impl ToMS for Duration {
+    fn to_ms(self) -> u32 {
+        let seconds_delta = self.as_secs() as u32;
+        let nano_delta = self.subsec_nanos();
+        (seconds_delta * 1000) + nano_delta / 1000000
+    }
+}
 
 /// Converts a Rust string into C string without error handling.
 /// If any error occurs, it is logged and then the program is immediantly

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,7 @@
 //! Utility functions for use within wlroots-rs
 
-use std::ffi::CString;
+use std::ffi::{CStr, CString};
+use std::os::raw::c_char;
 use std::process::exit;
 
 /// Converts a Rust string into C string without error handling.
@@ -17,5 +18,15 @@ pub fn safe_as_cstring<S>(string: S) -> CString
                      err);
             exit(1)
         }
+    }
+}
+
+/// Converts a C string into a Rust string without error handling.
+/// The pointer passed to this function _must_ be valid.
+pub unsafe fn c_to_rust_string(c_str: *const c_char) -> Option<String> {
+    if c_str.is_null() {
+        None
+    } else {
+        Some(CStr::from_ptr(c_str).to_string_lossy().into_owned())
     }
 }

--- a/wlroots-sys/src/lib.rs
+++ b/wlroots-sys/src/lib.rs
@@ -1,9 +1,9 @@
 #![allow(non_camel_case_types, non_upper_case_globals)]
 
 extern crate libc;
-extern crate wayland_server;
+pub extern crate wayland_server;
 #[macro_use]
-extern crate wayland_sys;
+pub extern crate wayland_sys;
 
 // For graphical functions
 pub mod gl {


### PR DESCRIPTION
# Compositor
* Allow (unsafe) access to display and event_loop pointers

# Seats
* Wrapped grabs
* Wrapped Seat and Seat Clients
* Wrapped Touch Points

# Surfaces
* Stubbed out surfaces

# Utils
* Added `c_to_rust_string`
* Added `ToMS` trait, implemented for `std::time::Duration` to convert it to milliseconds 

  