### PR TITLE
Fixed InputDevice safety hole, allow conversions from concrete device types

### DIFF
--- a/src/events/key_events.rs
+++ b/src/events/key_events.rs
@@ -9,14 +9,21 @@ pub struct KeyEvent {
 }
 
 impl KeyEvent {
+    /// Constructs a KeyEvent from the raw key event pointer information.
     pub(crate) unsafe fn new(key: *mut wlr_event_keyboard_key, xkb_state: *mut xkb_state) -> Self {
         KeyEvent { key, xkb_state }
     }
 
+    /// Gets the raw keycode from the device.
+    ///
+    /// Usually you want to use `KeyEvent::input_keys` since you care about what
+    /// value XKB says this is.
     pub fn keycode(&self) -> u32 {
         unsafe { (*self.key).keycode + 8 }
     }
 
+    /// Gets the keys that are pressed using XKB to convert them to a more
+    /// programmer friendly form.
     pub fn input_keys(&self) -> Vec<Key> {
         unsafe {
             let mut syms = 0 as *const xkb_keysym_t;

--- a/src/events/pointer_events.rs
+++ b/src/events/pointer_events.rs
@@ -40,7 +40,7 @@ pub struct AbsoluteMotionEvent {
 
 impl ButtonEvent {
     /// Constructs a `ButtonEvent` from the raw event pointer.
-    pub unsafe fn from_ptr(event: *mut wlr_event_pointer_button) -> Self {
+    pub(crate) unsafe fn from_ptr(event: *mut wlr_event_pointer_button) -> Self {
         ButtonEvent { device: InputDevice::from_ptr((*event).device),
                       event }
     }
@@ -67,7 +67,7 @@ impl ButtonEvent {
 
 impl AxisEvent {
     /// Constructs a `AxisEvent` from a raw event pointer.
-    pub unsafe fn from_ptr(event: *mut wlr_event_pointer_axis) -> Self {
+    pub(crate) unsafe fn from_ptr(event: *mut wlr_event_pointer_axis) -> Self {
         AxisEvent { device: InputDevice::from_ptr((*event).device),
                     event }
     }
@@ -87,7 +87,7 @@ impl AxisEvent {
 
 impl MotionEvent {
     /// Constructs a `MotionEvent` from a raw event pointer.
-    pub unsafe fn from_ptr(event: *mut wlr_event_pointer_motion) -> Self {
+    pub(crate) unsafe fn from_ptr(event: *mut wlr_event_pointer_motion) -> Self {
         MotionEvent { device: InputDevice::from_ptr((*event).device),
                       event }
     }
@@ -111,7 +111,7 @@ impl MotionEvent {
 
 impl AbsoluteMotionEvent {
     /// Construct an `AbsoluteMotionEvent` from a raw event pointer.
-    pub unsafe fn from_ptr(event: *mut wlr_event_pointer_motion_absolute) -> Self {
+    pub(crate) unsafe fn from_ptr(event: *mut wlr_event_pointer_motion_absolute) -> Self {
         AbsoluteMotionEvent { device: InputDevice::from_ptr((*event).device),
                               event }
     }

--- a/src/events/pointer_events.rs
+++ b/src/events/pointer_events.rs
@@ -7,34 +7,34 @@ use wlroots_sys::{wlr_button_state, wlr_event_pointer_axis, wlr_event_pointer_bu
 
 pub type ButtonState = wlr_button_state;
 
-#[derive(Debug)]
 /// Event that triggers when the pointer device scrolls (e.g using a wheel
 // or in the case of a touchpad when you use two fingers to scroll).
+#[derive(Debug)]
 pub struct AxisEvent {
     event: *mut wlr_event_pointer_axis,
     device: InputDevice
 }
 
-#[derive(Debug)]
 /// Event that triggers when a button is pressed (e.g left click, right click,
 /// a gaming mouse button, etc.).
+#[derive(Debug)]
 pub struct ButtonEvent {
     event: *mut wlr_event_pointer_button,
     device: InputDevice
 }
 
-#[derive(Debug)]
 /// Event that triggers when the pointer moves.
+#[derive(Debug)]
 pub struct MotionEvent {
     event: *mut wlr_event_pointer_motion,
     device: InputDevice
 }
 
-#[derive(Debug)]
 /// Event that triggers when data from a device that supports absolute motion
 /// sends data to the compositor.
 ///
 /// For more information on absolute motion, [see this link](https://wayland.freedesktop.org/libinput/doc/latest/absolute_axes.html).
+#[derive(Debug)]
 pub struct AbsoluteMotionEvent {
     event: *mut wlr_event_pointer_motion_absolute,
     device: InputDevice

--- a/src/events/pointer_events.rs
+++ b/src/events/pointer_events.rs
@@ -5,25 +5,39 @@ use types::input_device::InputDevice;
 use wlroots_sys::{wlr_button_state, wlr_event_pointer_axis, wlr_event_pointer_button,
                   wlr_event_pointer_motion, wlr_event_pointer_motion_absolute};
 
+// TODO FIXME Document this shit man
+
+#[derive(Debug)]
 pub struct AxisEvent {
-    event: *mut wlr_event_pointer_axis
+    event: *mut wlr_event_pointer_axis,
+    device: InputDevice
 }
 
+#[derive(Debug)]
 pub struct ButtonEvent {
-    event: *mut wlr_event_pointer_button
+    event: *mut wlr_event_pointer_button,
+    device: InputDevice
 }
 
+#[derive(Debug)]
 pub struct MotionEvent {
-    event: *mut wlr_event_pointer_motion
+    event: *mut wlr_event_pointer_motion,
+    device: InputDevice
 }
 
+#[derive(Debug)]
 pub struct AbsoluteMotionEvent {
-    event: *mut wlr_event_pointer_motion_absolute
+    event: *mut wlr_event_pointer_motion_absolute,
+    device: InputDevice
 }
 
 impl ButtonEvent {
     pub unsafe fn from_ptr(event: *mut wlr_event_pointer_button) -> Self {
-        ButtonEvent { event }
+        ButtonEvent { device: InputDevice::from_ptr((*event).device), event }
+    }
+
+    pub fn device(&self) -> &InputDevice {
+        &self.device
     }
 
     pub fn state(&self) -> wlr_button_state {
@@ -37,7 +51,11 @@ impl ButtonEvent {
 
 impl AxisEvent {
     pub unsafe fn from_ptr(event: *mut wlr_event_pointer_axis) -> Self {
-        AxisEvent { event }
+        AxisEvent { device: InputDevice::from_ptr((*event).device), event }
+    }
+
+    pub fn device(&self) -> &InputDevice {
+        &self.device
     }
 
     pub fn delta(&self) -> f64 {
@@ -47,11 +65,11 @@ impl AxisEvent {
 
 impl MotionEvent {
     pub unsafe fn from_ptr(event: *mut wlr_event_pointer_motion) -> Self {
-        MotionEvent { event }
+        MotionEvent { device: InputDevice::from_ptr((*event).device), event }
     }
 
-    pub fn device(&self) -> InputDevice {
-        unsafe { InputDevice::from_ptr((*self.event).device) }
+    pub fn device(&self) -> &InputDevice {
+        &self.device
     }
 
     pub fn delta(&self) -> (f64, f64) {
@@ -61,10 +79,10 @@ impl MotionEvent {
 
 impl AbsoluteMotionEvent {
     pub unsafe fn from_ptr(event: *mut wlr_event_pointer_motion_absolute) -> Self {
-        AbsoluteMotionEvent { event }
+        AbsoluteMotionEvent { device: InputDevice::from_ptr((*event).device), event }
     }
 
-    pub fn device(&self) -> InputDevice {
-        unsafe { InputDevice::from_ptr((*self.event).device) }
+    pub fn device(&self) -> &InputDevice {
+        &self.device
     }
 }

--- a/src/events/pointer_events.rs
+++ b/src/events/pointer_events.rs
@@ -5,6 +5,8 @@ use types::input_device::InputDevice;
 use wlroots_sys::{wlr_button_state, wlr_event_pointer_axis, wlr_event_pointer_button,
                   wlr_event_pointer_motion, wlr_event_pointer_motion_absolute};
 
+pub type ButtonState = wlr_button_state;
+
 #[derive(Debug)]
 /// Event that triggers when the pointer device scrolls (e.g using a wheel
 // or in the case of a touchpad when you use two fingers to scroll).
@@ -51,7 +53,7 @@ impl ButtonEvent {
     }
 
     /// Get the state of the button (e.g pressed or released).
-    pub fn state(&self) -> wlr_button_state {
+    pub fn state(&self) -> ButtonState {
         unsafe { (*self.event).state }
     }
 

--- a/src/events/pointer_events.rs
+++ b/src/events/pointer_events.rs
@@ -5,87 +5,118 @@ use types::input_device::InputDevice;
 use wlroots_sys::{wlr_button_state, wlr_event_pointer_axis, wlr_event_pointer_button,
                   wlr_event_pointer_motion, wlr_event_pointer_motion_absolute};
 
-// TODO FIXME Document this shit man
-
 #[derive(Debug)]
+/// Event that triggers when the pointer device scrolls (e.g using a wheel
+// or in the case of a touchpad when you use two fingers to scroll).
 pub struct AxisEvent {
     event: *mut wlr_event_pointer_axis,
     device: InputDevice
 }
 
 #[derive(Debug)]
+/// Event that triggers when a button is pressed (e.g left click, right click,
+/// a gaming mouse button, etc.).
 pub struct ButtonEvent {
     event: *mut wlr_event_pointer_button,
     device: InputDevice
 }
 
 #[derive(Debug)]
+/// Event that triggers when the pointer moves.
 pub struct MotionEvent {
     event: *mut wlr_event_pointer_motion,
     device: InputDevice
 }
 
 #[derive(Debug)]
+/// Event that triggers when data from a device that supports absolute motion
+/// sends data to the compositor.
+///
+/// For more information on absolute motion, [see this link](https://wayland.freedesktop.org/libinput/doc/latest/absolute_axes.html).
 pub struct AbsoluteMotionEvent {
     event: *mut wlr_event_pointer_motion_absolute,
     device: InputDevice
 }
 
 impl ButtonEvent {
+    /// Constructs a `ButtonEvent` from the raw event pointer.
     pub unsafe fn from_ptr(event: *mut wlr_event_pointer_button) -> Self {
         ButtonEvent { device: InputDevice::from_ptr((*event).device),
                       event }
     }
 
+    /// Get the device this event refers to.
     pub fn device(&self) -> &InputDevice {
         &self.device
     }
 
+    /// Get the state of the button (e.g pressed or released).
     pub fn state(&self) -> wlr_button_state {
         unsafe { (*self.event).state }
     }
 
+    /// Get the value of the button pressed. This will generally be an atomically
+    /// increasing value, with e.g left click being 1 and right click being 2...
+    ///
+    /// We make no guarantees that 1 always maps to left click, as this is device
+    /// driver specific.
     pub fn button(&self) -> u32 {
         unsafe { (*self.event).button }
     }
 }
 
 impl AxisEvent {
+    /// Constructs a `AxisEvent` from a raw event pointer.
     pub unsafe fn from_ptr(event: *mut wlr_event_pointer_axis) -> Self {
         AxisEvent { device: InputDevice::from_ptr((*event).device),
                     event }
     }
 
+    /// Get the device this event refers to.
     pub fn device(&self) -> &InputDevice {
         &self.device
     }
 
+    /// Get the change from the last axis value.
+    ///
+    /// Useful to determine e.g how much to scroll.
     pub fn delta(&self) -> f64 {
         unsafe { (*self.event).delta }
     }
 }
 
 impl MotionEvent {
+    /// Constructs a `MotionEvent` from a raw event pointer.
     pub unsafe fn from_ptr(event: *mut wlr_event_pointer_motion) -> Self {
         MotionEvent { device: InputDevice::from_ptr((*event).device),
                       event }
     }
 
+    /// Get the device this event refers to.
     pub fn device(&self) -> &InputDevice {
         &self.device
     }
 
+    /// Get the change from the last positional value.
+    ///
+    /// Returned in (x, y) form.
+    ///
+    /// Note you should not cast this to a type with less precision,
+    /// otherwise you'll lose important motion data which can cause bugs
+    /// (e.g see [this fun wlc bug](https://github.com/Cloudef/wlc/issues/181)).
     pub fn delta(&self) -> (f64, f64) {
         unsafe { ((*self.event).delta_x, (*self.event).delta_y) }
     }
 }
 
 impl AbsoluteMotionEvent {
+    /// Construct an `AbsoluteMotionEvent` from a raw event pointer.
     pub unsafe fn from_ptr(event: *mut wlr_event_pointer_motion_absolute) -> Self {
         AbsoluteMotionEvent { device: InputDevice::from_ptr((*event).device),
                               event }
     }
 
+    /// Get the device this event refers to.
     pub fn device(&self) -> &InputDevice {
         &self.device
     }

--- a/src/events/pointer_events.rs
+++ b/src/events/pointer_events.rs
@@ -33,7 +33,8 @@ pub struct AbsoluteMotionEvent {
 
 impl ButtonEvent {
     pub unsafe fn from_ptr(event: *mut wlr_event_pointer_button) -> Self {
-        ButtonEvent { device: InputDevice::from_ptr((*event).device), event }
+        ButtonEvent { device: InputDevice::from_ptr((*event).device),
+                      event }
     }
 
     pub fn device(&self) -> &InputDevice {
@@ -51,7 +52,8 @@ impl ButtonEvent {
 
 impl AxisEvent {
     pub unsafe fn from_ptr(event: *mut wlr_event_pointer_axis) -> Self {
-        AxisEvent { device: InputDevice::from_ptr((*event).device), event }
+        AxisEvent { device: InputDevice::from_ptr((*event).device),
+                    event }
     }
 
     pub fn device(&self) -> &InputDevice {
@@ -65,7 +67,8 @@ impl AxisEvent {
 
 impl MotionEvent {
     pub unsafe fn from_ptr(event: *mut wlr_event_pointer_motion) -> Self {
-        MotionEvent { device: InputDevice::from_ptr((*event).device), event }
+        MotionEvent { device: InputDevice::from_ptr((*event).device),
+                      event }
     }
 
     pub fn device(&self) -> &InputDevice {
@@ -79,7 +82,8 @@ impl MotionEvent {
 
 impl AbsoluteMotionEvent {
     pub unsafe fn from_ptr(event: *mut wlr_event_pointer_motion_absolute) -> Self {
-        AbsoluteMotionEvent { device: InputDevice::from_ptr((*event).device), event }
+        AbsoluteMotionEvent { device: InputDevice::from_ptr((*event).device),
+                              event }
     }
 
     pub fn device(&self) -> &InputDevice {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,5 +54,6 @@ pub use self::types::cursor::*;
 pub use self::types::input_device::*;
 pub use self::types::keyboard::*;
 pub use self::types::output::*;
+pub use self::types::pointer::*;
 pub use self::types::seat::*;
 pub use self::types::surface::*;

--- a/src/manager/input_manager.rs
+++ b/src/manager/input_manager.rs
@@ -67,7 +67,7 @@ wayland_listener!(InputManager, (Vec<Input>, Box<InputManagerHandler>), [
                     // Boring setup that we won't make the user do
                     add_keyboard(&mut dev);
                     // Get the optional user keyboard struct, add the on_key signal
-                    let mut keyboard_handle = match Keyboard::from_input_device(data) {
+                    let mut keyboard_handle = match Keyboard::new_from_input_device(data) {
                         Some(dev) => dev,
                         None => {
                             wlr_log!(L_ERROR, "Device {:#?} was not a keyboard!", dev);
@@ -86,7 +86,7 @@ wayland_listener!(InputManager, (Vec<Input>, Box<InputManagerHandler>), [
                 },
                 WLR_INPUT_DEVICE_POINTER => {
                     // Get the optional user pointer struct, add the signals
-                    let mut pointer_handle = match Pointer::from_input_device(data) {
+                    let mut pointer_handle = match Pointer::new_from_input_device(data) {
                         Some(dev) => dev,
                         None => {
                             wlr_log!(L_ERROR, "Device {:#?} was not a pointer!", dev);

--- a/src/manager/input_manager.rs
+++ b/src/manager/input_manager.rs
@@ -29,8 +29,8 @@ impl Input {
     pub unsafe fn input_device(&self) -> *mut wlr_input_device {
         use self::Input::*;
         match *self {
-            Keyboard(ref keyboard) => keyboard.input_device(),
-            Pointer(ref pointer) => pointer.input_device()
+            Keyboard(ref keyboard) => keyboard.input_device().as_ptr(),
+            Pointer(ref pointer) => pointer.input_device().as_ptr()
         }
     }
 }

--- a/src/manager/keyboard_handler.rs
+++ b/src/manager/keyboard_handler.rs
@@ -17,7 +17,7 @@ wayland_listener!(KeyboardWrapper, (Keyboard, Box<KeyboardHandler>), [
     key_listener => key_notify: |this: &mut KeyboardWrapper, data: *mut libc::c_void,| unsafe {
         let (ref mut keyboard, ref mut keyboard_handler) = this.data;
         let compositor = &mut *COMPOSITOR_PTR;
-        let xkb_state = (*keyboard.keyboard_ptr()).xkb_state;
+        let xkb_state = (*keyboard.as_ptr()).xkb_state;
         let mut key = KeyEvent::new(data as *mut wlr_event_keyboard_key, xkb_state);
 
         keyboard_handler.on_key(compositor, keyboard, &mut key)

--- a/src/manager/keyboard_handler.rs
+++ b/src/manager/keyboard_handler.rs
@@ -2,11 +2,11 @@
 
 use libc;
 
+use {InputDevice, Keyboard};
 use compositor::{Compositor, COMPOSITOR_PTR};
 use events::key_events::KeyEvent;
-use types::Keyboard;
 
-use wlroots_sys::{wlr_event_keyboard_key, wlr_input_device};
+use wlroots_sys::wlr_event_keyboard_key;
 
 pub trait KeyboardHandler {
     /// Callback that is triggered when a key is pressed.
@@ -25,7 +25,7 @@ wayland_listener!(KeyboardWrapper, (Keyboard, Box<KeyboardHandler>), [
 ]);
 
 impl KeyboardWrapper {
-    pub unsafe fn input_device(&self) -> *mut wlr_input_device {
+    pub fn input_device(&self) -> &InputDevice {
         self.data.0.input_device()
     }
 }

--- a/src/manager/output_handler.rs
+++ b/src/manager/output_handler.rs
@@ -34,6 +34,6 @@ impl UserOutput {
     }
 
     pub unsafe fn output_ptr(&self) -> *mut wlr_output {
-        self.data.0.to_ptr()
+        self.data.0.as_ptr()
     }
 }

--- a/src/manager/pointer_handler.rs
+++ b/src/manager/pointer_handler.rs
@@ -2,12 +2,11 @@
 
 use libc;
 
+use {InputDevice, Pointer};
 use compositor::{Compositor, COMPOSITOR_PTR};
 use events::pointer_events::{AbsoluteMotionEvent, AxisEvent, ButtonEvent, MotionEvent};
-use types::Pointer;
 
-use wlroots_sys::{wlr_event_pointer_axis, wlr_event_pointer_button, wlr_event_pointer_motion,
-                  wlr_input_device};
+use wlroots_sys::{wlr_event_pointer_axis, wlr_event_pointer_button, wlr_event_pointer_motion};
 
 pub trait PointerHandler {
     /// Callback that is triggered when the pointer moves.
@@ -47,7 +46,7 @@ wayland_listener!(PointerWrapper, (Pointer, Box<PointerHandler>), [
 ]);
 
 impl PointerWrapper {
-    pub unsafe fn input_device(&self) -> *mut wlr_input_device {
+    pub unsafe fn input_device(&self) -> &InputDevice {
         self.data.0.input_device()
     }
 }

--- a/src/render/gles2.rs
+++ b/src/render/gles2.rs
@@ -34,7 +34,7 @@ impl GLES2 {
     pub fn render<'output>(&mut self, output: &'output mut Output) -> GLES2Renderer<'output> {
         output.make_current();
         unsafe {
-            wlr_renderer_begin(self.renderer, output.to_ptr());
+            wlr_renderer_begin(self.renderer, output.as_ptr());
         }
         GLES2Renderer { renderer: self.renderer,
                         output }
@@ -47,7 +47,7 @@ impl GLES2 {
 
 impl<'output> GLES2Renderer<'output> {
     pub fn render_with_matrix(&mut self, texture: &Texture, matrix: &[f32; 16]) -> bool {
-        unsafe { wlr_render_with_matrix(self.renderer, texture.to_ptr(), matrix) }
+        unsafe { wlr_render_with_matrix(self.renderer, texture.as_ptr(), matrix) }
     }
 
     /// Create a texture using the GLES2 backend.

--- a/src/render/texture.rs
+++ b/src/render/texture.rs
@@ -81,7 +81,7 @@ impl Texture {
         Texture { texture }
     }
 
-    pub(crate) unsafe fn to_ptr(&self) -> *mut wlr_texture {
+    pub(crate) unsafe fn as_ptr(&self) -> *mut wlr_texture {
         self.texture
     }
 

--- a/src/types/cursor.rs
+++ b/src/types/cursor.rs
@@ -47,7 +47,7 @@ impl Cursor {
 
     pub fn warp(&mut self, dev: Option<InputDevice>, x: f64, y: f64) -> bool {
         unsafe {
-            let dev_ptr = dev.map(|dev| dev.to_ptr()).unwrap_or(ptr::null_mut());
+            let dev_ptr = dev.map(|dev| dev.as_ptr()).unwrap_or(ptr::null_mut());
             wlr_cursor_warp(self.cursor, dev_ptr, x, y)
         }
     }
@@ -58,13 +58,13 @@ impl Cursor {
         unsafe {
             // NOTE Rationale for why the pointer isn't leaked from the refcell:
             // * A pointer is not stored to the layout, the internal state is just updated.
-            wlr_cursor_attach_output_layout(self.cursor, layout.borrow_mut().to_ptr());
+            wlr_cursor_attach_output_layout(self.cursor, layout.borrow_mut().as_ptr());
             self.layout = Some(layout);
         }
     }
 
     pub fn move_to(&mut self, dev: &InputDevice, delta_x: f64, delta_y: f64) {
-        unsafe { wlr_cursor_move(self.cursor, dev.to_ptr(), delta_x, delta_y) }
+        unsafe { wlr_cursor_move(self.cursor, dev.as_ptr(), delta_x, delta_y) }
     }
 
     pub fn output_layout(&self) -> &Option<Rc<RefCell<OutputLayout>>> {

--- a/src/types/input_device.rs
+++ b/src/types/input_device.rs
@@ -7,6 +7,19 @@ pub struct InputDevice {
 }
 
 impl InputDevice {
+    /// Just like `std::clone::Clone`, but unsafe.
+    ///
+    /// # Unsafety
+    /// This is unsafe because the user should not be able to clone
+    /// this type out because it isn't bound by anything but the underlying
+    /// pointer could be removed at any time.
+    ///
+    /// This isn't exposed to the user, but still marked as `unsafe` to reduce
+    /// possible bugs from using this.
+    pub(crate) unsafe fn clone(&self) -> Self {
+        InputDevice { device: self.device }
+    }
+
     /// Get the type of the device
     pub fn dev_type(&self) -> wlr_input_device_type {
         unsafe { (*self.device).type_ }

--- a/src/types/input_device.rs
+++ b/src/types/input_device.rs
@@ -21,7 +21,7 @@ impl InputDevice {
         InputDevice { device: device }
     }
 
-    pub unsafe fn to_ptr(&self) -> *mut wlr_input_device {
+    pub unsafe fn as_ptr(&self) -> *mut wlr_input_device {
         self.device
     }
 }

--- a/src/types/keyboard.rs
+++ b/src/types/keyboard.rs
@@ -46,7 +46,7 @@ impl Keyboard {
     /// # Safety
     /// This creates a totally new Keyboard (e.g with its own reference count)
     /// so only do this once per `wlr_input_device`!
-    pub(crate) unsafe fn from_input_device(device: *mut wlr_input_device) -> Option<Self> {
+    pub(crate) unsafe fn new_from_input_device(device: *mut wlr_input_device) -> Option<Self> {
         use wlroots_sys::wlr_input_device_type::*;
         match (*device).type_ {
             WLR_INPUT_DEVICE_KEYBOARD => {

--- a/src/types/keyboard.rs
+++ b/src/types/keyboard.rs
@@ -37,6 +37,13 @@ pub struct KeyboardHandle {
 }
 
 impl Keyboard {
+    /// Tries to convert an input device to a Keyboard
+    ///
+    /// Returns None if it is of a different type of input variant.
+    ///
+    /// # Safety
+    /// This creates a totally new Keyboard (e.g with its own reference count)
+    /// so only do this once per `wlr_input_device`!
     pub(crate) unsafe fn from_input_device(device: *mut wlr_input_device) -> Option<Self> {
         use wlroots_sys::wlr_input_device_type::*;
         match (*device).type_ {

--- a/src/types/keyboard.rs
+++ b/src/types/keyboard.rs
@@ -60,11 +60,11 @@ impl Keyboard {
     unsafe fn from_handle(handle: &KeyboardHandle) -> Self {
         Keyboard { liveliness: None,
                    device: handle.input_device(),
-                   keyboard: handle.keyboard_ptr() }
+                   keyboard: handle.as_ptr() }
     }
 
     /// Gets the wlr_keyboard associated with this KeyboardHandle.
-    pub unsafe fn keyboard_ptr(&self) -> *mut wlr_keyboard {
+    pub unsafe fn as_ptr(&self) -> *mut wlr_keyboard {
         self.keyboard
     }
 
@@ -166,7 +166,7 @@ impl KeyboardHandle {
     }
 
     /// Gets the wlr_keyboard associated with this KeyboardHandle.
-    pub unsafe fn keyboard_ptr(&self) -> *mut wlr_keyboard {
+    pub unsafe fn as_ptr(&self) -> *mut wlr_keyboard {
         self.keyboard
     }
 }

--- a/src/types/output.rs
+++ b/src/types/output.rs
@@ -64,8 +64,9 @@ impl Output {
 
     /// Makes a new `Output` from a `wlr_output`.
     ///
-    /// # Unsafety
-    // Do not call this function multiple times for the same `wlr_output`.
+    /// # Safety
+    /// This creates a totally new Output (e.g with its own reference count)
+    /// so only do this once per `wlr_output`!
     pub unsafe fn new(output: *mut wlr_output) -> Self {
         Output { liveliness: Some(Rc::new(())),
                  output }

--- a/src/types/output.rs
+++ b/src/types/output.rs
@@ -92,7 +92,7 @@ impl Output {
 
     pub fn add_layout_auto(&mut self, layout: Rc<RefCell<OutputLayout>>) {
         unsafe {
-            wlr_output_layout_add_auto(layout.borrow_mut().to_ptr(), self.output);
+            wlr_output_layout_add_auto(layout.borrow_mut().as_ptr(), self.output);
             let user_data = self.user_data();
             if user_data.is_null() {
                 self.set_user_data(Rc::new(OutputState { layout: Some(layout) }));
@@ -118,7 +118,7 @@ impl Output {
                 first_mode_ptr = container_of!(&mut (*(*self.modes()).prev) as *mut _,
                                                wlr_output_mode,
                                                link);
-                wlr_output_set_mode(self.to_ptr(), first_mode_ptr);
+                wlr_output_set_mode(self.as_ptr(), first_mode_ptr);
             }
         }
     }
@@ -192,7 +192,7 @@ impl Output {
         (*self.output).events
     }
 
-    pub unsafe fn to_ptr(&self) -> *mut wlr_output {
+    pub unsafe fn as_ptr(&self) -> *mut wlr_output {
         self.output
     }
 
@@ -281,7 +281,7 @@ impl OutputLayout {
         unsafe { OutputLayout { layout: wlr_output_layout_create() } }
     }
 
-    pub unsafe fn to_ptr(&self) -> *mut wlr_output_layout {
+    pub unsafe fn as_ptr(&self) -> *mut wlr_output_layout {
         self.layout
     }
 
@@ -294,7 +294,7 @@ impl OutputLayout {
     /// pass it an invalid OutputHandle (e.g one that has already been freed).
     /// For now, this function is unsafe
     pub unsafe fn remove(&mut self, output: &mut Output) {
-        wlr_output_layout_remove(self.layout, output.to_ptr())
+        wlr_output_layout_remove(self.layout, output.as_ptr())
     }
 }
 

--- a/src/types/pointer.rs
+++ b/src/types/pointer.rs
@@ -61,7 +61,7 @@ impl Pointer {
     unsafe fn from_handle(handle: &PointerHandle) -> Self {
         Pointer { liveliness: None,
                   device: handle.input_device(),
-                  pointer: handle.pointer_ptr() }
+                  pointer: handle.as_ptr() }
     }
 
     /// Gets the wlr_input_device associated with this Pointer.
@@ -70,7 +70,7 @@ impl Pointer {
     }
 
     /// Gets the wlr_pointer associated with this Pointer.
-    pub unsafe fn pointer_ptr(&self) -> *mut wlr_pointer {
+    pub unsafe fn as_ptr(&self) -> *mut wlr_pointer {
         self.pointer
     }
 
@@ -148,7 +148,7 @@ impl PointerHandle {
     }
 
     /// Gets the wlr_pointer associated with this PointerHandle.
-    pub unsafe fn pointer_ptr(&self) -> *mut wlr_pointer {
+    pub unsafe fn as_ptr(&self) -> *mut wlr_pointer {
         self.pointer
     }
 }

--- a/src/types/pointer.rs
+++ b/src/types/pointer.rs
@@ -46,7 +46,7 @@ impl Pointer {
     /// # Safety
     /// This creates a totally new Pointer (e.g with its own reference count)
     /// so only do this once per `wlr_input_device`!
-    pub(crate) unsafe fn from_input_device(device: *mut wlr_input_device) -> Option<Self> {
+    pub(crate) unsafe fn new_from_input_device(device: *mut wlr_input_device) -> Option<Self> {
         use wlroots_sys::wlr_input_device_type::*;
         match (*device).type_ {
             WLR_INPUT_DEVICE_POINTER => {

--- a/src/types/pointer.rs
+++ b/src/types/pointer.rs
@@ -4,6 +4,8 @@ use std::rc::{Rc, Weak};
 
 use wlroots_sys::{wlr_input_device, wlr_pointer};
 
+use InputDevice;
+
 #[derive(Debug)]
 pub struct Pointer {
     /// The structure that ensures weak handles to this structure are still alive.
@@ -17,7 +19,7 @@ pub struct Pointer {
     /// marked function `upgrade` on a `PointerHandle`.
     liveliness: Option<Rc<()>>,
     /// The device that refers to this pointer.
-    device: *mut wlr_input_device,
+    device: InputDevice,
     /// The underlying pointer data.
     pointer: *mut wlr_pointer
 }
@@ -31,7 +33,7 @@ pub struct PointerHandle {
     /// this can no longer be used.
     handle: Weak<()>,
     /// The device that refers to this pointer.
-    device: *mut wlr_input_device,
+    device: InputDevice,
     /// The underlying pointer data.
     pointer: *mut wlr_pointer
 }
@@ -50,7 +52,7 @@ impl Pointer {
             WLR_INPUT_DEVICE_POINTER => {
                 let pointer = (*device).__bindgen_anon_1.pointer;
                 Some(Pointer { liveliness: Some(Rc::new(())),
-                               device,
+                               device: InputDevice::from_ptr(device),
                                pointer })
             }
             _ => None
@@ -60,13 +62,13 @@ impl Pointer {
     /// Creates an unbound Pointer from a `PointerHandle`
     unsafe fn from_handle(handle: &PointerHandle) -> Self {
         Pointer { liveliness: None,
-                  device: handle.input_device(),
+                  device: handle.input_device().clone(),
                   pointer: handle.as_ptr() }
     }
 
     /// Gets the wlr_input_device associated with this Pointer.
-    pub unsafe fn input_device(&self) -> *mut wlr_input_device {
-        self.device
+    pub fn input_device(&self) -> &InputDevice {
+        &self.device
     }
 
     /// Gets the wlr_pointer associated with this Pointer.
@@ -83,7 +85,10 @@ impl Pointer {
         let arc = self.liveliness.as_ref()
                       .expect("Cannot downgrade a previously upgraded PointerHandle!");
         PointerHandle { handle: Rc::downgrade(arc),
-                        device: self.device,
+                        // NOTE Rationale for cloning:
+                        // We can't use the keyboard handle unless the keyboard is alive,
+                        // which means the device pointer is still alive.
+                        device: unsafe { self.device.clone() },
                         pointer: self.pointer }
     }
 }
@@ -143,8 +148,8 @@ impl PointerHandle {
     }
 
     /// Gets the wlr_input_device associated with this PointerHandle.
-    pub unsafe fn input_device(&self) -> *mut wlr_input_device {
-        self.device
+    pub fn input_device(&self) -> &InputDevice {
+        &self.device
     }
 
     /// Gets the wlr_pointer associated with this PointerHandle.

--- a/src/types/pointer.rs
+++ b/src/types/pointer.rs
@@ -37,9 +37,13 @@ pub struct PointerHandle {
 }
 
 impl Pointer {
-    /// Tries to convert an input device to a pointer
+    /// Tries to convert an input device to a Pointer
     ///
-    /// Returns none if it is of a different input varient.
+    /// Returns none if it is of a different input variant.
+    ///
+    /// # Safety
+    /// This creates a totally new Pointer (e.g with its own reference count)
+    /// so only do this once per `wlr_input_device`!
     pub(crate) unsafe fn from_input_device(device: *mut wlr_input_device) -> Option<Self> {
         use wlroots_sys::wlr_input_device_type::*;
         match (*device).type_ {

--- a/src/types/seat/seat.rs
+++ b/src/types/seat/seat.rs
@@ -204,7 +204,7 @@ impl Seat {
 
     /// Set this keyboard as the active keyboard for the seat.
     pub fn set_keyboard(&mut self, dev: InputDevice) {
-        unsafe { wlr_seat_set_keyboard(self.seat, dev.to_ptr()) }
+        unsafe { wlr_seat_set_keyboard(self.seat, dev.as_ptr()) }
     }
 
     // TODO Point to the correct function name in this documentation.
@@ -435,7 +435,7 @@ impl Seat {
         }
     }
 
-    pub unsafe fn to_ptr(&self) -> *mut wlr_seat {
+    pub unsafe fn as_ptr(&self) -> *mut wlr_seat {
         self.seat
     }
 }

--- a/src/types/seat/seat_client.rs
+++ b/src/types/seat/seat_client.rs
@@ -32,7 +32,7 @@ impl<'wlr_seat> SeatClient<'wlr_seat> {
     pub unsafe fn client_for_wl_client(seat: &'wlr_seat mut Seat,
                                        client: *mut wl_client)
                                        -> Option<SeatClient<'wlr_seat>> {
-        let client = wlr_seat_client_for_wl_client(seat.to_ptr(), client);
+        let client = wlr_seat_client_for_wl_client(seat.as_ptr(), client);
         if client.is_null() {
             None
         } else {
@@ -54,7 +54,7 @@ impl<'wlr_seat> SeatClient<'wlr_seat> {
                      _phantom: PhantomData }
     }
 
-    pub unsafe fn to_ptr(&self) -> *mut wlr_seat_client {
+    pub unsafe fn as_ptr(&self) -> *mut wlr_seat_client {
         self.client
     }
 }


### PR DESCRIPTION
# Documentation
* Document key events
* Document pointer events

# Ergonomics
* Converted all `to_ptr` to `as_ptr`
* No longer expose the `from_ptr` methods on the pointer events
* Wrapped `wlr_button_state` with type `ButtonState` (to make it seem less gross even though it's a generated type from wlroots_sys)

# Safety
* Can no longer get an `InputDevice` from the pointer events. Instead, it's bound to the lifetime of the event.

# Features
* Can now get a reference to the underlying `InputDevice` from the concrete device type (e.g `Keyboard` or `Pointer`)