### PR TITLE
Fix multiple mutable borrows from using handles

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,37 @@
+//! All the errors used in wlroots-rs.
+
+use std::error::Error;
+use std::fmt;
+
+pub type UpgradeHandleResult<T> = Result<T, UpgradeHandleErr>;
+
+/// The types of ways upgrading a handle can fail.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum UpgradeHandleErr {
+    /// Attempting a handle that already has a mutable borrow to its
+    /// backing structure.
+    AlreadyBorrowed,
+    /// Trying to do a double upgrade (e.g downgrading and then upgrading
+    /// again).
+    DoubleUpgrade
+}
+
+impl fmt::Display for UpgradeHandleErr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use UpgradeHandleErr::*;
+        match *self {
+            AlreadyBorrowed => write!(f, "AlreadyBorrowed"),
+            DoubleUpgrade => write!(f, "DoubleUpgrade")
+        }
+    }
+}
+
+impl Error for UpgradeHandleErr {
+    fn description(&self) -> &str {
+        use UpgradeHandleErr::*;
+        match *self {
+            AlreadyBorrowed => "Structure is already mutably borrowed",
+            DoubleUpgrade => "Cannot upgrade a downgraded upgrade"
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ pub extern crate xkbcommon;
 mod macros;
 mod manager;
 mod compositor;
+mod errors;
 pub mod events;
 pub mod types;
 pub mod extensions;
@@ -57,3 +58,5 @@ pub use self::types::output::*;
 pub use self::types::pointer::*;
 pub use self::types::seat::*;
 pub use self::types::surface::*;
+
+pub use self::errors::*;

--- a/src/manager/input_manager.rs
+++ b/src/manager/input_manager.rs
@@ -123,7 +123,7 @@ wayland_listener!(InputManager, (Vec<Input>, Box<InputManagerHandler>), [
                         inputs.push(Input::Pointer(pointer))
                     }
                 },
-                _ => unimplemented!(), // TODO FIXME We _really_ shouldn't panic here
+                _ => unimplemented!(),
             }
             manager.input_added(compositor, &mut dev)
         }));
