### PR TITLE
Add panic catchers so we don't unwind into C

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,5 +1,4 @@
 /// Gets the offset of a field. Used by container_of!
-#[macro_export]
 macro_rules! offset_of(
     ($ty:ty, $field:ident) => {
         &(*(0 as *const $ty)).$field as *const _ as usize
@@ -9,7 +8,6 @@ macro_rules! offset_of(
 /// Gets the parent struct from a pointer.
 /// VERY unsafe. The parent struct _must_ be repr(C), and the
 /// type passed to this macro _must_ match the type of the parent.
-#[macro_export]
 macro_rules! container_of (
     ($ptr: expr, $container: ty, $field: ident) => {
         ($ptr as *mut u8).offset(-(offset_of!($container, $field) as isize)) as *mut $container
@@ -27,7 +25,6 @@ macro_rules! c_str {
     }
 }
 
-#[macro_export]
 /// Logs a message using wlroots' logging capability.
 ///
 /// Possible values for `verb`:
@@ -36,6 +33,7 @@ macro_rules! c_str {
 /// * L_INFO
 /// * L_DEBUG
 /// * L_ERROR
+#[macro_export]
 macro_rules! wlr_log {
     ($verb: expr, $($msg:tt)*) => {{
         use $crate::wlroots_sys::_wlr_log;
@@ -74,7 +72,7 @@ macro_rules! wlr_log {
 /// `unsafe`.
 ///
 /// # Example
-/// ```rust,no_run
+/// ```rust,no_run,ignore
 /// #[macro_use] extern crate wlroots;
 /// extern crate wlroots_sys;
 /// #[macro_use] extern crate wayland_sys;
@@ -123,7 +121,6 @@ macro_rules! wlr_log {
 ///
 /// Second, this macro doesn't protect against the stored data being unsized.
 /// Passing a pointer of unsized data to C is UB, don't do it.
-#[macro_export]
 macro_rules! wayland_listener {
     ($struct_name: ident, $data: ty, $([
         $($listener: ident => $listener_func: ident :

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -165,7 +165,11 @@ macro_rules! wayland_listener {
                 let manager: &mut $struct_name = &mut (*container_of!(listener,
                                                                       $struct_name,
                                                                       $listener));
-                (|$($func_arg: $func_type,)*| { $body })(manager, data);
+                $crate::utils::handle_unwind(
+                    ::std::panic::catch_unwind(
+                        ::std::panic::AssertUnwindSafe(|| {
+                            (|$($func_arg: $func_type,)*| { $body })(manager, data)
+                        })));
             })*)*
         }
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -88,3 +88,21 @@ pub unsafe fn c_to_rust_string(c_str: *const c_char) -> Option<String> {
         Some(CStr::from_ptr(c_str).to_string_lossy().into_owned())
     }
 }
+
+/// Handle unwinding from a panic, used in conjunction with
+/// `::std::panic::catch_unwind`.
+///
+/// When a panic occurs, we terminate the compositor and let the rest
+/// of the code run.
+pub(crate) unsafe fn handle_unwind<T>(res: ::std::thread::Result<T>) {
+    match res {
+        Ok(_) => {}
+        Err(err) => {
+            if ::compositor::COMPOSITOR_PTR == 0 as *mut _ {
+                ::std::process::abort();
+            }
+            (&mut *::compositor::COMPOSITOR_PTR).save_panic_error(err);
+            ::compositor::terminate()
+        }
+    }
+}


### PR DESCRIPTION
# How it works
The way it works is that we add it to the macro so that all callbacks from the handler traits will have to go through a panic catcher that will stop it from unwinding back into wlroots/wayland.

Once we catch it, we then terminate the compositor and let the rest of the code run (which won't be much, since we called wl_display_terminate it will stop the loop getting events and just let the rest of the code, of which there is 0 in the macro, run to completion and pop back up the stack back into C land).

Before terminating the compositor, we store the error in the Compositor structure so that we can re-throw it later.

Once it's terminated, in our mainloop function we check the internal error conditional that's set when a panic is thrown (see above). If it's set, then we re-throw using std::panic::resume_unwind.

What's nice about this is still prints the stacktrace, it just defers the unwinding until after we have left C land.

# Left to do
There's probably still some edge cases that are still not covered, as this only handles the obvious case for callbacks when we are calling Rust from C. There might be times we call _back_ into C (and then back into Rust), at which point we need an additional layer of panic catchers. So far that hasn't come up, but it's possible for wlroots to do something like that.