### PR TITLE
Finish wrapping Keyboard

### DIFF
--- a/examples/pointer.rs
+++ b/examples/pointer.rs
@@ -67,7 +67,7 @@ impl OutputManagerHandler for OutputManager {
 
 impl KeyboardHandler for ExKeyboardHandler {
     fn on_key(&mut self, compositor: &mut Compositor, _: &mut Keyboard, key_event: &mut KeyEvent) {
-        for key in key_event.input_keys() {
+        for key in key_event.pressed_keys() {
             if key == KEY_Escape {
                 compositor.terminate()
             }

--- a/examples/rotation.rs
+++ b/examples/rotation.rs
@@ -122,7 +122,7 @@ impl InputManagerHandler for InputManager {
 
 impl KeyboardHandler for KeyboardManager {
     fn on_key(&mut self, compositor: &mut Compositor, _: &mut Keyboard, key_event: &mut KeyEvent) {
-        let keys = key_event.input_keys();
+        let keys = key_event.pressed_keys();
 
         for key in keys {
             match key {

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -26,7 +26,7 @@ impl KeyboardHandler for ExKeyboardHandler {
               compositor: &mut Compositor,
               keyboard: &mut Keyboard,
               key_event: &mut KeyEvent) {
-        let keys = key_event.input_keys();
+        let keys = key_event.pressed_keys();
 
         wlr_log!(L_DEBUG,
                  "Got key event. Keys: {:?}. Modifiers: {}",

--- a/src/events/key_events.rs
+++ b/src/events/key_events.rs
@@ -1,6 +1,10 @@
+use std::time::Duration;
+
 use wlroots_sys::{wlr_event_keyboard_key, xkb_keysym_t, xkb_state, xkb_state_key_get_syms};
 
 pub type Key = xkb_keysym_t;
+
+use types::keyboard::KeyState;
 
 #[derive(Debug)]
 pub struct KeyEvent {
@@ -20,6 +24,21 @@ impl KeyEvent {
     /// value XKB says this is.
     pub fn keycode(&self) -> u32 {
         unsafe { (*self.key).keycode + 8 }
+    }
+
+    /// Get how long the key has been pressed down, in milliseconds.
+    pub fn time_msec(&self) -> Duration {
+        Duration::from_millis(unsafe { (*self.key).time_msec } as u64)
+    }
+
+    /// TODO What is this?
+    pub fn update_state(&self) -> bool {
+        unsafe { (*self.key).update_state }
+    }
+
+    /// Get the pressed/released state of the key.
+    pub fn key_state(&self) -> KeyState {
+        unsafe { (*self.key).state }
     }
 
     /// Gets the keys that are pressed using XKB to convert them to a more

--- a/src/events/key_events.rs
+++ b/src/events/key_events.rs
@@ -43,7 +43,7 @@ impl KeyEvent {
 
     /// Gets the keys that are pressed using XKB to convert them to a more
     /// programmer friendly form.
-    pub fn input_keys(&self) -> Vec<Key> {
+    pub fn pressed_keys(&self) -> Vec<Key> {
         unsafe {
             let mut syms = 0 as *const xkb_keysym_t;
             let key_length = xkb_state_key_get_syms(self.xkb_state, self.keycode(), &mut syms);

--- a/src/types/keyboard.rs
+++ b/src/types/keyboard.rs
@@ -133,13 +133,13 @@ impl Keyboard {
     }
 
     /// Get the list of LEDs for this keyboard as reported by XKB.
-    pub fn led_list(&self) -> Vec<LedIndex> {
-        unsafe { (*self.keyboard).led_indexes.to_vec() }
+    pub fn led_list(&self) -> &[LedIndex] {
+        unsafe { &(*self.keyboard).led_indexes }
     }
 
     /// Get the list of modifiers for this keyboard as reported by XKB.
-    pub fn modifier_list(&self) -> Vec<ModIndex> {
-        unsafe { (*self.keyboard).mod_indexes.to_vec() }
+    pub fn modifier_list(&self) -> &[ModIndex] {
+        unsafe { &(*self.keyboard).mod_indexes }
     }
 
     /// Get the size of the keymap.

--- a/src/types/keyboard.rs
+++ b/src/types/keyboard.rs
@@ -32,6 +32,7 @@ pub struct RepeatInfo {
     delay: i32
 }
 
+#[derive(Debug)]
 pub struct Keyboard {
     /// The structure that ensures weak handles to this structure are still alive.
     ///
@@ -49,6 +50,7 @@ pub struct Keyboard {
     keyboard: *mut wlr_keyboard
 }
 
+#[derive(Debug)]
 pub struct KeyboardHandle {
     /// The Rc that ensures that this handle is still alive.
     ///
@@ -241,14 +243,6 @@ impl Drop for Keyboard {
     }
 }
 
-impl fmt::Debug for Keyboard {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(f,
-               "Keyboard {{ device: {:?}, keyboard: {:?} }}",
-               self.device, self.keyboard)
-    }
-}
-
 impl KeyboardHandle {
     /// Upgrades the keyboard handle to a reference to the backing `Keyboard`.
     ///
@@ -318,14 +312,6 @@ impl KeyboardHandle {
     /// Gets the wlr_keyboard associated with this KeyboardHandle.
     pub(crate) unsafe fn as_ptr(&self) -> *mut wlr_keyboard {
         self.keyboard
-    }
-}
-
-impl fmt::Debug for KeyboardHandle {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(f,
-               "Keyboard {{ device: {:?}, keyboard: {:?} }}",
-               self.device, self.keyboard)
     }
 }
 

--- a/src/types/keyboard.rs
+++ b/src/types/keyboard.rs
@@ -4,8 +4,9 @@ use std::rc::{Rc, Weak};
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use errors::{UpgradeHandleErr, UpgradeHandleResult};
-use wlroots_sys::{wlr_input_device, wlr_keyboard, wlr_keyboard_get_modifiers, wlr_keyboard_led,
-                  wlr_keyboard_led_update, wlr_keyboard_modifier, wlr_keyboard_set_keymap};
+use wlroots_sys::{wlr_input_device, wlr_key_state, wlr_keyboard, wlr_keyboard_get_modifiers,
+                  wlr_keyboard_led, wlr_keyboard_led_update, wlr_keyboard_modifier,
+                  wlr_keyboard_set_keymap};
 
 use xkbcommon::xkb::Keymap;
 
@@ -13,6 +14,8 @@ use InputDevice;
 
 /// The maximum number of keycodes stored in a `Keyboard`.
 pub const WLR_KEYBOARD_KEYS_CAP: usize = 32;
+
+pub type KeyState = wlr_key_state;
 
 #[derive(Debug)]
 pub struct Keyboard {

--- a/src/types/keyboard.rs
+++ b/src/types/keyboard.rs
@@ -137,6 +137,9 @@ impl Keyboard {
     /// Set the keymap for this Keyboard.
     pub fn set_keymap(&mut self, keymap: &Keymap) {
         unsafe {
+            // NOTE wlr_keyboard_set_keymap updates the reference count,
+            // so we don't need to mem::forget the key map here
+            // or take it by value.
             wlr_keyboard_set_keymap(self.keyboard, keymap.get_raw_ptr() as _);
         }
     }

--- a/src/types/keyboard.rs
+++ b/src/types/keyboard.rs
@@ -10,6 +10,9 @@ use wlroots_sys::{wlr_input_device, wlr_keyboard, wlr_keyboard_get_modifiers, wl
 
 use InputDevice;
 
+/// The maximum number of keycodes stored in a `Keyboard`.
+pub const WLR_KEYBOARD_KEYS_CAP: usize = 32;
+
 #[derive(Debug)]
 pub struct Keyboard {
     /// The structure that ensures weak handles to this structure are still alive.

--- a/src/types/keyboard.rs
+++ b/src/types/keyboard.rs
@@ -256,9 +256,6 @@ impl KeyboardHandle {
     /// This function is unsafe, because it creates an unbounded `Keyboard`
     /// which may live forever..
     /// But no keyboard lives forever and might be disconnected at any time.
-    ///
-    /// # Panics
-    /// This function will panic if multiple mutable borrows are detected.
     pub(crate) unsafe fn upgrade(&self) -> UpgradeHandleResult<Keyboard> {
         self.handle.upgrade()
             .ok_or(UpgradeHandleErr::DoubleUpgrade)

--- a/src/types/keyboard.rs
+++ b/src/types/keyboard.rs
@@ -88,12 +88,16 @@ impl Keyboard {
         }
     }
 
+    /// Update the LED lights using the provided bitmap.
+    ///
+    /// 1 means one, 0 means off.
     pub fn update_led(&mut self, leds: KeyboardLed) {
         unsafe {
             wlr_keyboard_led_update(self.keyboard, leds.bits() as u32);
         }
     }
 
+    /// Get the modifiers that are currently pressed on the keyboard.
     pub fn get_modifiers(&self) -> KeyboardModifier {
         unsafe {
             KeyboardModifier::from_bits_truncate(wlr_keyboard_get_modifiers(self.keyboard))

--- a/src/types/keyboard.rs
+++ b/src/types/keyboard.rs
@@ -5,8 +5,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use errors::{UpgradeHandleErr, UpgradeHandleResult};
 use wlroots_sys::{wlr_input_device, wlr_keyboard, wlr_keyboard_get_modifiers, wlr_keyboard_led,
-                  wlr_keyboard_led_update, wlr_keyboard_modifier, wlr_keyboard_set_keymap,
-                  xkb_keymap};
+                  wlr_keyboard_led_update, wlr_keyboard_modifier, wlr_keyboard_set_keymap};
+
+use xkbcommon::xkb::Keymap;
 
 use InputDevice;
 
@@ -80,10 +81,10 @@ impl Keyboard {
         &self.device
     }
 
-    // TODO: Implement keymap wrapper?
-    pub fn set_keymap(&mut self, keymap: *mut xkb_keymap) {
+    /// Set the keymap for this Keyboard.
+    pub fn set_keymap(&mut self, keymap: &Keymap) {
         unsafe {
-            wlr_keyboard_set_keymap(self.keyboard, keymap);
+            wlr_keyboard_set_keymap(self.keyboard, keymap.get_raw_ptr() as _);
         }
     }
 

--- a/src/types/output.rs
+++ b/src/types/output.rs
@@ -260,9 +260,6 @@ impl OutputHandle {
     /// This function is unsafe, because it creates an unbound `Output`
     /// which may live forever..
     /// But no output lives forever and might be disconnected at any time.
-    ///
-    /// # Panics
-    /// This function will panic if multiple mutable borrows are detected.
     pub(crate) unsafe fn upgrade(&self) -> UpgradeHandleResult<Output> {
         self.handle.upgrade()
             .ok_or(UpgradeHandleErr::DoubleUpgrade)

--- a/src/types/pointer.rs
+++ b/src/types/pointer.rs
@@ -135,9 +135,6 @@ impl PointerHandle {
     /// This function is unsafe, because it creates an unbound `Pointer`
     /// which may live forever..
     /// But no pointer lives forever and might be disconnected at any time.
-    ///
-    /// # Panics
-    /// This function will panic if multiple mutable borrows are detected.
     pub unsafe fn upgrade(&self) -> UpgradeHandleResult<Pointer> {
         self.handle.upgrade()
             .ok_or(UpgradeHandleErr::DoubleUpgrade)


### PR DESCRIPTION
Added:

# KeyEvent
* `time_msec`
* `update_state`
  - What is this? is this useful? This needs to be much better documented.
* `key_state`
* `input_keys` -> `pressed_keys`

# Keyboard
* `ModifierMasks`
* `RepeatInfo`
* `set_keymap`
* `get_keymap`
* `keycodes`
* `led_list`
* `modifier_list`
* `keymap_size`
* `get_xkb_state`
* `repeat_info`
* `get_modifier_masks`

# Handles
* Fixed documentation about panicking (forgot about it in last PR)