### PR TITLE
Wrapped rest of Output, added OutputCursor

### DIFF
--- a/examples/pointer.rs
+++ b/examples/pointer.rs
@@ -103,7 +103,7 @@ impl PointerHandler for ExPointer {
 }
 
 impl OutputHandler for ExOutput {
-    fn output_frame(&mut self, compositor: &mut Compositor, output: &mut Output) {
+    fn on_frame(&mut self, compositor: &mut Compositor, output: &mut Output) {
         let state: &mut State = compositor.into();
         output.make_current();
         unsafe {

--- a/examples/rotation.rs
+++ b/examples/rotation.rs
@@ -78,7 +78,7 @@ impl OutputManagerHandler for OutputManager {
 }
 
 impl OutputHandler for ExOutput {
-    fn output_frame(&mut self, compositor: &mut Compositor, output: &mut Output) {
+    fn on_frame(&mut self, compositor: &mut Compositor, output: &mut Output) {
         let (width, height) = output.effective_resolution();
         let renderer = compositor.gles2
                                  .as_mut()

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -62,7 +62,7 @@ impl OutputManagerHandler for OutputManager {
 }
 
 impl OutputHandler for ExOutput {
-    fn output_frame(&mut self, _: &mut Compositor, output: &mut Output) {
+    fn on_frame(&mut self, _: &mut Compositor, output: &mut Output) {
         let now = Instant::now();
         let delta = now.duration_since(self.last_frame);
         let seconds_delta = delta.as_secs();

--- a/src/manager/output_handler.rs
+++ b/src/manager/output_handler.rs
@@ -7,27 +7,79 @@ use wlroots_sys::wlr_output;
 
 pub trait OutputHandler {
     /// Called every time the output frame is updated.
-    fn output_frame(&mut self, &mut Compositor, &mut Output) {}
+    fn on_frame(&mut self, &mut Compositor, &mut Output) {}
 
     /// Called every time the output mode changes.
-    fn output_mode(&mut self, &mut Output) {}
+    fn on_mode_change(&mut self, &mut Compositor, &mut Output) {}
+
+    /// Called every time the output is enabled.
+    fn on_enable(&mut self, &mut Compositor, &mut Output) {}
+
+    /// Called every time the output scale changes.
+    fn on_scale_change(&mut self, &mut Compositor, &mut Output) {}
+
+    /// Called every time the output transforms.
+    fn on_transform(&mut self, &mut Compositor, &mut Output) {}
+
+    /// Called every time the buffers are swapped on an output.
+    fn on_buffers_swapped(&mut self, &mut Compositor, &mut Output) {}
+
+    /// Called when an output is destroyed.
+    fn on_destroy(&mut self, &mut Compositor, &mut Output) {}
 }
 
 wayland_listener!(UserOutput, (Output, Box<OutputHandler>), [
     frame_listener => frame_notify: |this: &mut UserOutput, _output: *mut libc::c_void,| unsafe {
-        let output = &mut this.data.0;
-        let manager = &mut this.data.1;
+        let (ref mut output, ref mut manager) = this.data;
         let compositor = &mut *COMPOSITOR_PTR;
         output.set_lock(true);
-        manager.output_frame(compositor, output);
+        manager.on_frame(compositor, output);
         output.set_lock(false);
     };
     mode_listener => mode_notify: |this: &mut UserOutput, _output: *mut libc::c_void,|
     unsafe {
-        let output = &mut this.data.0;
-        let manager = &mut this.data.1;
+        let (ref mut output, ref mut manager) = this.data;
+        let compositor = &mut *COMPOSITOR_PTR;
         output.set_lock(true);
-        manager.output_mode(output);
+        manager.on_mode_change(compositor, output);
+        output.set_lock(false);
+    };
+    enable_listener => enable_notify: |this: &mut UserOutput, _output: *mut libc::c_void,| unsafe {
+        let (ref mut output, ref mut manager) = this.data;
+        let compositor = &mut *COMPOSITOR_PTR;
+        output.set_lock(true);
+        manager.on_enable(compositor, output);
+        output.set_lock(false);
+    };
+    scale_listener => scale_notify: |this: &mut UserOutput, _output: *mut libc::c_void,| unsafe {
+        let (ref mut output, ref mut manager) = this.data;
+        let compositor = &mut *COMPOSITOR_PTR;
+        output.set_lock(true);
+        manager.on_scale_change(compositor, output);
+        output.set_lock(false);
+    };
+    transform_listener => transform_notify: |this: &mut UserOutput, _output: *mut libc::c_void,|
+    unsafe {
+        let (ref mut output, ref mut manager) = this.data;
+        let compositor = &mut *COMPOSITOR_PTR;
+        output.set_lock(true);
+        manager.on_transform(compositor, output);
+        output.set_lock(false);
+    };
+    swap_buffers_listener => swap_buffers_notify: |this: &mut UserOutput,
+                                                   _output: *mut libc::c_void,| unsafe {
+        let (ref mut output, ref mut manager) = this.data;
+        let compositor = &mut *COMPOSITOR_PTR;
+        output.set_lock(true);
+        manager.on_buffers_swapped(compositor, output);
+        output.set_lock(false);
+    };
+    destroy_listener => destroy_notify: |this: &mut UserOutput, _output: *mut libc::c_void,|
+    unsafe {
+        let (ref mut output, ref mut manager) = this.data;
+        let compositor = &mut *COMPOSITOR_PTR;
+        output.set_lock(true);
+        manager.on_destroy(compositor, output);
         output.set_lock(false);
     };
 ]);

--- a/src/manager/output_manager.rs
+++ b/src/manager/output_manager.rs
@@ -100,10 +100,25 @@ wayland_listener!(OutputManager, (Vec<Box<UserOutput>>, Box<OutputManagerHandler
             let mut output = UserOutput::new((output_clone, output_ptr));
             // Add the output frame event to this manager
             wl_signal_add(&mut (*data).events.frame as *mut _ as _,
-                        output.frame_listener() as _);
-            // Add the output resolution event to this manager
+                          output.frame_listener() as _);
+            // Add the output mode event to this manager
             wl_signal_add(&mut (*data).events.mode as *mut _ as _,
-                        output.mode_listener() as _);
+                          output.mode_listener() as _);
+            // Add the output enable event to this manager
+            wl_signal_add(&mut (*data).events.enable as *mut _ as _,
+                          output.enable_listener() as _);
+            // Add the output scale change event to this manager
+            wl_signal_add(&mut (*data).events.scale as *mut _ as _,
+                          output.scale_listener() as _);
+            // Add the output transform event to this manager
+            wl_signal_add(&mut (*data).events.transform as *mut _ as _,
+                          output.transform_listener() as _);
+            // Add the output buffer swap event to this manager
+            wl_signal_add(&mut (*data).events.swap_buffers as *mut _ as _,
+                          output.swap_buffers_listener() as _);
+            // Add the output destroy event to this manager
+            wl_signal_add(&mut (*data).events.destroy as *mut _ as _,
+                          output.destroy_listener() as _);
             // Store the user UserOutput, free later in remove listener
             outputs.push(output);
         }

--- a/src/types/cursor/cursor.rs
+++ b/src/types/cursor/cursor.rs
@@ -171,12 +171,17 @@ impl Cursor {
 
     /// Attaches this cursor to the given output, which must be among the outputs in
     /// the current output_layout for this cursor.
-    pub fn map_to_output(&mut self, output: &Output) {
-        if !self.output_in_output_layout(output.weak_reference()) {
-            wlr_log!(L_ERROR, "Tried to map output not in the OutputLayout");
-            return
+    pub fn map_to_output(&mut self, output: Option<&Output>) {
+        match output {
+            None => unsafe { wlr_cursor_map_to_output(self.cursor, ptr::null_mut()) },
+            Some(output) => {
+                if !self.output_in_output_layout(output.weak_reference()) {
+                    wlr_log!(L_ERROR, "Tried to map output not in the OutputLayout");
+                    return
+                }
+                unsafe { wlr_cursor_map_to_output(self.cursor, output.as_ptr()) }
+            }
         }
-        unsafe { wlr_cursor_map_to_output(self.cursor, output.as_ptr()) }
     }
 
     /// Maps all input from a specific input device to a given output.

--- a/src/types/cursor/xcursor.rs
+++ b/src/types/cursor/xcursor.rs
@@ -71,8 +71,12 @@ impl XCursorTheme {
             let length = self.cursor_count() as usize;
             let xcursors_slice: &'theme [*mut wlr_xcursor] =
                 slice::from_raw_parts::<'theme, *mut wlr_xcursor>(cursor_ptr, length);
-            xcursors_slice.into_iter().map(|&xcursor|XCursor { xcursor, phantom: PhantomData })
-                .collect()
+            xcursors_slice.into_iter()
+                          .map(|&xcursor| {
+                                   XCursor { xcursor,
+                                             phantom: PhantomData }
+                               })
+                          .collect()
         }
     }
 

--- a/src/types/output/mod.rs
+++ b/src/types/output/mod.rs
@@ -1,2 +1,3 @@
 pub mod output;
 pub mod output_layout;
+pub mod output_mode;

--- a/src/types/output/mod.rs
+++ b/src/types/output/mod.rs
@@ -1,3 +1,4 @@
 pub mod output;
 pub mod output_layout;
 pub mod output_mode;
+pub mod output_cursor;

--- a/src/types/output/output.rs
+++ b/src/types/output/output.rs
@@ -283,11 +283,6 @@ impl Output {
         }
     }
 
-    /// TODO Make safe
-    pub unsafe fn events(&self) -> wlr_output_events {
-        (*self.output).events
-    }
-
     pub(crate) unsafe fn as_ptr(&self) -> *mut wlr_output {
         self.output
     }

--- a/src/types/output/output.rs
+++ b/src/types/output/output.rs
@@ -11,12 +11,15 @@ use wlroots_sys::{wl_list, wl_output_transform, wlr_output, wlr_output_effective
                   wlr_output_enable, wlr_output_get_gamma_size, wlr_output_make_current,
                   wlr_output_mode, wlr_output_set_custom_mode, wlr_output_set_fullscreen_surface,
                   wlr_output_set_gamma, wlr_output_set_mode, wlr_output_set_position,
-                  wlr_output_set_scale, wlr_output_set_transform, wlr_output_swap_buffers};
+                  wlr_output_set_scale, wlr_output_set_transform, wlr_output_swap_buffers,
+                  wl_output_subpixel};
 
 use super::output_layout::OutputLayoutHandle;
 use super::output_mode::OutputMode;
 use errors::{UpgradeHandleErr, UpgradeHandleResult};
 use utils::c_to_rust_string;
+
+pub type Subpixel = wl_output_subpixel;
 
 use {Origin, Size, Surface};
 
@@ -232,6 +235,11 @@ impl Output {
     /// Gets the output position in layout space reported to clients.
     pub fn layout_space_pos(&self) -> (i32, i32) {
         unsafe { ((*self.output).lx, (*self.output).ly) }
+    }
+
+    /// Get subpixel information about the output.
+    pub fn subpixel(&self) -> Subpixel {
+        unsafe { (*self.output).subpixel }
     }
 
     pub fn make_current(&mut self) {

--- a/src/types/output/output.rs
+++ b/src/types/output/output.rs
@@ -169,6 +169,19 @@ impl Output {
         }
     }
 
+    // TODO Could we pass an output mode from the wrong output here?
+    // What will happen?
+
+    /// Set this to be the current mode for the Output.
+    pub fn set_mode(&mut self, mode: OutputMode) {
+        unsafe { wlr_output_set_mode(self.output, mode.as_ptr()) }
+    }
+
+    /// Set a custom mode for this output.
+    pub fn set_custom_mode(&mut self, size: Size, refresh: i32) -> bool {
+        unsafe { wlr_output_set_custom_mode(self.output, size.width, size.height, refresh) }
+    }
+
     /// Gets the name of the output in UTF-8.
     pub fn name(&self) -> String {
         unsafe {
@@ -316,11 +329,6 @@ impl Output {
     /// Get the gamma size.
     pub fn get_gamma_size(&self) -> u32 {
         unsafe { wlr_output_get_gamma_size(self.output) }
-    }
-
-    /// Set a custom mode for this output.
-    pub fn set_custom_mode(&mut self, size: Size, refresh: i32) -> bool {
-        unsafe { wlr_output_set_custom_mode(self.output, size.width, size.height, refresh) }
     }
 
     /// Set the fullscreen surface for this output.

--- a/src/types/output/output.rs
+++ b/src/types/output/output.rs
@@ -12,6 +12,7 @@ use wlroots_sys::{wl_list, wl_output_transform, wlr_output, wlr_output_effective
 
 use super::output_layout::OutputLayoutHandle;
 use errors::{UpgradeHandleErr, UpgradeHandleResult};
+use utils::c_to_rust_string;
 
 struct OutputState {
     handle: Weak<AtomicBool>,
@@ -169,16 +170,22 @@ impl Output {
     /// Gets the make of the output in UTF-8.
     pub fn make(&self) -> String {
         unsafe {
-            CStr::from_ptr((*self.output).make.as_ptr()).to_string_lossy()
-                                                        .into_owned()
+            c_to_rust_string((*self.output).make.as_ptr()).expect("Could not parse make as UTF-8")
         }
     }
 
     /// Gets the model of the output in UTF-8.
     pub fn model(&self) -> String {
         unsafe {
-            CStr::from_ptr((*self.output).model.as_ptr()).to_string_lossy()
-                                                         .into_owned()
+            c_to_rust_string((*self.output).model.as_ptr()).expect("Could not parse model as UTF-8")
+        }
+    }
+
+    /// Gets the serial of the output in UTF-8.
+    pub fn serial(&self) -> String {
+        unsafe {
+            c_to_rust_string((*self.output).serial.as_ptr()).expect("Could not parse serial as \
+                                                                     UTF-8")
         }
     }
 

--- a/src/types/output/output.rs
+++ b/src/types/output/output.rs
@@ -173,7 +173,7 @@ impl Output {
     // What will happen?
 
     /// Set this to be the current mode for the Output.
-    pub fn set_mode(&mut self, mode: OutputMode) {
+    pub fn set_mode(&mut self, mode: OutputMode) -> bool {
         unsafe { wlr_output_set_mode(self.output, mode.as_ptr()) }
     }
 

--- a/src/types/output/output.rs
+++ b/src/types/output/output.rs
@@ -214,6 +214,11 @@ impl Output {
         unsafe { (*self.output).needs_swap }
     }
 
+    /// Get the refresh rate of the output.
+    pub fn refresh_rate(&self) -> i32 {
+        unsafe { (*self.output).refresh }
+    }
+
     pub fn current_mode(&self) -> Option<OutputMode> {
         unsafe {
             if (*self.output).current_mode.is_null() {

--- a/src/types/output/output.rs
+++ b/src/types/output/output.rs
@@ -7,12 +7,12 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use libc::c_float;
 use wayland_sys::server::WAYLAND_SERVER_HANDLE;
-use wlroots_sys::{wl_list, wl_output_transform, wlr_output, wlr_output_effective_resolution,
-                  wlr_output_enable, wlr_output_get_gamma_size, wlr_output_make_current,
-                  wlr_output_mode, wlr_output_set_custom_mode, wlr_output_set_fullscreen_surface,
-                  wlr_output_set_gamma, wlr_output_set_mode, wlr_output_set_position,
-                  wlr_output_set_scale, wlr_output_set_transform, wlr_output_swap_buffers,
-                  wl_output_subpixel};
+use wlroots_sys::{wl_list, wl_output_subpixel, wl_output_transform, wlr_output,
+                  wlr_output_effective_resolution, wlr_output_enable, wlr_output_get_gamma_size,
+                  wlr_output_make_current, wlr_output_mode, wlr_output_set_custom_mode,
+                  wlr_output_set_fullscreen_surface, wlr_output_set_gamma, wlr_output_set_mode,
+                  wlr_output_set_position, wlr_output_set_scale, wlr_output_set_transform,
+                  wlr_output_swap_buffers};
 
 use super::output_layout::OutputLayoutHandle;
 use super::output_mode::OutputMode;
@@ -20,6 +20,7 @@ use errors::{UpgradeHandleErr, UpgradeHandleResult};
 use utils::c_to_rust_string;
 
 pub type Subpixel = wl_output_subpixel;
+pub type Transform = wl_output_transform;
 
 use {Origin, Size, Surface};
 
@@ -161,7 +162,8 @@ impl Output {
                 // TODO Better logging
                 wlr_log!(L_DEBUG, "output added {:?}", self);
                 let first_mode_ptr: *mut wlr_output_mode;
-                first_mode_ptr = container_of!(&mut (*(*modes).prev) as *mut _, wlr_output_mode, link);
+                first_mode_ptr =
+                    container_of!(&mut (*(*modes).prev) as *mut _, wlr_output_mode, link);
                 wlr_output_set_mode(self.as_ptr(), first_mode_ptr);
             }
         }
@@ -242,6 +244,11 @@ impl Output {
         unsafe { (*self.output).subpixel }
     }
 
+    /// Get the transform information about the output.
+    pub fn get_transform(&self) -> Transform {
+        unsafe { (*self.output).transform }
+    }
+
     pub fn make_current(&mut self) {
         unsafe { wlr_output_make_current(self.output) }
     }
@@ -272,7 +279,7 @@ impl Output {
         unsafe { (*self.output).transform_matrix }
     }
 
-    pub fn transform(&mut self, transform: wl_output_transform) {
+    pub fn transform(&mut self, transform: Transform) {
         unsafe {
             wlr_output_set_transform(self.output, transform);
         }

--- a/src/types/output/output_cursor.rs
+++ b/src/types/output/output_cursor.rs
@@ -1,0 +1,77 @@
+//! TODO documentation
+
+use wlroots_sys::{wlr_output_cursor, wlr_output_cursor_create, wlr_output_cursor_destroy,
+                  wlr_output_cursor_move, wlr_output_cursor_set_image,
+                  wlr_output_cursor_set_surface};
+
+use {Output, OutputHandle, Surface};
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct OutputCursor {
+    cursor: *mut wlr_output_cursor,
+    output_handle: OutputHandle
+}
+
+impl OutputCursor {
+    /// Creates a new `OutputCursor` that's bound to the given `Output`.
+    ///
+    /// When the `Output` is destroyed, this can no longer be used.
+    ///
+    /// # Ergonomics
+    /// TODO Put in module documentation
+    ///
+    /// To make this easier for you, I would suggest putting the `OutputCursor` in your
+    /// `OutputHandler` implementor's state so that when the `Output` is removed you
+    /// just don't have to think about it and it will clean itself up by itself.
+    pub fn new<'output>(output: &'output mut Output) -> Option<OutputCursor> {
+        unsafe {
+            let output_handle = output.weak_reference();
+            let cursor = wlr_output_cursor_create(output.as_ptr());
+            if cursor.is_null() {
+                None
+            } else {
+                Some(OutputCursor { cursor,
+                                    output_handle })
+            }
+        }
+    }
+
+    /// Sets the hardware cursor's image.
+    pub fn set_image(&mut self,
+                     pixels: &[u8],
+                     stride: i32,
+                     width: u32,
+                     height: u32,
+                     hotspot_x: i32,
+                     hotspot_y: i32)
+                     -> bool {
+        unsafe {
+            // TODO Ensure the buffer is correct?
+            wlr_output_cursor_set_image(self.cursor,
+                                        pixels.as_ptr(),
+                                        stride,
+                                        width,
+                                        height,
+                                        hotspot_x,
+                                        hotspot_y)
+        }
+    }
+
+    /// Sets the hardware cursor's surface.
+    pub fn set_surface(&mut self, surface: Surface, hotspot_x: i32, hotspot_y: i32) {
+        unsafe {
+            wlr_output_cursor_set_surface(self.cursor, surface.as_ptr(), hotspot_x, hotspot_y)
+        }
+    }
+
+    /// Moves the hardware cursor to the desired location
+    pub fn move_to(&mut self, x: f64, y: f64) -> bool {
+        unsafe { wlr_output_cursor_move(self.cursor, x, y) }
+    }
+}
+
+impl Drop for OutputCursor {
+    fn drop(&mut self) {
+        unsafe { wlr_output_cursor_destroy(self.cursor) }
+    }
+}

--- a/src/types/output/output_cursor.rs
+++ b/src/types/output/output_cursor.rs
@@ -94,6 +94,37 @@ impl OutputCursor {
             }
         }
     }
+
+    /// Get the coordinates of the cursor.
+    ///
+    /// Returned value is in (x, y) format.
+    pub fn coords(&self) -> (f64, f64) {
+        unsafe { ((*self.cursor).x, (*self.cursor).y) }
+    }
+
+    /// Determines if the hardware cursor is enabled or not.
+    pub fn enabled(&self) -> bool {
+        unsafe { (*self.cursor).enabled }
+    }
+
+    /// Determines if the hardware cursor is visible or not.
+    pub fn visible(&self) -> bool {
+        unsafe { (*self.cursor).visible }
+    }
+
+    /// Gets the width and height of the hardware cursor.
+    ///
+    /// Returned value is in (width, height) format.
+    pub fn size(&self) -> (u32, u32) {
+        unsafe { ((*self.cursor).width, (*self.cursor).height) }
+    }
+
+    /// Gets the hotspot coordinates of the hardware cursor.
+    ///
+    /// Returned value is in (x, y) coordinates.
+    pub fn hotspots(&self) -> (i32, i32) {
+        unsafe { ((*self.cursor).hotspot_x, (*self.cursor).hotspot_y) }
+    }
 }
 
 impl Drop for OutputCursor {

--- a/src/types/output/output_layout.rs
+++ b/src/types/output/output_layout.rs
@@ -1,9 +1,9 @@
 //! TODO Documentation
 
+use std::marker::PhantomData;
 use std::panic;
 use std::rc::{Rc, Weak};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::marker::PhantomData;
 
 use wlroots_sys::{wlr_cursor_attach_output_layout, wlr_output_effective_resolution,
                   wlr_output_layout, wlr_output_layout_add, wlr_output_layout_add_auto,
@@ -246,7 +246,7 @@ impl OutputLayoutHandle {
     }
 }
 
-impl <'output> OutputLayoutOutput<'output> {
+impl<'output> OutputLayoutOutput<'output> {
     /// Get the absolute top left edge coordinate of this output in the output
     /// layout.
     pub fn top_left_edge(&self) -> Origin {

--- a/src/types/output/output_layout.rs
+++ b/src/types/output/output_layout.rs
@@ -1,18 +1,21 @@
 //! TODO Documentation
 
 use std::marker::PhantomData;
-use std::panic;
+use std::{ptr, panic};
 use std::rc::{Rc, Weak};
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use wlroots_sys::{wlr_cursor_attach_output_layout, wlr_output_effective_resolution,
                   wlr_output_layout, wlr_output_layout_add, wlr_output_layout_add_auto,
-                  wlr_output_layout_create, wlr_output_layout_destroy, wlr_output_layout_move,
-                  wlr_output_layout_output, wlr_output_layout_remove};
+                  wlr_output_layout_closest_point, wlr_output_layout_contains_point,
+                  wlr_output_layout_create, wlr_output_layout_destroy, wlr_output_layout_get_box,
+                  wlr_output_layout_get_center_output, wlr_output_layout_intersects,
+                  wlr_output_layout_move, wlr_output_layout_output,
+                  wlr_output_layout_output_coords, wlr_output_layout_remove};
 
 use errors::{UpgradeHandleErr, UpgradeHandleResult};
 
-use {Cursor, CursorBuilder, Origin, Output, OutputHandle};
+use {Area, Cursor, CursorBuilder, Origin, Output, OutputHandle};
 
 #[derive(Debug)]
 pub struct OutputLayout {
@@ -133,6 +136,67 @@ impl OutputLayout {
     pub fn move_output(&mut self, output: &mut Output, origin: Origin) {
         let (x, y) = (origin.x, origin.y);
         unsafe { wlr_output_layout_move(self.layout, output.as_ptr(), x, y) }
+    }
+
+    /// Get the closest point on this layout from the given point from the reference
+    /// output.
+    ///
+    /// If reference is None, gets the closest point from the entire layout.
+    ///
+    /// Returns the closest point in the format (x, y)
+    pub fn closest_point<'this, O>(&mut self, reference: O, x: f64, y: f64) -> (f64, f64)
+        where O: Into<Option<&'this mut Output>> {
+        unsafe {
+            let output_ptr = reference.into().map(|output| output.as_ptr()).unwrap_or(ptr::null_mut());
+            let (ref mut out_x, ref mut out_y) = (0.0, 0.0);
+            wlr_output_layout_closest_point(self.layout, output_ptr, x, y, out_x, out_y);
+            (*out_x, *out_y)
+        }
+    }
+
+    /// Determines if the `OutputLayout` contains the `Output` at the given point.
+    pub fn contains_point(&mut self, output: &mut Output, origin: Origin) -> bool {
+        unsafe {
+            wlr_output_layout_contains_point(self.layout, output.as_ptr(), origin.x, origin.y)
+        }
+    }
+
+    /// Get the box of the layout for the given reference output.
+    ///
+    /// If `reference` is None, the box will be for the extents of the entire layout.
+    pub fn get_box<'this, O>(&mut self, reference: O) -> Area where O: Into<Option<&'this mut Output>> {
+        unsafe {
+            let output_ptr = reference.into().map(|output| output.as_ptr()).unwrap_or(ptr::null_mut());
+            Area(*wlr_output_layout_get_box(self.layout, output_ptr))
+        }
+    }
+
+    /// Get the output closest to the center of the layout extents, if one exists.
+    pub fn get_center_output(&mut self) -> Option<OutputHandle> {
+        unsafe {
+            let output = wlr_output_layout_get_center_output(self.layout);
+            if output.is_null() {
+                None
+            } else {
+                Some(OutputHandle::from_ptr(output))
+            }
+        }
+    }
+
+    /// Determines if the `Output` in the `OutputLayout` intersects with
+    /// the provided `Area`.
+    pub fn intersects(&mut self, output: &mut Output, area: Area) -> bool {
+        unsafe {
+            wlr_output_layout_intersects(self.layout, output.as_ptr(), &area.0)
+        }
+    }
+
+    /// Given x and y as pointers to global coordinates, adjusts them to local output
+    /// coordinates relative to the given reference output.
+    pub fn output_coords(&mut self, output: &mut Output, x: &mut f64, y: &mut f64) {
+        unsafe {
+            wlr_output_layout_output_coords(self.layout, output.as_ptr(), x, y)
+        }
     }
 
     /// Remove an output from this layout.

--- a/src/types/output/output_mode.rs
+++ b/src/types/output/output_mode.rs
@@ -8,6 +8,10 @@ pub struct OutputMode {
 }
 
 impl OutputMode {
+    pub(crate) unsafe fn new(output_mode: *mut wlr_output_mode) -> Self {
+        OutputMode { output_mode }
+    }
+
     /// Gets the flags set on this OutputMode.
     pub fn flags(&self) -> u32 {
         unsafe { (*self.output_mode).flags }

--- a/src/types/output/output_mode.rs
+++ b/src/types/output/output_mode.rs
@@ -1,0 +1,27 @@
+//! TODO Documentation
+
+use wlroots_sys::wlr_output_mode;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct OutputMode {
+    output_mode: *mut wlr_output_mode
+}
+
+impl OutputMode {
+    /// Gets the flags set on this OutputMode.
+    pub fn flags(&self) -> u32 {
+        unsafe { (*self.output_mode).flags }
+    }
+
+    /// Gets the dimensions of this OutputMode.
+    ///
+    /// Returned value is (width, height)
+    pub fn dimensions(&self) -> (i32, i32) {
+        unsafe { ((*self.output_mode).width, (*self.output_mode).height) }
+    }
+
+    /// Get the refresh value of the output.
+    pub fn refresh(&self) -> i32 {
+        unsafe { (*self.output_mode).refresh }
+    }
+}

--- a/src/types/output/output_mode.rs
+++ b/src/types/output/output_mode.rs
@@ -12,6 +12,10 @@ impl OutputMode {
         OutputMode { output_mode }
     }
 
+    pub(crate) unsafe fn as_ptr(&self) -> *mut wlr_output_mode {
+        self.output_mode
+    }
+
     /// Gets the flags set on this OutputMode.
     pub fn flags(&self) -> u32 {
         unsafe { (*self.output_mode).flags }


### PR DESCRIPTION
Add rest of functions for `Output` (Fixes #38)

Does a lot of work for #41, but doesn't totally clear it just yet. It still needs work on setting the surface/buffer contents and to ensure it's safe to use.

Renamed the output callback functions.

Fixes `Cursor::map_to_output` to take an optional output.