@@ -136,7 +136,7 @@ wayland_listener!(InputManager, (Vec<Input>, Box<InputManagerHandler>), [
             // Instead, execution keeps going with an eventual segfault (if lucky).
             //
             // To fix this, we abort the process if there was a panic in input setup.
-            Err(_) => ::std::process::abort()
+            Err(_) => abort()
         }
     };
     remove_listener => remove_notify: |this: &mut InputManager, data: *mut libc::c_void,| unsafe {

--- a/src/manager/input_manager.rs
+++ b/src/manager/input_manager.rs
@@ -72,7 +72,7 @@ wayland_listener!(InputManager, (Vec<Input>, Box<InputManagerHandler>), [
         use self::wlr_input_device_type::*;
         let mut dev = InputDevice::from_ptr(data);
         let compositor = &mut *COMPOSITOR_PTR;
-        let res = panic::catch_unwind(panic::AssertUnwindSafe(|| unsafe {
+        let res = panic::catch_unwind(panic::AssertUnwindSafe(|| {
             match dev.dev_type() {
                 WLR_INPUT_DEVICE_KEYBOARD => {
                     // Boring setup that we won't make the user do

--- a/src/manager/input_manager.rs
+++ b/src/manager/input_manager.rs
@@ -74,8 +74,10 @@ wayland_listener!(InputManager, (Vec<Input>, Box<InputManagerHandler>), [
                             abort()
                         }
                     };
+                    keyboard_handle.set_lock(true);
                     if let Some(keyboard_handler) = manager.keyboard_added(compositor,
                                                                            &mut keyboard_handle) {
+                        keyboard_handle.set_lock(false);
                         let mut keyboard = KeyboardWrapper::new((keyboard_handle,
                                                                  keyboard_handler));
                         wl_signal_add(&mut (*dev.dev_union().keyboard).events.key as *mut _ as _,
@@ -93,7 +95,9 @@ wayland_listener!(InputManager, (Vec<Input>, Box<InputManagerHandler>), [
                             abort()
                         }
                     };
+                    pointer_handle.set_lock(true);
                     if let Some(pointer) = manager.pointer_added(compositor, &mut pointer_handle) {
+                        pointer_handle.set_lock(false);
                         let mut pointer = PointerWrapper::new((pointer_handle, pointer));
                         wl_signal_add(&mut (*dev.dev_union().pointer).events.motion as *mut _ as _,
                                     pointer.motion_listener() as *mut _ as _);

--- a/src/manager/keyboard_handler.rs
+++ b/src/manager/keyboard_handler.rs
@@ -20,7 +20,9 @@ wayland_listener!(KeyboardWrapper, (Keyboard, Box<KeyboardHandler>), [
         let xkb_state = (*keyboard.as_ptr()).xkb_state;
         let mut key = KeyEvent::new(data as *mut wlr_event_keyboard_key, xkb_state);
 
-        keyboard_handler.on_key(compositor, keyboard, &mut key)
+        keyboard.set_lock(true);
+        keyboard_handler.on_key(compositor, keyboard, &mut key);
+        keyboard.set_lock(false);
     };
 ]);
 

--- a/src/manager/output_handler.rs
+++ b/src/manager/output_handler.rs
@@ -18,13 +18,17 @@ wayland_listener!(UserOutput, (Output, Box<OutputHandler>), [
         let output = &mut this.data.0;
         let manager = &mut this.data.1;
         let compositor = &mut *COMPOSITOR_PTR;
-        manager.output_frame(compositor, output)
+        output.set_lock(true);
+        manager.output_frame(compositor, output);
+        output.set_lock(false);
     };
     resolution_listener => resolution_notify: |this: &mut UserOutput, _output: *mut libc::c_void,|
     unsafe {
         let output = &mut this.data.0;
         let manager = &mut this.data.1;
-        manager.output_resolution(output)
+        output.set_lock(true);
+        manager.output_resolution(output);
+        output.set_lock(false);
     };
 ]);
 

--- a/src/manager/pointer_handler.rs
+++ b/src/manager/pointer_handler.rs
@@ -22,26 +22,38 @@ pub trait PointerHandler {
 
 wayland_listener!(PointerWrapper, (Pointer, Box<PointerHandler>), [
     button_listener => key_notify: |this: &mut PointerWrapper, data: *mut libc::c_void,| unsafe {
+        let pointer = &mut this.data.0;
         let event = ButtonEvent::from_ptr(data as *mut wlr_event_pointer_button);
         let compositor = &mut *COMPOSITOR_PTR;
-        this.data.1.on_button(compositor, &mut this.data.0, &event)
+        pointer.set_lock(true);
+        this.data.1.on_button(compositor, pointer, &event);
+        pointer.set_lock(false);
     };
     motion_listener => motion_notify:  |this: &mut PointerWrapper, data: *mut libc::c_void,|
     unsafe {
+        let pointer = &mut this.data.0;
         let event = MotionEvent::from_ptr(data as *mut wlr_event_pointer_motion);
         let compositor = &mut *COMPOSITOR_PTR;
-        this.data.1.on_motion(compositor, &mut this.data.0, &event)
+        pointer.set_lock(true);
+        this.data.1.on_motion(compositor, pointer, &event);
+        pointer.set_lock(false);
     };
     motion_absolute_listener => motion_absolute_notify:
     |this: &mut PointerWrapper, data: *mut libc::c_void,| unsafe {
+        let pointer = &mut this.data.0;
         let event = AbsoluteMotionEvent::from_ptr(data as *mut _);
         let compositor = &mut *COMPOSITOR_PTR;
-        this.data.1.on_motion_absolute(compositor, &mut this.data.0, &event)
+        pointer.set_lock(true);
+        this.data.1.on_motion_absolute(compositor, pointer, &event);
+        pointer.set_lock(false);
     };
     axis_listener => axis_notify:  |this: &mut PointerWrapper, data: *mut libc::c_void,| unsafe {
+        let pointer = &mut this.data.0;
         let event = AxisEvent::from_ptr(data as *mut wlr_event_pointer_axis);
         let compositor = &mut *COMPOSITOR_PTR;
-        this.data.1.on_axis(compositor, &mut this.data.0, &event)
+        pointer.set_lock(true);
+        this.data.1.on_axis(compositor, pointer, &event);
+        pointer.set_lock(false);
     };
 ]);
 

--- a/src/types/keyboard.rs
+++ b/src/types/keyboard.rs
@@ -194,14 +194,16 @@ impl KeyboardHandle {
             Some(ref mut keyboard) => {
                 let res = Some(runner(keyboard));
                 self.handle.upgrade().map(|check| {
-                    // Sanity check that it hasn't been tampered with.
-                    if !check.load(Ordering::Acquire) {
-                        wlr_log!(L_ERROR, "After running keyboard callback, \
-                                           mutable lock was false for: {:?}", keyboard);
-                        panic!("Lock in incorrect state!");
-                    }
-                    check.store(false, Ordering::Release);
-                });
+                                              // Sanity check that it hasn't been tampered with.
+                                              if !check.load(Ordering::Acquire) {
+                                                  wlr_log!(L_ERROR,
+                                                           "After running keyboard callback, \
+                                                            mutable lock was false for: {:?}",
+                                                           keyboard);
+                                                  panic!("Lock in incorrect state!");
+                                              }
+                                              check.store(false, Ordering::Release);
+                                          });
                 res
             }
         }

--- a/src/types/keyboard.rs
+++ b/src/types/keyboard.rs
@@ -155,13 +155,13 @@ impl KeyboardHandle {
     /// to a short lived scope of an anonymous function,
     /// this function ensures the Keyboard does not live longer
     /// than it exists.
-    pub fn run<F, R>(&self, runner: F) -> Option<R>
-        where F: FnOnce(&Keyboard) -> R
+    pub fn run<F, R>(&mut self, runner: F) -> Option<R>
+        where F: FnOnce(&mut Keyboard) -> R
     {
-        let pointer = unsafe { self.upgrade() };
-        match pointer {
+        let mut keyboard = unsafe { self.upgrade() };
+        match keyboard {
             None => None,
-            Some(pointer) => Some(runner(&pointer))
+            Some(ref mut keyboard) => Some(runner(keyboard))
         }
     }
 

--- a/src/types/keyboard.rs
+++ b/src/types/keyboard.rs
@@ -110,6 +110,17 @@ impl Keyboard {
                          device: unsafe { self.device.clone() },
                          keyboard: self.keyboard }
     }
+
+    /// Manually set the lock used to determine if a double-borrow is
+    /// occuring on this structure.
+    ///
+    /// # Panics
+    /// Panics when trying to set the lock on an upgraded handle.
+    pub(crate) unsafe fn set_lock(&self, val: bool) {
+        self.liveliness.as_ref()
+            .expect("Tried to set lock on borrowed Keyboard")
+            .store(val, Ordering::Release);
+    }
 }
 
 impl Drop for Keyboard {

--- a/src/types/output.rs
+++ b/src/types/output.rs
@@ -262,13 +262,13 @@ impl OutputHandle {
     /// to a short lived scope of an anonymous function,
     /// this function ensures the Output does not live longer
     /// than it exists.
-    pub fn run<F, R>(&self, runner: F) -> Option<R>
-        where F: FnOnce(&Output) -> R
+    pub fn run<F, R>(&mut self, runner: F) -> Option<R>
+        where F: FnOnce(&mut Output) -> R
     {
-        let output = unsafe { self.upgrade() };
+        let mut output = unsafe { self.upgrade() };
         match output {
             None => None,
-            Some(output) => Some(runner(&output))
+            Some(ref mut output) => Some(runner(output))
         }
     }
 

--- a/src/types/output.rs
+++ b/src/types/output.rs
@@ -3,6 +3,7 @@
 use std::cell::RefCell;
 use std::ffi::CStr;
 use std::rc::{Rc, Weak};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use wayland_sys::server::WAYLAND_SERVER_HANDLE;
 use wlroots_sys::{wl_list, wl_output_transform, wlr_output, wlr_output_effective_resolution,
@@ -26,7 +27,7 @@ pub struct Output {
     /// the operations are **unchecked**.
     /// This is means safe operations might fail, but only if you use the unsafe
     /// marked function `upgrade` on a `OutputHandle`.
-    liveliness: Option<Rc<()>>,
+    liveliness: Option<Rc<AtomicBool>>,
     /// The output ptr that refers to this `Output`
     output: *mut wlr_output
 }
@@ -38,7 +39,7 @@ pub struct OutputHandle {
     ///
     /// When wlroots deallocates the pointer associated with this handle,
     /// this can no longer be used.
-    handle: Weak<()>,
+    handle: Weak<AtomicBool>,
     /// The output ptr that refers to this `Output`
     output: *mut wlr_output
 }
@@ -68,7 +69,7 @@ impl Output {
     /// This creates a totally new Output (e.g with its own reference count)
     /// so only do this once per `wlr_output`!
     pub unsafe fn new(output: *mut wlr_output) -> Self {
-        Output { liveliness: Some(Rc::new(())),
+        Output { liveliness: Some(Rc::new(AtomicBool::new(false))),
                  output }
     }
 
@@ -245,12 +246,23 @@ impl OutputHandle {
     /// This function is unsafe, because it creates an unbound `Output`
     /// which may live forever..
     /// But no output lives forever and might be disconnected at any time.
-    pub unsafe fn upgrade(&self) -> Option<Output> {
+    ///
+    /// # Panics
+    /// This function will panic if multiple mutable borrows are detected.
+    pub(crate) unsafe fn upgrade(&self) -> Option<Output> {
         self.handle.upgrade()
             // NOTE
             // We drop the Rc here because having two would allow a dangling
             // pointer to exist!
-            .map(|_| Output::from_handle(self))
+            .map(|check| {
+                let output = Output::from_handle(self);
+                if check.load(Ordering::Acquire) {
+                    wlr_log!(L_ERROR, "Double mutable borrows on {:?}", output);
+                    panic!("Double mutable borrow detected");
+                }
+                check.store(true, Ordering::Release);
+                output
+            })
     }
 
     /// Run a function on the referenced Output, if it still exists
@@ -262,13 +274,32 @@ impl OutputHandle {
     /// to a short lived scope of an anonymous function,
     /// this function ensures the Output does not live longer
     /// than it exists.
+    ///
+    /// # Panics
+    /// This function will panic if multiple mutable borrows are detected.
+    /// This will happen if you call `upgrade` directly within this callback,
+    /// or if you run this function within the another run to the same `Output`.
+    ///
+    /// So don't nest `run` calls and everything will be ok :).
     pub fn run<F, R>(&mut self, runner: F) -> Option<R>
         where F: FnOnce(&mut Output) -> R
     {
         let mut output = unsafe { self.upgrade() };
         match output {
             None => None,
-            Some(ref mut output) => Some(runner(output))
+            Some(ref mut output) => {
+                let res = Some(runner(output));
+                self.handle.upgrade().map(|check| {
+                    // Sanity check that it hasn't been tampered with.
+                    if !check.load(Ordering::Acquire) {
+                        wlr_log!(L_ERROR, "After running output callback, \
+                                           mutable lock was false for: {:?}", output);
+                        panic!("Lock in incorrect state!");
+                    }
+                    check.store(false, Ordering::Release);
+                });
+                res
+            }
         }
     }
 

--- a/src/types/output.rs
+++ b/src/types/output.rs
@@ -214,6 +214,17 @@ impl Output {
         Output { liveliness: None,
                  output: handle.as_ptr() }
     }
+
+    /// Manually set the lock used to determine if a double-borrow is
+    /// occuring on this structure.
+    ///
+    /// # Panics
+    /// Panics when trying to set the lock on an upgraded handle.
+    pub(crate) unsafe fn set_lock(&self, val: bool) {
+        self.liveliness.as_ref()
+            .expect("Tried to set lock on borrowed Output")
+            .store(val, Ordering::Release);
+    }
 }
 
 impl Drop for Output {

--- a/src/types/output.rs
+++ b/src/types/output.rs
@@ -301,14 +301,16 @@ impl OutputHandle {
             Some(ref mut output) => {
                 let res = Some(runner(output));
                 self.handle.upgrade().map(|check| {
-                    // Sanity check that it hasn't been tampered with.
-                    if !check.load(Ordering::Acquire) {
-                        wlr_log!(L_ERROR, "After running output callback, \
-                                           mutable lock was false for: {:?}", output);
-                        panic!("Lock in incorrect state!");
-                    }
-                    check.store(false, Ordering::Release);
-                });
+                                              // Sanity check that it hasn't been tampered with.
+                                              if !check.load(Ordering::Acquire) {
+                                                  wlr_log!(L_ERROR,
+                                                           "After running output callback, \
+                                                            mutable lock was false for: {:?}",
+                                                           output);
+                                                  panic!("Lock in incorrect state!");
+                                              }
+                                              check.store(false, Ordering::Release);
+                                          });
                 res
             }
         }

--- a/src/types/pointer.rs
+++ b/src/types/pointer.rs
@@ -92,6 +92,17 @@ impl Pointer {
                         device: unsafe { self.device.clone() },
                         pointer: self.pointer }
     }
+
+    /// Manually set the lock used to determine if a double-borrow is
+    /// occuring on this structure.
+    ///
+    /// # Panics
+    /// Panics when trying to set the lock on an upgraded handle.
+    pub(crate) unsafe fn set_lock(&self, val: bool) {
+        self.liveliness.as_ref()
+            .expect("Tried to set lock on borrowed Pointer")
+            .store(val, Ordering::Release);
+    }
 }
 
 impl Drop for Pointer {

--- a/src/types/pointer.rs
+++ b/src/types/pointer.rs
@@ -176,14 +176,16 @@ impl PointerHandle {
             Some(ref mut pointer) => {
                 let res = Some(runner(pointer));
                 self.handle.upgrade().map(|check| {
-                    // Sanity check that it hasn't been tampered with.
-                    if !check.load(Ordering::Acquire) {
-                        wlr_log!(L_ERROR, "After running pointer callback, \
-                                           mutable lock was false for: {:?}", pointer);
-                        panic!("Lock in incorrect state!");
-                    }
-                    check.store(false, Ordering::Release);
-                });
+                                              // Sanity check that it hasn't been tampered with.
+                                              if !check.load(Ordering::Acquire) {
+                                                  wlr_log!(L_ERROR,
+                                                           "After running pointer callback, \
+                                                            mutable lock was false for: {:?}",
+                                                           pointer);
+                                                  panic!("Lock in incorrect state!");
+                                              }
+                                              check.store(false, Ordering::Release);
+                                          });
                 res
             }
         }

--- a/src/types/pointer.rs
+++ b/src/types/pointer.rs
@@ -137,13 +137,13 @@ impl PointerHandle {
     /// to a short lived scope of an anonymous function,
     /// this function ensures the Pointer does not live longer
     /// than it exists.
-    pub fn run<F, R>(&self, runner: F) -> Option<R>
+    pub fn run<F, R>(&mut self, runner: F) -> Option<R>
         where F: FnOnce(&Pointer) -> R
     {
-        let pointer = unsafe { self.upgrade() };
+        let mut pointer = unsafe { self.upgrade() };
         match pointer {
             None => None,
-            Some(pointer) => Some(runner(&pointer))
+            Some(ref mut pointer) => Some(runner(pointer))
         }
     }
 


### PR DESCRIPTION
Plug safety hole from multi mut handles 

This plugs the hole that can be caused from running multiple handles within the `run` callback that all point to the same backing wlroots owned storage.

It was probably safe, tbh, because internally they all use *mut to get their data and it probably syncs that up just fine (e.g there's no incorrect way for Rust to re-order / elide the data fetching because it's behind an opaque barrier). However, UB is UB, so this limitation has been added.

The solution is to add an AtomicBool to the Rc in the concrete types and check that each time we acquire it. This means we can no longer expose the unsafe `upgrade` function, but that's not a problem since that wasn't supposed to be used anyways. The reason we can't expose it is that there's no way to set the bool back to false after it's done executing since once you upgrade you lose that information (because we can't let the Rc live longer than 1, this is an Rc but really it's just a bunch of weak pointer to one owner).
