### PR TITLE
Handle-ify wlroots owned objects

### DIFF
--- a/examples/pointer.rs
+++ b/examples/pointer.rs
@@ -7,7 +7,7 @@ use wlroots::{AxisEvent, ButtonEvent, Compositor, CompositorBuilder, Cursor, Inp
               KeyEvent, KeyboardHandler, MotionEvent, OutputBuilder, OutputBuilderResult,
               OutputHandler, OutputLayout, OutputManagerHandler, PointerHandler, XCursor,
               XCursorTheme};
-use wlroots::types::{KeyboardHandle, OutputHandle, PointerHandle};
+use wlroots::types::{KeyboardHandle, OutputHandle, Pointer};
 use wlroots::wlroots_sys::gl;
 use wlroots::wlroots_sys::wlr_button_state::WLR_BUTTON_RELEASED;
 use wlroots::xkbcommon::xkb::keysyms::KEY_Escape;
@@ -36,7 +36,7 @@ struct Output;
 
 struct InputManager;
 
-struct Pointer;
+struct ExPointer;
 
 struct ExKeyboardHandler;
 
@@ -77,20 +77,14 @@ impl KeyboardHandler for ExKeyboardHandler {
     }
 }
 
-impl PointerHandler for Pointer {
-    fn on_motion(&mut self,
-                 compositor: &mut Compositor,
-                 _: &mut PointerHandle,
-                 event: &MotionEvent) {
+impl PointerHandler for ExPointer {
+    fn on_motion(&mut self, compositor: &mut Compositor, _: &mut Pointer, event: &MotionEvent) {
         let state: &mut State = compositor.into();
         let (delta_x, delta_y) = event.delta();
         state.cursor.move_to(&event.device(), delta_x, delta_y);
     }
 
-    fn on_button(&mut self,
-                 compositor: &mut Compositor,
-                 _: &mut PointerHandle,
-                 event: &ButtonEvent) {
+    fn on_button(&mut self, compositor: &mut Compositor, _: &mut Pointer, event: &ButtonEvent) {
         let state: &mut State = compositor.into();
         if event.state() == WLR_BUTTON_RELEASED {
             state.color = state.default_color;
@@ -100,7 +94,7 @@ impl PointerHandler for Pointer {
         }
     }
 
-    fn on_axis(&mut self, compositor: &mut Compositor, _: &mut PointerHandle, event: &AxisEvent) {
+    fn on_axis(&mut self, compositor: &mut Compositor, _: &mut Pointer, event: &AxisEvent) {
         let state: &mut State = compositor.into();
         for color_byte in &mut state.default_color[..3] {
             *color_byte += if event.delta() > 0.0 { -0.05 } else { 0.05 };
@@ -130,9 +124,9 @@ impl OutputHandler for Output {
 impl InputManagerHandler for InputManager {
     fn pointer_added(&mut self,
                      _: &mut Compositor,
-                     _: &mut PointerHandle)
+                     _: &mut Pointer)
                      -> Option<Box<PointerHandler>> {
-        Some(Box::new(Pointer))
+        Some(Box::new(ExPointer))
     }
 
     fn keyboard_added(&mut self,

--- a/examples/pointer.rs
+++ b/examples/pointer.rs
@@ -7,7 +7,7 @@ use wlroots::{AxisEvent, ButtonEvent, Compositor, CompositorBuilder, Cursor, Inp
               KeyEvent, KeyboardHandler, MotionEvent, OutputBuilder, OutputBuilderResult,
               OutputHandler, OutputLayout, OutputManagerHandler, PointerHandler, XCursor,
               XCursorTheme};
-use wlroots::types::{Keyboard, OutputHandle, Pointer};
+use wlroots::types::{Keyboard, Output, Pointer};
 use wlroots::wlroots_sys::gl;
 use wlroots::wlroots_sys::wlr_button_state::WLR_BUTTON_RELEASED;
 use wlroots::xkbcommon::xkb::keysyms::KEY_Escape;
@@ -32,7 +32,7 @@ compositor_data!(State);
 
 struct OutputManager;
 
-struct Output;
+struct ExOutput;
 
 struct InputManager;
 
@@ -45,7 +45,7 @@ impl OutputManagerHandler for OutputManager {
                              compositor: &mut Compositor,
                              builder: OutputBuilder<'output>)
                              -> Option<OutputBuilderResult<'output>> {
-        let result = builder.build_best_mode(Output);
+        let result = builder.build_best_mode(ExOutput);
         let state: &mut State = compositor.into();
         let cursor = &mut state.cursor;
         // TODO use output config if present instead of auto
@@ -106,8 +106,8 @@ impl PointerHandler for ExPointer {
     }
 }
 
-impl OutputHandler for Output {
-    fn output_frame(&mut self, compositor: &mut Compositor, output: &mut OutputHandle) {
+impl OutputHandler for ExOutput {
+    fn output_frame(&mut self, compositor: &mut Compositor, output: &mut Output) {
         let state: &mut State = compositor.into();
         output.make_current();
         unsafe {

--- a/examples/pointer.rs
+++ b/examples/pointer.rs
@@ -7,7 +7,7 @@ use wlroots::{AxisEvent, ButtonEvent, Compositor, CompositorBuilder, Cursor, Inp
               KeyEvent, KeyboardHandler, MotionEvent, OutputBuilder, OutputBuilderResult,
               OutputHandler, OutputLayout, OutputManagerHandler, PointerHandler, XCursor,
               XCursorTheme};
-use wlroots::types::{KeyboardHandle, OutputHandle, Pointer};
+use wlroots::types::{Keyboard, OutputHandle, Pointer};
 use wlroots::wlroots_sys::gl;
 use wlroots::wlroots_sys::wlr_button_state::WLR_BUTTON_RELEASED;
 use wlroots::xkbcommon::xkb::keysyms::KEY_Escape;
@@ -65,10 +65,7 @@ impl OutputManagerHandler for OutputManager {
 }
 
 impl KeyboardHandler for ExKeyboardHandler {
-    fn on_key(&mut self,
-              compositor: &mut Compositor,
-              _: &mut KeyboardHandle,
-              key_event: &mut KeyEvent) {
+    fn on_key(&mut self, compositor: &mut Compositor, _: &mut Keyboard, key_event: &mut KeyEvent) {
         for key in key_event.input_keys() {
             if key == KEY_Escape {
                 compositor.terminate()
@@ -131,7 +128,7 @@ impl InputManagerHandler for InputManager {
 
     fn keyboard_added(&mut self,
                       _: &mut Compositor,
-                      _: &mut KeyboardHandle)
+                      _: &mut Keyboard)
                       -> Option<Box<KeyboardHandler>> {
         Some(Box::new(ExKeyboardHandler))
     }

--- a/examples/rotation.rs
+++ b/examples/rotation.rs
@@ -7,7 +7,7 @@ use std::time::Instant;
 use wlroots::{Compositor, CompositorBuilder, InputManagerHandler, KeyEvent, KeyboardHandler,
               OutputBuilder, OutputBuilderResult, OutputHandler, OutputManagerHandler};
 use wlroots::render::{Texture, TextureFormat};
-use wlroots::types::{KeyboardHandle, OutputHandle};
+use wlroots::types::{Keyboard, OutputHandle};
 use wlroots::wlroots_sys::wl_output_transform;
 use wlroots::xkbcommon::xkb::keysyms;
 
@@ -113,17 +113,14 @@ impl OutputHandler for Output {
 impl InputManagerHandler for InputManager {
     fn keyboard_added(&mut self,
                       _: &mut Compositor,
-                      _: &mut KeyboardHandle)
+                      _: &mut Keyboard)
                       -> Option<Box<KeyboardHandler>> {
         Some(Box::new(KeyboardManager))
     }
 }
 
 impl KeyboardHandler for KeyboardManager {
-    fn on_key(&mut self,
-              compositor: &mut Compositor,
-              _: &mut KeyboardHandle,
-              key_event: &mut KeyEvent) {
+    fn on_key(&mut self, compositor: &mut Compositor, _: &mut Keyboard, key_event: &mut KeyEvent) {
         let keys = key_event.input_keys();
 
         for key in keys {

--- a/examples/rotation.rs
+++ b/examples/rotation.rs
@@ -7,7 +7,7 @@ use std::time::Instant;
 use wlroots::{Compositor, CompositorBuilder, InputManagerHandler, KeyEvent, KeyboardHandler,
               OutputBuilder, OutputBuilderResult, OutputHandler, OutputManagerHandler};
 use wlroots::render::{Texture, TextureFormat};
-use wlroots::types::{Keyboard, OutputHandle};
+use wlroots::types::{Keyboard, Output};
 use wlroots::wlroots_sys::wl_output_transform;
 use wlroots::xkbcommon::xkb::keysyms;
 
@@ -57,7 +57,7 @@ impl CompositorState {
 
 struct OutputManager;
 
-struct Output;
+struct ExOutput;
 
 struct InputManager;
 
@@ -69,15 +69,15 @@ impl OutputManagerHandler for OutputManager {
                              builder: OutputBuilder<'output>)
                              -> Option<OutputBuilderResult<'output>> {
         let compositor_data: &mut CompositorState = compositor.into();
-        let output = Output;
+        let output = ExOutput;
         let res = builder.build_best_mode(output);
         res.output.transform(compositor_data.rotation);
         Some(res)
     }
 }
 
-impl OutputHandler for Output {
-    fn output_frame(&mut self, compositor: &mut Compositor, output: &mut OutputHandle) {
+impl OutputHandler for ExOutput {
+    fn output_frame(&mut self, compositor: &mut Compositor, output: &mut Output) {
         let (width, height) = output.effective_resolution();
         let renderer = compositor.gles2
                                  .as_mut()

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -5,11 +5,11 @@ use std::time::Instant;
 
 use wlroots::{Compositor, CompositorBuilder, InputManagerHandler, KeyEvent, KeyboardHandler,
               OutputBuilder, OutputBuilderResult, OutputHandler, OutputManagerHandler};
-use wlroots::types::{Keyboard, OutputHandle};
+use wlroots::types::{Keyboard, Output};
 use wlroots::wlroots_sys::gl;
 use wlroots::xkbcommon::xkb::keysyms::KEY_Escape;
 
-struct Output {
+struct ExOutput {
     color: [f32; 3],
     dec: usize,
     last_frame: Instant
@@ -54,14 +54,14 @@ impl OutputManagerHandler for OutputManager {
                              _: &mut Compositor,
                              builder: OutputBuilder<'output>)
                              -> Option<OutputBuilderResult<'output>> {
-        Some(builder.build_best_mode(Output { color: [0.0, 0.0, 0.0],
-                                              dec: 0,
-                                              last_frame: Instant::now() }))
+        Some(builder.build_best_mode(ExOutput { color: [0.0, 0.0, 0.0],
+                                                dec: 0,
+                                                last_frame: Instant::now() }))
     }
 }
 
-impl OutputHandler for Output {
-    fn output_frame(&mut self, _: &mut Compositor, output: &mut OutputHandle) {
+impl OutputHandler for ExOutput {
+    fn output_frame(&mut self, _: &mut Compositor, output: &mut Output) {
         let now = Instant::now();
         let delta = now.duration_since(self.last_frame);
         let seconds_delta = delta.as_secs();

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 
 use wlroots::{Compositor, CompositorBuilder, InputManagerHandler, KeyEvent, KeyboardHandler,
               OutputBuilder, OutputBuilderResult, OutputHandler, OutputManagerHandler};
-use wlroots::types::{KeyboardHandle, OutputHandle};
+use wlroots::types::{Keyboard, OutputHandle};
 use wlroots::wlroots_sys::gl;
 use wlroots::xkbcommon::xkb::keysyms::KEY_Escape;
 
@@ -23,7 +23,7 @@ struct ExKeyboardHandler;
 impl KeyboardHandler for ExKeyboardHandler {
     fn on_key(&mut self,
               compositor: &mut Compositor,
-              keyboard: &mut KeyboardHandle,
+              keyboard: &mut Keyboard,
               key_event: &mut KeyEvent) {
         let keys = key_event.input_keys();
 
@@ -43,7 +43,7 @@ impl KeyboardHandler for ExKeyboardHandler {
 impl InputManagerHandler for InputManager {
     fn keyboard_added(&mut self,
                       _: &mut Compositor,
-                      _: &mut KeyboardHandle)
+                      _: &mut Keyboard)
                       -> Option<Box<KeyboardHandler>> {
         Some(Box::new(ExKeyboardHandler))
     }

--- a/src/manager/input_manager.rs
+++ b/src/manager/input_manager.rs
@@ -9,7 +9,7 @@ use std::process::abort;
 
 use super::{KeyboardHandler, KeyboardWrapper, PointerHandler, PointerWrapper};
 use compositor::{Compositor, COMPOSITOR_PTR};
-use types::{InputDevice, KeyboardHandle, Pointer};
+use types::{InputDevice, Keyboard, Pointer};
 use utils::safe_as_cstring;
 
 use wayland_sys::server::WAYLAND_SERVER_HANDLE;
@@ -45,10 +45,7 @@ pub trait InputManagerHandler {
         // TODO
     }
 
-    fn keyboard_added(&mut self,
-                      &mut Compositor,
-                      &mut KeyboardHandle)
-                      -> Option<Box<KeyboardHandler>> {
+    fn keyboard_added(&mut self, &mut Compositor, &mut Keyboard) -> Option<Box<KeyboardHandler>> {
         None
     }
 
@@ -70,7 +67,7 @@ wayland_listener!(InputManager, (Vec<Input>, Box<InputManagerHandler>), [
                     // Boring setup that we won't make the user do
                     add_keyboard(&mut dev);
                     // Get the optional user keyboard struct, add the on_key signal
-                    let mut keyboard_handle = match KeyboardHandle::from_input_device(data) {
+                    let mut keyboard_handle = match Keyboard::from_input_device(data) {
                         Some(dev) => dev,
                         None => {
                             wlr_log!(L_ERROR, "Device {:#?} was not a keyboard!", dev);

--- a/src/manager/input_manager.rs
+++ b/src/manager/input_manager.rs
@@ -9,7 +9,7 @@ use std::process::abort;
 
 use super::{KeyboardHandler, KeyboardWrapper, PointerHandler, PointerWrapper};
 use compositor::{Compositor, COMPOSITOR_PTR};
-use types::{InputDevice, KeyboardHandle, PointerHandle};
+use types::{InputDevice, KeyboardHandle, Pointer};
 use utils::safe_as_cstring;
 
 use wayland_sys::server::WAYLAND_SERVER_HANDLE;
@@ -52,10 +52,7 @@ pub trait InputManagerHandler {
         None
     }
 
-    fn pointer_added(&mut self,
-                     &mut Compositor,
-                     &mut PointerHandle)
-                     -> Option<Box<PointerHandler>> {
+    fn pointer_added(&mut self, &mut Compositor, &mut Pointer) -> Option<Box<PointerHandler>> {
         None
     }
 }
@@ -92,7 +89,7 @@ wayland_listener!(InputManager, (Vec<Input>, Box<InputManagerHandler>), [
                 },
                 WLR_INPUT_DEVICE_POINTER => {
                     // Get the optional user pointer struct, add the signals
-                    let mut pointer_handle = match PointerHandle::from_input_device(data) {
+                    let mut pointer_handle = match Pointer::from_input_device(data) {
                         Some(dev) => dev,
                         None => {
                             wlr_log!(L_ERROR, "Device {:#?} was not a pointer!", dev);

--- a/src/manager/keyboard_handler.rs
+++ b/src/manager/keyboard_handler.rs
@@ -4,20 +4,20 @@ use libc;
 
 use compositor::{Compositor, COMPOSITOR_PTR};
 use events::key_events::KeyEvent;
-use types::KeyboardHandle;
+use types::Keyboard;
 
 use wlroots_sys::{wlr_event_keyboard_key, wlr_input_device};
 
 pub trait KeyboardHandler {
     /// Callback that is triggered when a key is pressed.
-    fn on_key(&mut self, &mut Compositor, &mut KeyboardHandle, &mut KeyEvent) {}
+    fn on_key(&mut self, &mut Compositor, &mut Keyboard, &mut KeyEvent) {}
 }
 
-wayland_listener!(KeyboardWrapper, (KeyboardHandle, Box<KeyboardHandler>), [
+wayland_listener!(KeyboardWrapper, (Keyboard, Box<KeyboardHandler>), [
     key_listener => key_notify: |this: &mut KeyboardWrapper, data: *mut libc::c_void,| unsafe {
         let (ref mut keyboard, ref mut keyboard_handler) = this.data;
         let compositor = &mut *COMPOSITOR_PTR;
-        let xkb_state = (*keyboard.to_ptr()).xkb_state;
+        let xkb_state = (*keyboard.keyboard_ptr()).xkb_state;
         let mut key = KeyEvent::new(data as *mut wlr_event_keyboard_key, xkb_state);
 
         keyboard_handler.on_key(compositor, keyboard, &mut key)

--- a/src/manager/output_manager.rs
+++ b/src/manager/output_manager.rs
@@ -5,7 +5,7 @@
 use compositor::{Compositor, COMPOSITOR_PTR};
 use libc;
 use manager::{OutputHandler, UserOutput};
-use types::OutputHandle;
+use types::Output;
 
 use wayland_sys::server::WAYLAND_SERVER_HANDLE;
 use wayland_sys::server::signal::wl_signal_add;
@@ -14,19 +14,19 @@ use wlroots_sys::wlr_output;
 /// Used to ensure the output sets the mode before doing any other
 /// operation on the Output.
 pub struct OutputBuilder<'output> {
-    output: &'output mut OutputHandle
+    output: &'output mut Output
 }
 
 /// Used to ensure that the builder is used to construct
 /// the OutputHandler instance.
 pub struct OutputBuilderResult<'output> {
-    pub output: &'output mut OutputHandle,
+    pub output: &'output mut Output,
     result: Box<OutputHandler>
 }
 
 /// Wrapper around Output destruction so that you can't call
 /// unsafe methods (e.g anything like setting the mode).
-pub struct OutputDestruction<'output>(&'output mut OutputHandle);
+pub struct OutputDestruction<'output>(&'output mut Output);
 
 /// Handles output addition and removal.
 pub trait OutputManagerHandler {
@@ -62,12 +62,22 @@ wayland_listener!(OutputManager, (Vec<Box<UserOutput>>, Box<OutputManagerHandler
     add_listener => add_notify: |this: &mut OutputManager, data: *mut libc::c_void,| unsafe {
         let (ref mut outputs, ref mut manager) = this.data;
         let data = data as *mut wlr_output;
-        let mut output = OutputHandle::from_ptr(data as *mut wlr_output);
+        let mut output = Output::new(data as *mut wlr_output);
+        // NOTE
+        // This clone is required because we pass it mutably to the output builder,
+        // but due to lack of NLL there's no way to tell Rust it's safe to use it in
+        // in the if branch.
+        //
+        // Thus, we need to clone it here and then drop the original once at the end.
+        //
+        // This is not a real clone, but an pub(crate) unsafe one we added, so it doesn't
+        // break safety concerns in user code. Just an unfortunate hack we have to put here.
+        let output_clone = output.clone();
         let builder = OutputBuilder { output: &mut output };
         let compositor = &mut *COMPOSITOR_PTR;
-        if let Some(OutputBuilderResult {result: output, ..}) = manager.output_added(compositor,
-                                                                                     builder) {
-            let mut output = UserOutput::new((data, output));
+        let build_result = manager.output_added(compositor, builder);
+        if let Some(OutputBuilderResult {result: output_ptr, .. }) = build_result {
+            let mut output = UserOutput::new((output_clone, output_ptr));
             // Add the output frame event to this manager
             wl_signal_add(&mut (*data).events.frame as *mut _ as _,
                         output.frame_listener() as _);
@@ -81,11 +91,20 @@ wayland_listener!(OutputManager, (Vec<Box<UserOutput>>, Box<OutputManagerHandler
     remove_listener => remove_notify: |this: &mut OutputManager, data: *mut libc::c_void,| unsafe {
         let (ref mut outputs, ref mut manager) = this.data;
         let data = data as *mut wlr_output;
-        let mut output = OutputHandle::from_ptr(data);
-        let compositor = &mut *COMPOSITOR_PTR;
-        manager.output_removed(compositor, OutputDestruction(&mut output));
-        if let Some(layout) = output.layout() {
-            layout.borrow_mut().remove(&mut output);
+        // NOTE
+        // We get it from the list so that we can get the Rc'd `Output`, because there's
+        // no way to re-construct that using just the raw pointer.
+        {
+            let output = &mut outputs.iter_mut().find(|output| output.output_ptr() == data)
+                // NOTE
+                // Rationale for panicking: Will be caught by panic catchers.
+                .expect("remove_listener got an output that it doesn't control!")
+                .output_mut();
+            let compositor = &mut *COMPOSITOR_PTR;
+            manager.output_removed(compositor, OutputDestruction(output));
+            if let Some(layout) = output.layout() {
+                layout.borrow_mut().remove(output);
+            }
         }
         // Remove user output data
         if let Some(index) = outputs.iter().position(|output| output.output_ptr() == data) {

--- a/src/manager/pointer_handler.rs
+++ b/src/manager/pointer_handler.rs
@@ -4,24 +4,24 @@ use libc;
 
 use compositor::{Compositor, COMPOSITOR_PTR};
 use events::pointer_events::{AbsoluteMotionEvent, AxisEvent, ButtonEvent, MotionEvent};
-use types::PointerHandle;
+use types::Pointer;
 
 use wlroots_sys::{wlr_event_pointer_axis, wlr_event_pointer_button, wlr_event_pointer_motion,
                   wlr_input_device};
 
 pub trait PointerHandler {
     /// Callback that is triggered when the pointer moves.
-    fn on_motion(&mut self, &mut Compositor, &mut PointerHandle, &MotionEvent) {}
+    fn on_motion(&mut self, &mut Compositor, &mut Pointer, &MotionEvent) {}
 
-    fn on_motion_absolute(&mut self, &mut Compositor, &mut PointerHandle, &AbsoluteMotionEvent) {}
+    fn on_motion_absolute(&mut self, &mut Compositor, &mut Pointer, &AbsoluteMotionEvent) {}
 
     /// Callback that is triggered when the buttons on the pointer are pressed.
-    fn on_button(&mut self, &mut Compositor, &mut PointerHandle, &ButtonEvent) {}
+    fn on_button(&mut self, &mut Compositor, &mut Pointer, &ButtonEvent) {}
 
-    fn on_axis(&mut self, &mut Compositor, &mut PointerHandle, &AxisEvent) {}
+    fn on_axis(&mut self, &mut Compositor, &mut Pointer, &AxisEvent) {}
 }
 
-wayland_listener!(PointerWrapper, (PointerHandle, Box<PointerHandler>), [
+wayland_listener!(PointerWrapper, (Pointer, Box<PointerHandler>), [
     button_listener => key_notify: |this: &mut PointerWrapper, data: *mut libc::c_void,| unsafe {
         let event = ButtonEvent::from_ptr(data as *mut wlr_event_pointer_button);
         let compositor = &mut *COMPOSITOR_PTR;

--- a/src/render/gles2.rs
+++ b/src/render/gles2.rs
@@ -1,5 +1,5 @@
 use render::Texture;
-use types::OutputHandle;
+use types::Output;
 
 use wlroots_sys::{wlr_backend, wlr_render_texture_create, wlr_render_with_matrix, wlr_renderer,
                   wlr_renderer_begin, wlr_renderer_destroy, wlr_renderer_end,
@@ -13,7 +13,7 @@ pub struct GLES2 {
 /// Renderer for GLES2
 pub struct GLES2Renderer<'output> {
     renderer: *mut wlr_renderer,
-    output: &'output mut OutputHandle
+    output: &'output mut Output
 }
 
 impl GLES2 {
@@ -31,7 +31,7 @@ impl GLES2 {
         }
     }
 
-    pub fn render<'output>(&mut self, output: &'output mut OutputHandle) -> GLES2Renderer<'output> {
+    pub fn render<'output>(&mut self, output: &'output mut Output) -> GLES2Renderer<'output> {
         output.make_current();
         unsafe {
             wlr_renderer_begin(self.renderer, output.to_ptr());

--- a/src/types/keyboard.rs
+++ b/src/types/keyboard.rs
@@ -133,6 +133,25 @@ impl KeyboardHandle {
             .map(|_| Keyboard::from_handle(self))
     }
 
+    /// Run a function on the referenced Keyboard, if it still exists
+    ///
+    /// Returns the result of the function, if successful
+    ///
+    /// # Safety
+    /// By enforcing a rather harsh limit on the lifetime of the output
+    /// to a short lived scope of an anonymous function,
+    /// this function ensures the Keyboard does not live longer
+    /// than it exists.
+    pub fn run<F, R>(&self, runner: F) -> Option<R>
+        where F: FnOnce(&Keyboard) -> R
+    {
+        let pointer = unsafe { self.upgrade() };
+        match pointer {
+            None => None,
+            Some(pointer) => Some(runner(&pointer))
+        }
+    }
+
     /// Gets the wlr_input_device associated with this KeyboardHandle
     pub unsafe fn input_device(&self) -> *mut wlr_input_device {
         self.device

--- a/src/types/keyboard.rs
+++ b/src/types/keyboard.rs
@@ -99,6 +99,26 @@ impl Keyboard {
     }
 }
 
+impl Drop for Keyboard {
+    fn drop(&mut self) {
+        match self.liveliness {
+            None => {}
+            Some(ref liveliness) => {
+                if Rc::strong_count(liveliness) == 1 {
+                    wlr_log!(L_DEBUG, "Dropped Keyboard {:p}", self.keyboard);
+                    let weak_count = Rc::weak_count(liveliness);
+                    if weak_count > 0 {
+                        wlr_log!(L_DEBUG,
+                                 "Still {} weak pointers to Keyboard {:p}",
+                                 weak_count,
+                                 self.keyboard);
+                    }
+                }
+            }
+        }
+    }
+}
+
 impl KeyboardHandle {
     /// Upgrades the keyboard handle to a reference to the backing `Keyboard`.
     ///

--- a/src/types/keyboard.rs
+++ b/src/types/keyboard.rs
@@ -123,13 +123,14 @@ impl KeyboardHandle {
     /// Upgrades the keyboard handle to a reference to the backing `Keyboard`.
     ///
     /// # Unsafety
-    /// This function is unsafe, because it creates a lifetime bound to
-    /// KeyboardHandle, which may live forever..
+    /// This function is unsafe, because it creates an unbounded `Keyboard`
+    /// which may live forever..
     /// But no keyboard lives forever and might be disconnected at any time.
     pub unsafe fn upgrade(&self) -> Option<Keyboard> {
         self.handle.upgrade()
         // NOTE
-        // We drop the upgrade here because we don't want to cause a memory leak!
+        // We drop the Rc here because having two would allow a dangling
+        // pointer to exist!
             .map(|_| Keyboard::from_handle(self))
     }
 

--- a/src/types/keyboard.rs
+++ b/src/types/keyboard.rs
@@ -125,7 +125,7 @@ impl KeyboardHandle {
     /// # Unsafety
     /// This function is unsafe, because it creates a lifetime bound to
     /// KeyboardHandle, which may live forever..
-    /// But no output lives forever and might be disconnected at any time.
+    /// But no keyboard lives forever and might be disconnected at any time.
     pub unsafe fn upgrade(&self) -> Option<Keyboard> {
         self.handle.upgrade()
         // NOTE

--- a/src/types/output.rs
+++ b/src/types/output.rs
@@ -241,13 +241,14 @@ impl OutputHandle {
     /// Upgrades the output handle to a reference to the backing `Output`.
     ///
     /// # Unsafety
-    /// This function is unsafe, because it creates a lifetime bound to
-    /// OutputHandle, which may live forever..
+    /// This function is unsafe, because it creates an unbound `Output`
+    /// which may live forever..
     /// But no output lives forever and might be disconnected at any time.
     pub unsafe fn upgrade(&self) -> Option<Output> {
         self.handle.upgrade()
             // NOTE
-            // We drop the upgrade here because we don't want to cause a memory leak!
+            // We drop the Rc here because having two would allow a dangling
+            // pointer to exist!
             .map(|_| Output::from_handle(self))
     }
 

--- a/src/types/output.rs
+++ b/src/types/output.rs
@@ -253,6 +253,25 @@ impl OutputHandle {
             .map(|_| Output::from_handle(self))
     }
 
+    /// Run a function on the referenced Output, if it still exists
+    ///
+    /// Returns the result of the function, if successful
+    ///
+    /// # Safety
+    /// By enforcing a rather harsh limit on the lifetime of the output
+    /// to a short lived scope of an anonymous function,
+    /// this function ensures the Output does not live longer
+    /// than it exists.
+    pub fn run<F, R>(&self, runner: F) -> Option<R>
+        where F: FnOnce(&Output) -> R
+    {
+        let output = unsafe { self.upgrade() };
+        match output {
+            None => None,
+            Some(output) => Some(runner(&output))
+        }
+    }
+
     pub unsafe fn as_ptr(&self) -> *mut wlr_output {
         self.output
     }

--- a/src/types/output.rs
+++ b/src/types/output.rs
@@ -105,11 +105,9 @@ impl Output {
     /// Sets the best modesetting for an output.
     ///
     /// NOTE You _cannot_ call this when the output will be removed.
-    /// It must only be called at startup.
     ///
     /// I'm still marking it as safe though because we protect against that
-    /// action
-    /// in the output destruction callback.
+    /// action in the output destruction callback.
     pub fn choose_best_mode(&mut self) {
         unsafe {
             let length = ffi_dispatch!(WAYLAND_SERVER_HANDLE, wl_list_length, self.modes() as _);

--- a/src/types/output.rs
+++ b/src/types/output.rs
@@ -1,3 +1,9 @@
+//! TODO Documentation
+
+use std::cell::RefCell;
+use std::ffi::CStr;
+use std::rc::{Rc, Weak};
+
 use wayland_sys::server::WAYLAND_SERVER_HANDLE;
 use wlroots_sys::{wl_list, wl_output_transform, wlr_output, wlr_output_effective_resolution,
                   wlr_output_events, wlr_output_layout, wlr_output_layout_add_auto,
@@ -5,17 +11,35 @@ use wlroots_sys::{wl_list, wl_output_transform, wlr_output, wlr_output_effective
                   wlr_output_make_current, wlr_output_mode, wlr_output_set_mode,
                   wlr_output_set_transform, wlr_output_swap_buffers};
 
-use std::cell::RefCell;
-use std::ffi::CStr;
-use std::rc::Rc;
-
 pub struct OutputState {
     pub layout: Option<Rc<RefCell<OutputLayout>>>
+}
+
+#[derive(Debug)]
+pub struct Output {
+    /// The structure that ensures weak handles to this structure are still alive.
+    ///
+    /// They contain weak handles, and will safely not use dead memory when this
+    /// is freed by wlroots.
+    ///
+    /// If this is `None`, then this is from an upgraded `OutputHandle`, and
+    /// the operations are **unchecked**.
+    /// This is means safe operations might fail, but only if you use the unsafe
+    /// marked function `upgrade` on a `OutputHandle`.
+    liveliness: Option<Rc<()>>,
+    /// The output ptr that refers to this `Output`
+    output: *mut wlr_output
 }
 
 /// A wrapper around a wlr_output.
 #[derive(Debug)]
 pub struct OutputHandle {
+    /// The Rc that ensures that this handle is still alive.
+    ///
+    /// When wlroots deallocates the pointer associated with this handle,
+    /// this can no longer be used.
+    handle: Weak<()>,
+    /// The output ptr that refers to this `Output`
     output: *mut wlr_output
 }
 
@@ -24,7 +48,29 @@ pub struct OutputLayout {
     layout: *mut wlr_output_layout
 }
 
-impl OutputHandle {
+impl Output {
+    /// Just like `std::clone::Clone`, but unsafe.
+    ///
+    /// # Unsafety
+    /// You can create a reference leak using this method very easily,
+    /// and it could make it so that weak handles to an output are dangling.
+    ///
+    /// This exists due to an issue in output_manager.rs that might be fixed
+    /// with NLL, so if this is no longer necessary it should be removed asap.
+    pub(crate) unsafe fn clone(&self) -> Output {
+        Output { liveliness: self.liveliness.clone(),
+                 output: self.output }
+    }
+
+    /// Makes a new `Output` from a `wlr_output`.
+    ///
+    /// # Unsafety
+    // Do not call this function multiple times for the same `wlr_output`.
+    pub unsafe fn new(output: *mut wlr_output) -> Self {
+        Output { liveliness: Some(Rc::new(())),
+                 output }
+    }
+
     pub unsafe fn set_user_data(&mut self, data: Rc<OutputState>) {
         (*self.output).data = Rc::into_raw(data) as *mut _
     }
@@ -148,21 +194,31 @@ impl OutputHandle {
         (*self.output).events
     }
 
-    pub unsafe fn from_ptr(output: *mut wlr_output) -> Self {
-        OutputHandle { output }
-    }
-
     pub unsafe fn to_ptr(&self) -> *mut wlr_output {
         self.output
     }
 }
 
-impl Drop for OutputHandle {
+impl Drop for Output {
     fn drop(&mut self) {
         // NOTE
         // We do _not_ need to call wlr_output_destroy for the output
         // That is handled by the backend automatically
-        // This is left here so no one does this in the future.
+        match self.liveliness {
+            None => {}
+            Some(ref liveliness) => {
+                if Rc::strong_count(liveliness) == 1 {
+                    wlr_log!(L_DEBUG, "Dropped output {:p}", self.output);
+                    let weak_count = Rc::weak_count(liveliness);
+                    if weak_count > 0 {
+                        wlr_log!(L_DEBUG,
+                                 "Still {} weak pointers to Output {:p}",
+                                 weak_count,
+                                 self.output);
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -183,7 +239,7 @@ impl OutputLayout {
     /// The underlying function hasn't been proven to be stable if you
     /// pass it an invalid OutputHandle (e.g one that has already been freed).
     /// For now, this function is unsafe
-    pub unsafe fn remove(&mut self, output: &mut OutputHandle) {
+    pub unsafe fn remove(&mut self, output: &mut Output) {
         wlr_output_layout_remove(self.layout, output.to_ptr())
     }
 }

--- a/src/types/pointer.rs
+++ b/src/types/pointer.rs
@@ -1,14 +1,42 @@
+//! TODO Documentation
+
+use std::rc::{Rc, Weak};
+
 use wlroots_sys::{wlr_input_device, wlr_pointer};
 
-/// A wlr_input_device that is guaranteed to be a pointer.
-pub struct PointerHandle {
-    /// The device that refers to this pointer
+#[derive(Debug)]
+pub struct Pointer {
+    /// The structure that ensures weak handles to this structure are still alive.
+    ///
+    /// They containe weak handles, and will safely not use dead memory when this
+    /// is freed by wlroots.
+    ///
+    /// If this is `None`, then this is from an upgraded `PointerHandle`, and
+    /// the operations are **unchecked**.
+    /// This is means safe operations might fail, but only if you use the unsafe
+    /// marked function `upgrade` on a `PointerHandle`.
+    liveliness: Option<Rc<()>>,
+    /// The device that refers to this pointer.
     device: *mut wlr_input_device,
-    /// The underlying pointer data
+    /// The underlying pointer data.
     pointer: *mut wlr_pointer
 }
 
-impl PointerHandle {
+/// A wlr_input_device that is guaranteed to be a pointer.
+#[derive(Debug)]
+pub struct PointerHandle {
+    /// The Rc that ensures that this handle is still alive.
+    ///
+    /// When wlroots deallocates the pointer associated with this handle,
+    /// this can no longer be used.
+    handle: Weak<()>,
+    /// The device that refers to this pointer.
+    device: *mut wlr_input_device,
+    /// The underlying pointer data.
+    pointer: *mut wlr_pointer
+}
+
+impl Pointer {
     /// Tries to convert an input device to a pointer
     ///
     /// Returns none if it is of a different input varient.
@@ -17,17 +45,65 @@ impl PointerHandle {
         match (*device).type_ {
             WLR_INPUT_DEVICE_POINTER => {
                 let pointer = (*device).__bindgen_anon_1.pointer;
-                Some(PointerHandle { device, pointer })
+                Some(Pointer { liveliness: Some(Rc::new(())),
+                               device,
+                               pointer })
             }
             _ => None
         }
     }
 
-    /// Gets the wlr_input_device associated with this Pointer
+    /// Creates an unbound Pointer from a `PointerHandle`
+    pub unsafe fn from_handle(handle: &PointerHandle) -> Pointer {
+        Pointer { liveliness: None,
+                  device: handle.input_device(),
+                  pointer: handle.pointer() }
+    }
+
+    /// Gets the wlr_input_device associated with this Pointer.
     pub unsafe fn input_device(&self) -> *mut wlr_input_device {
         self.device
     }
 
+    /// Gets the wlr_pointer associated with this Pointer.
+    pub unsafe fn pointer(&self) -> *mut wlr_pointer {
+        self.pointer
+    }
+
+    /// Creates a weak reference to a `Pointer`.
+    ///
+    /// # Panics
+    /// If this `Pointer` is a previously upgraded `PointerHandle`,
+    /// then this function will panic.
+    pub fn weak_reference(&self) -> PointerHandle {
+        let arc = self.liveliness.as_ref()
+                      .expect("Cannot downgrade a previously upgraded PointerHandle!");
+        PointerHandle { handle: Rc::downgrade(arc),
+                        device: self.device,
+                        pointer: self.pointer }
+    }
+}
+
+impl PointerHandle {
+    /// Upgrades the pointer handle to a reference to the backing `Pointer`.
+    ///
+    /// # Unsafety
+    /// This function is unsafe, because it creates a lifetime bound to
+    /// PointerHandle, which may live forever..
+    /// But no output lives forever and might be disconnected at any time.
+    pub unsafe fn upgrade(&self) -> Option<Pointer> {
+        self.handle.upgrade()
+            // NOTE
+            // We drop the upgrade here because we don't want to cause a memory leak!
+            .map(|_| Pointer::from_handle(self))
+    }
+
+    /// Gets the wlr_input_device associated with this PointerHandle.
+    pub unsafe fn input_device(&self) -> *mut wlr_input_device {
+        self.device
+    }
+
+    /// Gets the wlr_pointer associated with this PointerHandle.
     pub unsafe fn pointer(&self) -> *mut wlr_pointer {
         self.pointer
     }

--- a/src/types/pointer.rs
+++ b/src/types/pointer.rs
@@ -54,7 +54,7 @@ impl Pointer {
     }
 
     /// Creates an unbound Pointer from a `PointerHandle`
-    pub unsafe fn from_handle(handle: &PointerHandle) -> Pointer {
+    unsafe fn from_handle(handle: &PointerHandle) -> Self {
         Pointer { liveliness: None,
                   device: handle.input_device(),
                   pointer: handle.pointer_ptr() }

--- a/src/types/pointer.rs
+++ b/src/types/pointer.rs
@@ -8,7 +8,7 @@ use wlroots_sys::{wlr_input_device, wlr_pointer};
 pub struct Pointer {
     /// The structure that ensures weak handles to this structure are still alive.
     ///
-    /// They containe weak handles, and will safely not use dead memory when this
+    /// They contain weak handles, and will safely not use dead memory when this
     /// is freed by wlroots.
     ///
     /// If this is `None`, then this is from an upgraded `PointerHandle`, and
@@ -57,7 +57,7 @@ impl Pointer {
     pub unsafe fn from_handle(handle: &PointerHandle) -> Pointer {
         Pointer { liveliness: None,
                   device: handle.input_device(),
-                  pointer: handle.pointer() }
+                  pointer: handle.pointer_ptr() }
     }
 
     /// Gets the wlr_input_device associated with this Pointer.
@@ -66,7 +66,7 @@ impl Pointer {
     }
 
     /// Gets the wlr_pointer associated with this Pointer.
-    pub unsafe fn pointer(&self) -> *mut wlr_pointer {
+    pub unsafe fn pointer_ptr(&self) -> *mut wlr_pointer {
         self.pointer
     }
 
@@ -104,7 +104,7 @@ impl PointerHandle {
     }
 
     /// Gets the wlr_pointer associated with this PointerHandle.
-    pub unsafe fn pointer(&self) -> *mut wlr_pointer {
+    pub unsafe fn pointer_ptr(&self) -> *mut wlr_pointer {
         self.pointer
     }
 }

--- a/src/types/pointer.rs
+++ b/src/types/pointer.rs
@@ -118,6 +118,25 @@ impl PointerHandle {
             .map(|_| Pointer::from_handle(self))
     }
 
+    /// Run a function on the referenced Pointer, if it still exists
+    ///
+    /// Returns the result of the function, if successful
+    ///
+    /// # Safety
+    /// By enforcing a rather harsh limit on the lifetime of the output
+    /// to a short lived scope of an anonymous function,
+    /// this function ensures the Pointer does not live longer
+    /// than it exists.
+    pub fn run<F, R>(&self, runner: F) -> Option<R>
+        where F: FnOnce(&Pointer) -> R
+    {
+        let pointer = unsafe { self.upgrade() };
+        match pointer {
+            None => None,
+            Some(pointer) => Some(runner(&pointer))
+        }
+    }
+
     /// Gets the wlr_input_device associated with this PointerHandle.
     pub unsafe fn input_device(&self) -> *mut wlr_input_device {
         self.device

--- a/src/types/pointer.rs
+++ b/src/types/pointer.rs
@@ -108,13 +108,14 @@ impl PointerHandle {
     /// Upgrades the pointer handle to a reference to the backing `Pointer`.
     ///
     /// # Unsafety
-    /// This function is unsafe, because it creates a lifetime bound to
-    /// PointerHandle, which may live forever..
+    /// This function is unsafe, because it creates an unbound `Pointer`
+    /// which may live forever..
     /// But no pointer lives forever and might be disconnected at any time.
     pub unsafe fn upgrade(&self) -> Option<Pointer> {
         self.handle.upgrade()
             // NOTE
-            // We drop the upgrade here because we don't want to cause a memory leak!
+            // We drop the Rc here because having two would allow a dangling
+            // pointer to exist!
             .map(|_| Pointer::from_handle(self))
     }
 

--- a/src/types/pointer.rs
+++ b/src/types/pointer.rs
@@ -84,6 +84,26 @@ impl Pointer {
     }
 }
 
+impl Drop for Pointer {
+    fn drop(&mut self) {
+        match self.liveliness {
+            None => {}
+            Some(ref liveliness) => {
+                if Rc::strong_count(liveliness) == 1 {
+                    wlr_log!(L_DEBUG, "Dropped Pointer {:p}", self.pointer);
+                    let weak_count = Rc::weak_count(liveliness);
+                    if weak_count > 0 {
+                        wlr_log!(L_DEBUG,
+                                 "Still {} weak pointers to Pointer {:p}",
+                                 weak_count,
+                                 self.pointer);
+                    }
+                }
+            }
+        }
+    }
+}
+
 impl PointerHandle {
     /// Upgrades the pointer handle to a reference to the backing `Pointer`.
     ///

--- a/src/types/pointer.rs
+++ b/src/types/pointer.rs
@@ -110,7 +110,7 @@ impl PointerHandle {
     /// # Unsafety
     /// This function is unsafe, because it creates a lifetime bound to
     /// PointerHandle, which may live forever..
-    /// But no output lives forever and might be disconnected at any time.
+    /// But no pointer lives forever and might be disconnected at any time.
     pub unsafe fn upgrade(&self) -> Option<Pointer> {
         self.handle.upgrade()
             // NOTE


### PR DESCRIPTION
Stealing a bit from [wlc.rs](https://github.com/Drakulix/wlc.rs) here, I changed how `Keyboard`, `Pointer`, and `Output` function by making some "owned" types that are passed by reference in the callbacks (so just like before) and a `*Handle` struct for each type that can be constructed from those owned types.

E.g, given a `Pointer` you can make a `PointerHandle` which you can store within your compositor state. Internally, it uses an `Rc<()>`/`Weak<()>` (so essentially just a non-atomic counter) to ensure that when you use a handle it will actually exist. To use this safely, you pass it a callback to `run` that will execute code within a limited context that ensures that the handle is valid (e.g as long as we are in this callback, it's valid to use).

I haven't done this with `InputDevice` yet because I'm not sure how often that will be necessary / don't want to cause issues with conflicting `Keyboard` and `Pointer` handles. It will depend on how much conversion between an `InputDevice` and the underlying device type happens and how we deal with that.

One other thing this design might help with is `OutputLayout`, which right now _requires_ being a `Rc<RefCell>` to be referred to in `Cursor`s and `Output`s. Instead, what will probably happen is that the `OutputLayout` will hold an `OutputHandle` and it can do the appropriate things with that (and if it fails, it can return an error and remove it from its internal list of `wlr_output`s it manages). Not sure what I'll do with `Cursor`, as that's owned by the wlroots-rs user and I have to double check you can't add the same cursor to multiple `OutputLayout`s (but I believe you can).

That last change hasn't happened yet, as I want to independently verify this is correct before I do that. And because I need more thought into how I'll structure `Cursor` along with it.

**EDIT:** As can be seen on [this line in wlroots](https://github.com/swaywm/wlroots/blob/e46d2dd0f884c96bb535c280a6ec9ea616d39b5c/types/wlr_cursor.c#L575) it looks like a cursor can only be on one `OutputLayout`. So that's good! Still need to ensure there's no time you want access to a `Cursor` but you don't have access to the layout, or that you want to in some way share that so that e.g you can swap two cursors very easily without having to reconstruct them (but that might be an edge case I shouldn't worry about)

Also added better logging so that we can see _exactly_ when a wlroots-owned object is destroyed and how many weak handles still exist to it.