### PR TITLE
Finished wrapping Cursor, XCursor, and XCursorTheme

### DIFF
--- a/examples/pointer.rs
+++ b/examples/pointer.rs
@@ -74,7 +74,7 @@ impl PointerHandler for ExPointer {
     fn on_motion(&mut self, compositor: &mut Compositor, _: &mut Pointer, event: &MotionEvent) {
         let state: &mut State = compositor.into();
         let (delta_x, delta_y) = event.delta();
-        state.layout.cursors()[0].move_to(&event.device(), delta_x, delta_y);
+        state.layout.cursors()[0].move_to(event.device(), delta_x, delta_y);
     }
 
     fn on_button(&mut self, compositor: &mut Compositor, _: &mut Pointer, event: &ButtonEvent) {

--- a/examples/pointer.rs
+++ b/examples/pointer.rs
@@ -4,7 +4,7 @@ extern crate wlroots;
 use wlroots::{AxisEvent, ButtonEvent, Compositor, CompositorBuilder, CursorBuilder,
               InputManagerHandler, KeyEvent, Keyboard, KeyboardHandler, MotionEvent, Output,
               OutputBuilder, OutputBuilderResult, OutputHandler, OutputLayout,
-              OutputManagerHandler, Pointer, PointerHandler, XCursor, XCursorTheme};
+              OutputManagerHandler, Pointer, PointerHandler, XCursorTheme};
 use wlroots::utils::{init_logging, L_DEBUG};
 use wlroots::wlroots_sys::gl;
 use wlroots::wlroots_sys::wlr_button_state::WLR_BUTTON_RELEASED;
@@ -13,15 +13,15 @@ use wlroots::xkbcommon::xkb::keysyms::KEY_Escape;
 struct State {
     color: [f32; 4],
     default_color: [f32; 4],
-    xcursor: XCursor,
+    xcursor_theme: XCursorTheme,
     layout: OutputLayout
 }
 
 impl State {
-    fn new(xcursor: XCursor, layout: OutputLayout) -> Self {
+    fn new(xcursor_theme: XCursorTheme, layout: OutputLayout) -> Self {
         State { color: [0.25, 0.25, 0.25, 1.0],
                 default_color: [0.25, 0.25, 0.25, 1.0],
-                xcursor,
+                xcursor_theme,
                 layout }
     }
 }
@@ -45,7 +45,10 @@ impl OutputManagerHandler for OutputManager {
                              -> Option<OutputBuilderResult<'output>> {
         let result = builder.build_best_mode(ExOutput);
         let state: &mut State = compositor.into();
-        let image = &state.xcursor.images()[0];
+        let xcursor = state.xcursor_theme
+                           .get_cursor("left_ptr".into())
+                           .expect("Could not load left_ptr cursor");
+        let image = &xcursor.images()[0];
         // TODO use output config if present instead of auto
         state.layout.add_auto(result.output);
         let cursor = &mut state.layout.cursors()[0];
@@ -130,16 +133,11 @@ impl InputManagerHandler for InputManager {
 fn main() {
     init_logging(L_DEBUG, None);
     let cursor = CursorBuilder::new().expect("Could not create cursor");
-    let xcursor;
-    {
-        let xcursor_theme = XCursorTheme::load_theme(None, 16).expect("Could not load theme");
-        xcursor = xcursor_theme.get_cursor("left_ptr".into())
-                               .expect("Could not load cursor from theme");
-    }
+    let xcursor_theme = XCursorTheme::load_theme(None, 16).expect("Could not load theme");
     let mut layout = OutputLayout::new().expect("Could not construct an output layout");
 
     layout.attach_cursor(cursor);
-    let compositor = CompositorBuilder::new().build_auto(State::new(xcursor, layout),
+    let compositor = CompositorBuilder::new().build_auto(State::new(xcursor_theme, layout),
                                                          Box::new(InputManager),
                                                          Box::new(OutputManager));
     compositor.run();

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -14,6 +14,24 @@ macro_rules! container_of (
     }
 );
 
+/// Iterates over a wl_list.
+///
+/// # Safety
+/// It is not safe to delete an element while iterating over the list,
+/// so don't do it!
+macro_rules! wl_list_for_each {
+    ($ptr: expr, $container: ty, $field: ident, ($pos: ident) => $body: block) => {
+        $pos = container_of!($ptr.next, $container, $field);
+        loop {
+            if &(*$pos).$field as *const _ == &$ptr as *const _ {
+                break
+            }
+            { $body }
+            $pos = container_of!((*$pos).$field.next, $container, $field);
+        }
+    }
+}
+
 /// Convert a literal string to a C string.
 /// Note: Does not check for internal nulls, nor does it do any conversions on
 /// the grapheme clustors. Just passes the bytes as is.

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -20,7 +20,8 @@ macro_rules! container_of (
 /// It is not safe to delete an element while iterating over the list,
 /// so don't do it!
 macro_rules! wl_list_for_each {
-    ($ptr: expr, $container: ty, $field: ident, ($pos: ident) => $body: block) => {
+    ($ptr: expr, $field: ident, ($pos: ident : $container: ty) => $body: block) => {
+        let mut $pos: *mut $container;
         $pos = container_of!($ptr.next, $container, $field);
         loop {
             if &(*$pos).$field as *const _ == &$ptr as *const _ {

--- a/src/types/cursor/cursor.rs
+++ b/src/types/cursor/cursor.rs
@@ -129,10 +129,6 @@ impl Cursor {
         }
     }
 
-    // TODO Ensure the safety of these functions.
-    // It's possible we need more handles floating about with checks...
-    // or a different memory model -_-
-
     /// Attaches this input device to this cursor. The input device must be one of:
     ///
     /// - WLR_INPUT_DEVICE_POINTER
@@ -142,6 +138,11 @@ impl Cursor {
     /// TODO Make this impossible to mess up with using an enum
     /// Note that it's safe to use the wrong type.
     pub fn attach_input_device(&mut self, dev: &InputDevice) {
+        // NOTE Rationale for not storing handle:
+        //
+        // Internally, on the destroy event this will automatically
+        // destroy the internal wlr_cursor_device used to refer to
+        // this InputDevice.
         unsafe { wlr_cursor_attach_input_device(self.cursor, dev.as_ptr()) }
     }
 

--- a/src/types/cursor/cursor.rs
+++ b/src/types/cursor/cursor.rs
@@ -57,7 +57,8 @@ impl CursorBuilder {
     }
 
     pub(crate) fn build(self, output_layout: OutputLayoutHandle) -> Cursor {
-        Cursor { cursor: self.cursor, output_layout,  }
+        Cursor { cursor: self.cursor,
+                 output_layout }
     }
 }
 
@@ -189,7 +190,8 @@ impl Cursor {
         // returns early (and thus does nothing unsafe).
 
         if !self.output_in_output_layout(output.weak_reference()) {
-            wlr_log!(L_ERROR, "Tried to map input to an output not in the OutputLayout");
+            wlr_log!(L_ERROR,
+                     "Tried to map input to an output not in the OutputLayout");
             return
         }
         unsafe { wlr_cursor_map_input_to_output(self.cursor, dev.as_ptr(), output.as_ptr()) }
@@ -248,13 +250,13 @@ impl Cursor {
     /// Otherwise it returns `true`.
     fn output_in_output_layout(&mut self, output: OutputHandle) -> bool {
         match self.output_layout.run(|output_layout| {
-            for (cur_output, _) in output_layout.outputs() {
-                if cur_output == output {
-                    return true
-                }
-            }
-            false
-        }) {
+                                         for (cur_output, _) in output_layout.outputs() {
+                                             if cur_output == output {
+                                                 return true
+                                             }
+                                         }
+                                         false
+                                     }) {
             Ok(res) => res,
             Err(UpgradeHandleErr::AlreadyDropped) => false,
             Err(err) => panic!(err)

--- a/src/types/cursor/cursor.rs
+++ b/src/types/cursor/cursor.rs
@@ -155,9 +155,10 @@ impl Cursor {
 
     /// Attaches this cursor to the given output, which must be among the outputs in
     /// the current output_layout for this cursor.
-    ///
-    /// This call is invalid for a cursor without an associated output layout.
     pub fn map_to_output(&mut self, output: &Output) {
+        // TODO Check for if this output is in the output layout?
+        // We can store a handle to the output layout, but it needs
+        // to be updated in case we support moving cursors between them.
         unsafe { wlr_cursor_map_to_output(self.cursor, output.as_ptr()) }
     }
 
@@ -166,6 +167,12 @@ impl Cursor {
     /// The input device must be attached to this cursor
     /// and the output must be among the outputs in the attached output layout.
     pub fn map_input_to_output(&mut self, dev: &InputDevice, output: &Output) {
+        // NOTE Rationale for why we don't check input:
+        //
+        // If the input isn't found, then wlroots prints a diagnostic and
+        // returns early (and thus does nothing unsafe).
+
+        // TODO Similar output check to map_to_output
         unsafe { wlr_cursor_map_input_to_output(self.cursor, dev.as_ptr(), output.as_ptr()) }
     }
 
@@ -177,7 +184,13 @@ impl Cursor {
 
     /// Maps inputs from this input device to an arbitrary region on the associated
     /// wlr_output_layout.
+    ///
+    /// The input device must be attached to this cursor.
     pub fn map_input_to_region(&mut self, dev: &InputDevice, mut area: Area) {
+        // NOTE Rationale for why we don't check input:
+        //
+        // If the input isn't found, then wlroots prints a diagnostic and
+        // returns early (and thus does nothing unsafe).
         unsafe { wlr_cursor_map_input_to_region(self.cursor, dev.as_ptr(), &mut area.0) }
     }
 

--- a/src/types/cursor/cursor.rs
+++ b/src/types/cursor/cursor.rs
@@ -90,8 +90,11 @@ impl Cursor {
     ///
     /// `dev` may be passed to respect device mapping constraints. If `dev` is None,
     /// device mapping constraints will be ignored.
-    pub fn move_to(&mut self, dev: &InputDevice, delta_x: f64, delta_y: f64) {
-        unsafe { wlr_cursor_move(self.cursor, dev.as_ptr(), delta_x, delta_y) }
+    pub fn move_to(&mut self, dev: Option<&InputDevice>, delta_x: f64, delta_y: f64) {
+        unsafe {
+            let dev_ptr = dev.map(|dev| dev.as_ptr()).unwrap_or(ptr::null_mut());
+            wlr_cursor_move(self.cursor, dev_ptr, delta_x, delta_y)
+        }
     }
 
     // TODO Allow setting cursor images to arbitrary bytes,

--- a/src/types/cursor/cursor.rs
+++ b/src/types/cursor/cursor.rs
@@ -2,10 +2,14 @@
 
 use std::ptr;
 
-use wlroots_sys::{wlr_cursor, wlr_cursor_create, wlr_cursor_destroy, wlr_cursor_move,
-                  wlr_cursor_set_image, wlr_cursor_warp};
+use wlroots_sys::{wlr_cursor, wlr_cursor_absolute_to_layout_coords,
+                  wlr_cursor_attach_input_device, wlr_cursor_create, wlr_cursor_destroy,
+                  wlr_cursor_detach_input_device, wlr_cursor_map_input_to_output,
+                  wlr_cursor_map_input_to_region, wlr_cursor_map_to_output,
+                  wlr_cursor_map_to_region, wlr_cursor_move, wlr_cursor_set_image,
+                  wlr_cursor_set_surface, wlr_cursor_warp, wlr_cursor_warp_absolute};
 
-use {InputDevice, XCursorImage};
+use {Area, InputDevice, Output, Surface, XCursorImage};
 
 #[derive(Debug)]
 pub struct CursorBuilder {
@@ -56,20 +60,42 @@ impl CursorBuilder {
 }
 
 impl Cursor {
+    /// Get the coordinates the cursor is located at.
     pub fn coords(&self) -> (f64, f64) {
         unsafe { ((*self.cursor).x, (*self.cursor).y) }
     }
 
+    /// Warp the cursor to the given x and y in layout coordinates. If x and y are
+    /// out of the layout boundaries or constraints, no warp will happen.
+    ///
+    /// `dev` may be passed to respect device mapping constraints. If `dev` is None,
+    /// device mapping constraints will be ignored.
+    ///
+    /// Returns true when the mouse warp was successful.
     pub fn warp(&mut self, dev: Option<&InputDevice>, x: f64, y: f64) -> bool {
         unsafe {
-            let dev_ptr = dev.map(|dev| dev.as_ptr()).unwrap_or(ptr::null_mut());
+            let dev_ptr = dev.map(|input_device| input_device.as_ptr()).unwrap_or(ptr::null_mut());
             wlr_cursor_warp(self.cursor, dev_ptr, x, y)
         }
     }
 
+    pub fn warp_absolute(&mut self, dev: Option<&InputDevice>, x_mm: f64, y_mm: f64) {
+        unsafe {
+            let dev_ptr = dev.map(|input_device| input_device.as_ptr()).unwrap_or(ptr::null_mut());
+            wlr_cursor_warp_absolute(self.cursor, dev_ptr, x_mm, y_mm)
+        }
+    }
+
+    /// Move the cursor in the direction of the given x and y coordinates.
+    ///
+    /// `dev` may be passed to respect device mapping constraints. If `dev` is None,
+    /// device mapping constraints will be ignored.
     pub fn move_to(&mut self, dev: &InputDevice, delta_x: f64, delta_y: f64) {
         unsafe { wlr_cursor_move(self.cursor, dev.as_ptr(), delta_x, delta_y) }
     }
+
+    // TODO Allow setting cursor images to arbitrary bytes,
+    // just like in wlroots. Want to make sure that's safe though
 
     /// Sets the image of the cursor to the image from the XCursor.
     pub fn set_cursor_image(&mut self, image: &XCursorImage) {
@@ -88,6 +114,93 @@ impl Cursor {
                                  image.hotspot_x as i32,
                                  image.hotspot_y as i32,
                                  scale)
+        }
+    }
+
+    /// Set the cursor surface. The surface can be committed to update the cursor
+    /// image. The surface position is substracted from the hotspot.
+    ///
+    /// A `None` surface commit hides the cursor.
+    pub fn set_surface(&mut self, surface: Option<&Surface>, hotspot_x: i32, hotspot_y: i32) {
+        unsafe {
+            let surface_ptr = surface.map(|surface| surface.as_ptr())
+                                     .unwrap_or(ptr::null_mut());
+            wlr_cursor_set_surface(self.cursor, surface_ptr, hotspot_x, hotspot_y)
+        }
+    }
+
+    // TODO Ensure the safety of these functions.
+    // It's possible we need more handles floating about with checks...
+    // or a different memory model -_-
+
+    /// Attaches this input device to this cursor. The input device must be one of:
+    ///
+    /// - WLR_INPUT_DEVICE_POINTER
+    /// - WLR_INPUT_DEVICE_TOUCH
+    /// - WLR_INPUT_DEVICE_TABLET_TOOL
+    ///
+    /// TODO Make this impossible to mess up with using an enum
+    /// Note that it's safe to use the wrong type.
+    pub fn attach_input_device(&mut self, dev: &InputDevice) {
+        unsafe { wlr_cursor_attach_input_device(self.cursor, dev.as_ptr()) }
+    }
+
+    /// Deattaches the input device from this cursor.
+    pub fn deattach_input_device(&mut self, dev: &InputDevice) {
+        unsafe { wlr_cursor_detach_input_device(self.cursor, dev.as_ptr()) }
+    }
+
+    // TODO Test what it means for the call to be "invalid". Segfault?
+
+    /// Attaches this cursor to the given output, which must be among the outputs in
+    /// the current output_layout for this cursor.
+    ///
+    /// This call is invalid for a cursor without an associated output layout.
+    pub fn map_to_output(&mut self, output: &Output) {
+        unsafe { wlr_cursor_map_to_output(self.cursor, output.as_ptr()) }
+    }
+
+    /// Maps all input from a specific input device to a given output.
+    ///
+    /// The input device must be attached to this cursor
+    /// and the output must be among the outputs in the attached output layout.
+    pub fn map_input_to_output(&mut self, dev: &InputDevice, output: &Output) {
+        unsafe { wlr_cursor_map_input_to_output(self.cursor, dev.as_ptr(), output.as_ptr()) }
+    }
+
+    /// Maps this cursor to an arbitrary region on the associated
+    /// wlr_output_layout.
+    pub fn map_to_region(&mut self, mut area: Area) {
+        unsafe { wlr_cursor_map_to_region(self.cursor, &mut area.0) }
+    }
+
+    /// Maps inputs from this input device to an arbitrary region on the associated
+    /// wlr_output_layout.
+    pub fn map_input_to_region(&mut self, dev: &InputDevice, mut area: Area) {
+        unsafe { wlr_cursor_map_input_to_region(self.cursor, dev.as_ptr(), &mut area.0) }
+    }
+
+    /// Convert absolute coordinates to layout coordinates for the device.
+    ///
+    /// Coordinates are in (x, y).
+    pub fn absolute_to_layout_coords(&mut self,
+                                     dev: &InputDevice,
+                                     x_mm: f64,
+                                     y_mm: f64,
+                                     width_mm: f64,
+                                     height_mm: f64)
+                                     -> (f64, f64) {
+        unsafe {
+            let (mut lx, mut ly) = (0.0, 0.0);
+            wlr_cursor_absolute_to_layout_coords(self.cursor,
+                                                 dev.as_ptr(),
+                                                 x_mm,
+                                                 y_mm,
+                                                 width_mm,
+                                                 height_mm,
+                                                 &mut lx,
+                                                 &mut ly);
+            (lx, ly)
         }
     }
 

--- a/src/types/cursor/cursor.rs
+++ b/src/types/cursor/cursor.rs
@@ -1,13 +1,11 @@
 //! Wrapper for wlr_cursor
 
-use std::{mem, ptr, slice};
+use std::ptr;
 
 use wlroots_sys::{wlr_cursor, wlr_cursor_create, wlr_cursor_destroy, wlr_cursor_move,
-                  wlr_cursor_set_image, wlr_cursor_warp, wlr_xcursor, wlr_xcursor_image,
-                  wlr_xcursor_theme, wlr_xcursor_theme_get_cursor, wlr_xcursor_theme_load};
+                  wlr_cursor_set_image, wlr_cursor_warp};
 
-use InputDevice;
-use utils::safe_as_cstring;
+use {InputDevice, XCursorImage};
 
 #[derive(Debug)]
 pub struct CursorBuilder {
@@ -17,16 +15,6 @@ pub struct CursorBuilder {
 #[derive(Debug)]
 pub struct Cursor {
     cursor: *mut wlr_cursor
-}
-
-#[derive(Debug)]
-pub struct XCursorTheme {
-    theme: *mut wlr_xcursor_theme
-}
-
-#[derive(Debug)]
-pub struct XCursor {
-    xcursor: *mut wlr_xcursor
 }
 
 impl CursorBuilder {
@@ -112,79 +100,4 @@ impl Drop for Cursor {
     fn drop(&mut self) {
         unsafe { wlr_cursor_destroy(self.cursor) }
     }
-}
-
-impl XCursorTheme {
-    /// If no name is given, defaults to "default".
-    pub fn load_theme(name: Option<String>, size: i32) -> Option<Self> {
-        unsafe {
-            let name_str = name.map(safe_as_cstring);
-            let name_ptr = name_str.map(|s| s.as_ptr()).unwrap_or(ptr::null_mut());
-            let theme = wlr_xcursor_theme_load(name_ptr, size);
-            if theme.is_null() {
-                None
-            } else {
-                Some(XCursorTheme { theme })
-            }
-        }
-    }
-
-    pub fn get_cursor(&self, name: String) -> Option<XCursor> {
-        let name_str = safe_as_cstring(name);
-        let xcursor =
-            unsafe { wlr_xcursor_theme_get_cursor(self.theme, name_str.as_ptr()) };
-        if xcursor.is_null() {
-            None
-        } else {
-            Some(XCursor { xcursor })
-        }
-    }
-
-    #[allow(dead_code)]
-    pub(crate) unsafe fn as_ptr(self) -> *mut wlr_xcursor_theme {
-        self.theme
-    }
-}
-
-impl XCursor {
-    #[allow(dead_code)]
-    pub(crate) unsafe fn as_ptr(&mut self) -> *mut wlr_xcursor {
-        self.xcursor
-    }
-
-    pub fn images<'cursor>(&'cursor self) -> Vec<XCursorImage<'cursor>> {
-        unsafe {
-            let image_ptr = (*self.xcursor).images as *const *const wlr_xcursor_image;
-            let length = (*self.xcursor).image_count;
-            let cursors_slice: &'cursor [*const wlr_xcursor_image] =
-                slice::from_raw_parts::<'cursor, *const wlr_xcursor_image>(image_ptr,
-                                                                           length as usize);
-            let mut result = Vec::with_capacity(cursors_slice.len());
-            for cursor in cursors_slice {
-                result.push(XCursorImage {
-                    width: (**cursor).width,
-                    height: (**cursor).height,
-                    hotspot_x: (**cursor).hotspot_x,
-                    hotspot_y: (**cursor).hotspot_y,
-                    delay: (**cursor).delay,
-                    buffer: slice::from_raw_parts::<'cursor, u8>(
-                        (**cursor).buffer as *const u8,
-                        (**cursor).width as usize * (**cursor).height as usize
-                            * mem::size_of::<u32>()
-                    )
-                })
-            }
-            result
-        }
-    }
-}
-
-#[derive(Debug)]
-pub struct XCursorImage<'cursor> {
-    pub width: u32,
-    pub height: u32,
-    pub hotspot_x: u32,
-    pub hotspot_y: u32,
-    pub delay: u32,
-    pub buffer: &'cursor [u8]
 }

--- a/src/types/cursor/cursor.rs
+++ b/src/types/cursor/cursor.rs
@@ -72,16 +72,22 @@ impl Cursor {
     /// device mapping constraints will be ignored.
     ///
     /// Returns true when the mouse warp was successful.
-    pub fn warp(&mut self, dev: Option<&InputDevice>, x: f64, y: f64) -> bool {
+    pub fn warp<'this, O>(&'this mut self, dev: O, x: f64, y: f64) -> bool
+        where O: Into<Option<&'this InputDevice>>
+    {
         unsafe {
-            let dev_ptr = dev.map(|input_device| input_device.as_ptr()).unwrap_or(ptr::null_mut());
+            let dev_ptr = dev.into().map(|input_device| input_device.as_ptr())
+                             .unwrap_or(ptr::null_mut());
             wlr_cursor_warp(self.cursor, dev_ptr, x, y)
         }
     }
 
-    pub fn warp_absolute(&mut self, dev: Option<&InputDevice>, x_mm: f64, y_mm: f64) {
+    pub fn warp_absolute<'this, O>(&'this mut self, dev: O, x_mm: f64, y_mm: f64)
+        where O: Into<Option<&'this InputDevice>>
+    {
         unsafe {
-            let dev_ptr = dev.map(|input_device| input_device.as_ptr()).unwrap_or(ptr::null_mut());
+            let dev_ptr = dev.into().map(|input_device| input_device.as_ptr())
+                             .unwrap_or(ptr::null_mut());
             wlr_cursor_warp_absolute(self.cursor, dev_ptr, x_mm, y_mm)
         }
     }
@@ -90,9 +96,12 @@ impl Cursor {
     ///
     /// `dev` may be passed to respect device mapping constraints. If `dev` is None,
     /// device mapping constraints will be ignored.
-    pub fn move_to(&mut self, dev: Option<&InputDevice>, delta_x: f64, delta_y: f64) {
+    pub fn move_to<'this, O>(&'this mut self, dev: O, delta_x: f64, delta_y: f64)
+        where O: Into<Option<&'this InputDevice>>
+    {
         unsafe {
-            let dev_ptr = dev.map(|dev| dev.as_ptr()).unwrap_or(ptr::null_mut());
+            let dev_ptr = dev.into().map(|dev| dev.as_ptr())
+                             .unwrap_or(ptr::null_mut());
             wlr_cursor_move(self.cursor, dev_ptr, delta_x, delta_y)
         }
     }
@@ -124,9 +133,12 @@ impl Cursor {
     /// image. The surface position is substracted from the hotspot.
     ///
     /// A `None` surface commit hides the cursor.
-    pub fn set_surface(&mut self, surface: Option<&Surface>, hotspot_x: i32, hotspot_y: i32) {
+    pub fn set_surface<'this, O>(&'this mut self, surface: O, hotspot_x: i32, hotspot_y: i32)
+        where O: Into<Option<&'this Surface>>
+    {
         unsafe {
-            let surface_ptr = surface.map(|surface| surface.as_ptr())
+            let surface_ptr = surface.into()
+                                     .map(|surface| surface.as_ptr())
                                      .unwrap_or(ptr::null_mut());
             wlr_cursor_set_surface(self.cursor, surface_ptr, hotspot_x, hotspot_y)
         }

--- a/src/types/cursor/cursor.rs
+++ b/src/types/cursor/cursor.rs
@@ -248,8 +248,8 @@ impl Cursor {
     /// Otherwise it returns `true`.
     fn output_in_output_layout(&mut self, output: OutputHandle) -> bool {
         match self.output_layout.run(|output_layout| {
-            for cur_output in &output_layout.outputs {
-                if *cur_output == output {
+            for (cur_output, _) in output_layout.outputs() {
+                if cur_output == output {
                     return true
                 }
             }

--- a/src/types/cursor/mod.rs
+++ b/src/types/cursor/mod.rs
@@ -1,0 +1,5 @@
+pub mod cursor;
+pub mod xcursor;
+
+pub use cursor::*;
+pub use xcursor::*;

--- a/src/types/cursor/xcursor.rs
+++ b/src/types/cursor/xcursor.rs
@@ -64,6 +64,18 @@ impl XCursorTheme {
         unsafe { (*self.theme).cursor_count }
     }
 
+    /// Gets all the cursors from this theme.
+    pub fn cursors<'theme>(&'theme mut self) -> Vec<XCursor<'theme>> {
+        unsafe {
+            let cursor_ptr = (*self.theme).cursors as *const *mut wlr_xcursor;
+            let length = self.cursor_count() as usize;
+            let xcursors_slice: &'theme [*mut wlr_xcursor] =
+                slice::from_raw_parts::<'theme, *mut wlr_xcursor>(cursor_ptr, length);
+            xcursors_slice.into_iter().map(|&xcursor|XCursor { xcursor, phantom: PhantomData })
+                .collect()
+        }
+    }
+
     /// Get the cursor with the provided name, if it exists.
     pub fn get_cursor<'theme>(&'theme self, name: String) -> Option<XCursor<'theme>> {
         let name_str = safe_as_cstring(name);

--- a/src/types/cursor/xcursor.rs
+++ b/src/types/cursor/xcursor.rs
@@ -1,0 +1,93 @@
+//! TODO Documentation
+
+use std::{mem, ptr, slice};
+
+use wlroots_sys::{wlr_xcursor, wlr_xcursor_image, wlr_xcursor_theme, wlr_xcursor_theme_get_cursor,
+                  wlr_xcursor_theme_load};
+
+use utils::safe_as_cstring;
+
+#[derive(Debug)]
+pub struct XCursorTheme {
+    theme: *mut wlr_xcursor_theme
+}
+
+#[derive(Debug)]
+pub struct XCursor {
+    xcursor: *mut wlr_xcursor
+}
+
+#[derive(Debug)]
+pub struct XCursorImage<'cursor> {
+    pub width: u32,
+    pub height: u32,
+    pub hotspot_x: u32,
+    pub hotspot_y: u32,
+    pub delay: u32,
+    pub buffer: &'cursor [u8]
+}
+
+impl XCursorTheme {
+    /// If no name is given, defaults to "default".
+    pub fn load_theme(name: Option<String>, size: i32) -> Option<Self> {
+        unsafe {
+            let name_str = name.map(safe_as_cstring);
+            let name_ptr = name_str.map(|s| s.as_ptr()).unwrap_or(ptr::null_mut());
+            let theme = wlr_xcursor_theme_load(name_ptr, size);
+            if theme.is_null() {
+                None
+            } else {
+                Some(XCursorTheme { theme })
+            }
+        }
+    }
+
+    pub fn get_cursor(&self, name: String) -> Option<XCursor> {
+        let name_str = safe_as_cstring(name);
+        let xcursor =
+            unsafe { wlr_xcursor_theme_get_cursor(self.theme, name_str.as_ptr()) };
+        if xcursor.is_null() {
+            None
+        } else {
+            Some(XCursor { xcursor })
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) unsafe fn as_ptr(self) -> *mut wlr_xcursor_theme {
+        self.theme
+    }
+}
+
+impl XCursor {
+    #[allow(dead_code)]
+    pub(crate) unsafe fn as_ptr(&mut self) -> *mut wlr_xcursor {
+        self.xcursor
+    }
+
+    pub fn images<'cursor>(&'cursor self) -> Vec<XCursorImage<'cursor>> {
+        unsafe {
+            let image_ptr = (*self.xcursor).images as *const *const wlr_xcursor_image;
+            let length = (*self.xcursor).image_count;
+            let cursors_slice: &'cursor [*const wlr_xcursor_image] =
+                slice::from_raw_parts::<'cursor, *const wlr_xcursor_image>(image_ptr,
+                                                                           length as usize);
+            let mut result = Vec::with_capacity(cursors_slice.len());
+            for cursor in cursors_slice {
+                result.push(XCursorImage {
+                    width: (**cursor).width,
+                    height: (**cursor).height,
+                    hotspot_x: (**cursor).hotspot_x,
+                    hotspot_y: (**cursor).hotspot_y,
+                    delay: (**cursor).delay,
+                    buffer: slice::from_raw_parts::<'cursor, u8>(
+                        (**cursor).buffer as *const u8,
+                        (**cursor).width as usize * (**cursor).height as usize
+                            * mem::size_of::<u32>()
+                    )
+                })
+            }
+            result
+        }
+    }
+}

--- a/src/types/keyboard.rs
+++ b/src/types/keyboard.rs
@@ -342,3 +342,11 @@ impl fmt::Display for KeyboardModifier {
         write!(formatter, "{:?}", mods)
     }
 }
+
+impl PartialEq for KeyboardHandle {
+    fn eq(&self, other: &KeyboardHandle) -> bool {
+        self.keyboard == other.keyboard
+    }
+}
+
+impl Eq for KeyboardHandle {}

--- a/src/types/keyboard.rs
+++ b/src/types/keyboard.rs
@@ -269,11 +269,11 @@ impl KeyboardHandle {
     /// or if you run this function within the another run to the same `Output`.
     ///
     /// So don't nest `run` calls and everything will be ok :).
-    pub fn run<F, R>(&mut self, runner: F) -> UpgradeHandleResult<Option<R>>
+    pub fn run<F, R>(&mut self, runner: F) -> UpgradeHandleResult<R>
         where F: FnOnce(&mut Keyboard) -> R
     {
         let mut keyboard = unsafe { self.upgrade()? };
-        let res = panic::catch_unwind(panic::AssertUnwindSafe(|| Some(runner(&mut keyboard))));
+        let res = panic::catch_unwind(panic::AssertUnwindSafe(|| runner(&mut keyboard)));
         self.handle.upgrade().map(|check| {
                                       // Sanity check that it hasn't been tampered with.
                                       if !check.load(Ordering::Acquire) {

--- a/src/types/output/output.rs
+++ b/src/types/output/output.rs
@@ -69,9 +69,11 @@ impl Output {
         (*output).data = ptr::null_mut();
         let liveliness = Rc::new(AtomicBool::new(false));
         let handle = Rc::downgrade(&liveliness);
-        let state = Box::new(OutputState {handle, layout_handle: None });
+        let state = Box::new(OutputState { handle,
+                                           layout_handle: None });
         (*output).data = Box::into_raw(state) as *mut _;
-        Output { liveliness: Some(liveliness), output }
+        Output { liveliness: Some(liveliness),
+                 output }
     }
 
     pub(crate) unsafe fn set_output_layout(&mut self, layout_handle: Option<OutputLayoutHandle>) {
@@ -362,7 +364,6 @@ impl OutputHandle {
         self.output
     }
 }
-
 
 impl PartialEq for OutputHandle {
     fn eq(&self, other: &OutputHandle) -> bool {

--- a/src/types/output/output.rs
+++ b/src/types/output/output.rs
@@ -341,3 +341,12 @@ impl OutputHandle {
         self.output
     }
 }
+
+
+impl PartialEq for OutputHandle {
+    fn eq(&self, other: &OutputHandle) -> bool {
+        self.output == other.output
+    }
+}
+
+impl Eq for OutputHandle {}

--- a/src/types/output/output.rs
+++ b/src/types/output/output.rs
@@ -315,11 +315,11 @@ impl OutputHandle {
     /// or if you run this function within the another run to the same `Output`.
     ///
     /// So don't nest `run` calls and everything will be ok :).
-    pub fn run<F, R>(&mut self, runner: F) -> UpgradeHandleResult<Option<R>>
+    pub fn run<F, R>(&mut self, runner: F) -> UpgradeHandleResult<R>
         where F: FnOnce(&mut Output) -> R
     {
         let mut output = unsafe { self.upgrade()? };
-        let res = panic::catch_unwind(panic::AssertUnwindSafe(|| Some(runner(&mut output))));
+        let res = panic::catch_unwind(panic::AssertUnwindSafe(|| runner(&mut output)));
         self.handle.upgrade().map(|check| {
                                       // Sanity check that it hasn't been tampered with.
                                       if !check.load(Ordering::Acquire) {

--- a/src/types/output/output_layout.rs
+++ b/src/types/output/output_layout.rs
@@ -254,3 +254,11 @@ impl OutputLayoutOutput {
         }
     }
 }
+
+impl PartialEq for OutputLayoutHandle {
+    fn eq(&self, other: &OutputLayoutHandle) -> bool {
+        self.layout == other.layout
+    }
+}
+
+impl Eq for OutputLayoutHandle {}

--- a/src/types/output/output_layout.rs
+++ b/src/types/output/output_layout.rs
@@ -69,17 +69,12 @@ impl OutputLayout {
     pub fn outputs(&mut self) -> Vec<(OutputHandle, Origin)> {
         unsafe {
             let mut result = vec![];
-            // TODO Macro for for-each pattern here
-            let mut pos = container_of!((*self.layout).outputs.next, wlr_output_layout_output, link);
-            loop {
-                if &(*pos).link as *const _ == &(*self.layout).outputs as *const _ {
-                    return result;
-                }
-                // TODO Get details from the user data
+            let mut pos: *mut wlr_output_layout_output;
+            wl_list_for_each!((*self.layout).outputs, wlr_output_layout_output, link, (pos) => {
                 result.push((OutputHandle::from_ptr((*pos).output),
-                             Origin::new((*pos).x, (*pos).y)));
-                pos = container_of!((*pos).link.next, wlr_output_layout_output, link);
-            }
+                             Origin::new((*pos).x, (*pos).y)))
+            });
+            result
         }
     }
 

--- a/src/types/output/output_layout.rs
+++ b/src/types/output/output_layout.rs
@@ -69,8 +69,7 @@ impl OutputLayout {
     pub fn outputs(&mut self) -> Vec<(OutputHandle, Origin)> {
         unsafe {
             let mut result = vec![];
-            let mut pos: *mut wlr_output_layout_output;
-            wl_list_for_each!((*self.layout).outputs, wlr_output_layout_output, link, (pos) => {
+            wl_list_for_each!((*self.layout).outputs, link, (pos: wlr_output_layout_output) => {
                 result.push((OutputHandle::from_ptr((*pos).output),
                              Origin::new((*pos).x, (*pos).y)))
             });

--- a/src/types/output/output_layout.rs
+++ b/src/types/output/output_layout.rs
@@ -188,11 +188,11 @@ impl OutputLayoutHandle {
     /// to a short lived scope of an anonymous function,
     /// this function ensures the OutputLayout does not live longer
     /// than it exists (because the lifetime is controlled by the user).
-    pub fn run<F, R>(&mut self, runner: F) -> UpgradeHandleResult<Option<R>>
+    pub fn run<F, R>(&mut self, runner: F) -> UpgradeHandleResult<R>
         where F: FnOnce(&mut OutputLayout) -> R
     {
         let mut output_layout = unsafe { self.upgrade()? };
-        let res = panic::catch_unwind(panic::AssertUnwindSafe(|| Some(runner(&mut output_layout))));
+        let res = panic::catch_unwind(panic::AssertUnwindSafe(|| runner(&mut output_layout)));
         self.handle.upgrade().map(|check| {
                                       // Sanity check that it hasn't been tampered with.
                                       if !check.load(Ordering::Acquire) {

--- a/src/types/output/output_layout.rs
+++ b/src/types/output/output_layout.rs
@@ -9,7 +9,6 @@ use wlroots_sys::{wlr_cursor_attach_output_layout, wlr_output_effective_resoluti
                   wlr_output_layout_create, wlr_output_layout_destroy, wlr_output_layout_move,
                   wlr_output_layout_output, wlr_output_layout_remove};
 
-use super::output::OutputState;
 use errors::{UpgradeHandleErr, UpgradeHandleResult};
 
 use {Cursor, CursorBuilder, Origin, Output, OutputHandle};
@@ -77,7 +76,7 @@ impl OutputLayout {
                     return result;
                 }
                 // TODO Get details from the user data
-                result.push((Output::new((*pos).output).weak_reference(),
+                result.push((OutputHandle::from_ptr((*pos).output),
                              Origin::new((*pos).x, (*pos).y)));
                 pos = container_of!((*pos).link.next, wlr_output_layout_output, link);
             }
@@ -108,7 +107,7 @@ impl OutputLayout {
     pub fn add_auto(&mut self, output: &mut Output) {
         unsafe {
             let layout_handle = self.weak_reference();
-            output.set_user_data(Box::new(OutputState { layout_handle }));
+            output.set_output_layout(Some(layout_handle));
             wlr_output_layout_add_auto(self.layout, output.as_ptr());
             wlr_log!(L_DEBUG, "Added {:?} to {:?}", output, self);
         }
@@ -128,7 +127,7 @@ impl OutputLayout {
     pub fn remove(&mut self, output: &mut Output) {
         wlr_log!(L_DEBUG, "Removing {:?} from {:?}", output, self);
         unsafe {
-            output.clear_user_data();
+            output.clear_output_layout_data();
             wlr_output_layout_remove(self.layout, output.as_ptr());
         };
     }

--- a/src/types/output/output_layout.rs
+++ b/src/types/output/output_layout.rs
@@ -47,7 +47,6 @@ pub(crate) struct OutputLayoutHandle {
 
 /// The coordinate information of an `Output` within an `OutputLayout`.
 #[derive(Debug)]
-// TODO Remove pub?
 pub struct OutputLayoutOutput<'output> {
     layout_output: *mut wlr_output_layout_output,
     phantom: PhantomData<&'output OutputLayout>

--- a/src/types/pointer.rs
+++ b/src/types/pointer.rs
@@ -168,11 +168,11 @@ impl PointerHandle {
     /// or if you run this function within the another run to the same `Output`.
     ///
     /// So don't nest `run` calls and everything will be ok :).
-    pub fn run<F, R>(&mut self, runner: F) -> UpgradeHandleResult<Option<R>>
+    pub fn run<F, R>(&mut self, runner: F) -> UpgradeHandleResult<R>
         where F: FnOnce(&Pointer) -> R
     {
         let mut pointer = unsafe { self.upgrade()? };
-        let res = panic::catch_unwind(panic::AssertUnwindSafe(|| Some(runner(&mut pointer))));
+        let res = panic::catch_unwind(panic::AssertUnwindSafe(|| runner(&mut pointer)));
         self.handle.upgrade().map(|check| {
                                       // Sanity check that it hasn't been tampered with.
                                       if !check.load(Ordering::Acquire) {

--- a/src/types/pointer.rs
+++ b/src/types/pointer.rs
@@ -200,3 +200,11 @@ impl PointerHandle {
         self.pointer
     }
 }
+
+impl PartialEq for PointerHandle {
+    fn eq(&self, other: &PointerHandle) -> bool {
+        self.pointer == other.pointer
+    }
+}
+
+impl Eq for PointerHandle {}


### PR DESCRIPTION
Fixes #33 and Fixes #35 (mostly, there are some things that are being split off into separate issues).

Split up `types/cursor.rs` into `types/cursor/xcursor.rs` and `types/cursor/cursor.rs`.

# Handles
* impl `Eq` and `PartialEq` for all `*Handle` types.

# OutputLayoutOutput
* Add a type that returns a borrow of this structure

# Cursor
* Adds the rest of the functions for this.
* [x] **Still need to fix attaching `Output`s that are not in the `OutputLayout` associated with the `Cursor`.**
  - [x] ~Right now it's not usable though because internally it locks an `OutputLayoutHandle` to the `OutputLayout` that owns the `Cursor`...yikes. So instead we could add a `CursorHandle` and let that be the primary way you access the cursor.~ nvm, I don't want _another_ Handle...

# XCursor and XCursorTheme
* Fixed lifetime for `XCursor`
  - Now that `XCursorTheme` has a destructor, the `XCursor` needs to live as long as the theme. The lifetime has been added, and now the correct usage is to store the `XCursorTheme` instead of an `XCursor` if you want to reuse it when constructing cursors.
  - Note that this technically wasn't unsound before because we didn't free the structure, but I'll mark it as unsound regardless.
* Added rest of functions
* Removed unused `as_ptr` definitions.