### PR TITLE
Wayland Shells

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,11 @@ lazy_static = "0.2"
 xkbcommon = "0.3"
 bitflags = "1.0"
 
+[dev-dependencies]
+wayland-client = { version = "0.12.*" }
+byteorder = "1"
+tempfile = "2"
+
 [build-dependencies]
 gl_generator = "0.5.0"
 

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -1,16 +1,7 @@
 extern crate wlroots;
 
-struct InputManager;
-struct OutputManager;
-
-impl wlroots::OutputManagerHandler for OutputManager {}
-impl wlroots::InputManagerHandler for InputManager {}
-
 fn main() {
-    use wlroots::utils::*;
-    init_logging(L_DEBUG, None);
-    wlroots::CompositorBuilder::new().build_auto((),
-                                                 Box::new(InputManager),
-                                                 Box::new(OutputManager))
+    wlroots::utils::init_logging(wlroots::utils::L_DEBUG, None);
+    wlroots::CompositorBuilder::new().build_auto((), None, None, None)
                                      .run()
 }

--- a/examples/pointer.rs
+++ b/examples/pointer.rs
@@ -1,10 +1,11 @@
 #[macro_use]
 extern crate wlroots;
 
-use wlroots::{AxisEvent, ButtonEvent, Compositor, CompositorBuilder, CursorBuilder,
-              InputManagerHandler, KeyEvent, Keyboard, KeyboardHandler, MotionEvent, Output,
-              OutputBuilder, OutputBuilderResult, OutputHandler, OutputLayout,
-              OutputManagerHandler, Pointer, PointerHandler, XCursorTheme};
+use wlroots::{Compositor, CompositorBuilder, CursorBuilder, InputManagerHandler, Keyboard,
+              KeyboardHandler, Output, OutputBuilder, OutputBuilderResult, OutputHandler,
+              OutputLayout, OutputManagerHandler, Pointer, PointerHandler, XCursorTheme};
+use wlroots::key_events::KeyEvent;
+use wlroots::pointer_events::{AxisEvent, ButtonEvent, MotionEvent};
 use wlroots::utils::{init_logging, L_DEBUG};
 use wlroots::wlroots_sys::gl;
 use wlroots::wlroots_sys::wlr_button_state::WLR_BUTTON_RELEASED;

--- a/examples/rotation.rs
+++ b/examples/rotation.rs
@@ -4,9 +4,9 @@ extern crate wlroots;
 use std::env;
 use std::time::Instant;
 
-use wlroots::{Compositor, CompositorBuilder, InputManagerHandler, KeyEvent, Keyboard,
-              KeyboardHandler, Output, OutputBuilder, OutputBuilderResult, OutputHandler,
-              OutputManagerHandler};
+use wlroots::{Compositor, CompositorBuilder, InputManagerHandler, Keyboard, KeyboardHandler,
+              Output, OutputBuilder, OutputBuilderResult, OutputHandler, OutputManagerHandler};
+use wlroots::key_events::KeyEvent;
 use wlroots::render::{Texture, TextureFormat};
 use wlroots::utils::{init_logging, L_DEBUG};
 use wlroots::wlroots_sys::wl_output_transform;

--- a/examples/rotation.rs
+++ b/examples/rotation.rs
@@ -162,11 +162,11 @@ fn main() {
         WL_OUTPUT_TRANSFORM_NORMAL
     };
     let compositor_state = CompositorState::new(rotation);
-    let input_manager = Box::new(InputManager);
-    let output_manager = Box::new(OutputManager);
-    let mut compositor =
-        CompositorBuilder::new().gles2(true)
-                                .build_auto(compositor_state, input_manager, output_manager);
+    let mut compositor = CompositorBuilder::new().gles2(true)
+                                                 .build_auto(compositor_state,
+                                                             Some(Box::new(InputManager)),
+                                                             Some(Box::new(OutputManager)),
+                                                             None);
     {
         let gles2 = &mut compositor.gles2.as_mut().unwrap();
         let compositor_data: &mut CompositorState = (&mut compositor.data).downcast_mut().unwrap();

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -3,9 +3,9 @@ extern crate wlroots;
 
 use std::time::Instant;
 
-use wlroots::{Compositor, CompositorBuilder, InputManagerHandler, KeyEvent, Keyboard,
-              KeyboardHandler, Output, OutputBuilder, OutputBuilderResult, OutputHandler,
-              OutputManagerHandler};
+use wlroots::{Compositor, CompositorBuilder, InputManagerHandler, Keyboard, KeyboardHandler,
+              Output, OutputBuilder, OutputBuilderResult, OutputHandler, OutputManagerHandler};
+use wlroots::key_events::KeyEvent;
 use wlroots::utils::{init_logging, L_DEBUG};
 use wlroots::wlroots_sys::gl;
 use wlroots::xkbcommon::xkb::keysyms::KEY_Escape;

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -90,6 +90,9 @@ impl OutputHandler for ExOutput {
 
 fn main() {
     init_logging(L_DEBUG, None);
-    CompositorBuilder::new().build_auto((), Box::new(InputManager), Box::new(OutputManager))
+    CompositorBuilder::new().build_auto((),
+                                        Some(Box::new(InputManager)),
+                                        Some(Box::new(OutputManager)),
+                                        None)
                             .run()
 }

--- a/examples/wl_shell_test.rs
+++ b/examples/wl_shell_test.rs
@@ -3,11 +3,13 @@ extern crate wlroots;
 
 use std::process::Command;
 
-use wlroots::{AxisEvent, ButtonEvent, Compositor, CompositorBuilder, CursorBuilder,
-              InputManagerHandler, KeyEvent, Keyboard, KeyboardHandler, MotionEvent, Output,
+use wlroots::{Compositor, CompositorBuilder, CursorBuilder,
+              InputManagerHandler, Keyboard, KeyboardHandler, Output,
               OutputBuilder, OutputBuilderResult, OutputHandler, OutputLayout,
               OutputManagerHandler, Pointer, PointerHandler, WlShellHandler,
               WlShellManagerHandler, WlShellSurface, XCursorTheme};
+use wlroots::pointer_events::{AxisEvent, ButtonEvent, MotionEvent};
+use wlroots::key_events::{KeyEvent};
 use wlroots::utils::{init_logging, L_DEBUG};
 use wlroots::wlroots_sys::gl;
 use wlroots::wlroots_sys::wlr_button_state::WLR_BUTTON_RELEASED;

--- a/examples/wl_shell_test.rs
+++ b/examples/wl_shell_test.rs
@@ -3,13 +3,12 @@ extern crate wlroots;
 
 use std::process::Command;
 
-use wlroots::{Compositor, CompositorBuilder, CursorBuilder,
-              InputManagerHandler, Keyboard, KeyboardHandler, Output,
-              OutputBuilder, OutputBuilderResult, OutputHandler, OutputLayout,
-              OutputManagerHandler, Pointer, PointerHandler, WlShellHandler,
+use wlroots::{Compositor, CompositorBuilder, CursorBuilder, InputManagerHandler, Keyboard,
+              KeyboardHandler, Output, OutputBuilder, OutputBuilderResult, OutputHandler,
+              OutputLayout, OutputManagerHandler, Pointer, PointerHandler, WlShellHandler,
               WlShellManagerHandler, WlShellSurface, XCursorTheme};
+use wlroots::key_events::KeyEvent;
 use wlroots::pointer_events::{AxisEvent, ButtonEvent, MotionEvent};
-use wlroots::key_events::{KeyEvent};
 use wlroots::utils::{init_logging, L_DEBUG};
 use wlroots::wlroots_sys::gl;
 use wlroots::wlroots_sys::wlr_button_state::WLR_BUTTON_RELEASED;

--- a/examples/wl_shell_test.rs
+++ b/examples/wl_shell_test.rs
@@ -1,7 +1,11 @@
+extern crate byteorder;
+extern crate tempfile;
+#[macro_use]
+extern crate wayland_client;
 #[macro_use]
 extern crate wlroots;
 
-use std::process::Command;
+use std::thread;
 
 use wlroots::{Compositor, CompositorBuilder, CursorBuilder, InputManagerHandler, Keyboard,
               KeyboardHandler, Output, OutputBuilder, OutputBuilderResult, OutputHandler,
@@ -85,7 +89,132 @@ impl KeyboardHandler for ExKeyboardHandler {
             }
             // TODO This is a dumb way to compare these values
             else if key_event.key_state() as u32 == 1 {
-                Command::new("simple_window").spawn().unwrap();
+                thread::spawn(move || {
+                    use byteorder::{NativeEndian, WriteBytesExt};
+                    use std::cmp::min;
+                    use std::io::Write;
+                    use std::os::unix::io::AsRawFd;
+                    use wayland_client::EnvHandler;
+                    use wayland_client::protocol::{wl_compositor, wl_pointer, wl_seat, wl_shell,
+                                                   wl_shell_surface, wl_shm};
+
+                    wayland_env!(WaylandEnv,
+                                 compositor: wl_compositor::WlCompositor,
+                                 //seat: wl_seat::WlSeat,
+                                 shell: wl_shell::WlShell,
+                                 shm: wl_shm::WlShm);
+
+                    fn shell_surface_impl() -> wl_shell_surface::Implementation<()> {
+                        wl_shell_surface::Implementation { ping: |_, _, shell_surface, serial| {
+                                                               shell_surface.pong(serial);
+                                                           },
+                                                           configure: |_, _, _, _, _, _| {
+                                                               /* not used in this example */
+                                                           },
+                                                           popup_done: |_, _, _| {
+                                                               /* not used in this example */
+                                                           } }
+                    }
+
+                    fn pointer_impl() -> wl_pointer::Implementation<()> {
+                        wl_pointer::Implementation {
+                            enter: |_, _, _pointer, _serial, _surface, x, y| {
+                                println!("Pointer entered surface at ({},{}).", x, y);
+                            },
+                            leave: |_, _, _pointer, _serial, _surface| {
+                                println!("Pointer left surface.");
+                            },
+                            motion: |_, _, _pointer, _time, x, y| {
+                                println!("Pointer moved to ({},{}).", x, y);
+                            },
+                            button: |_, _, _pointer, _serial, _time, button, state| {
+                                println!(
+                                    "Button {} ({}) was {:?}.",
+                                    match button {
+                                        272 => "Left",
+                                        273 => "Right",
+                                        274 => "Middle",
+                                        _ => "Unknown",
+                                    },
+                                    button,
+                                    state
+                                );
+                            },
+                            axis: |_, _, _, _, _, _| { /* not used in this example */ },
+                            frame: |_, _, _| { /* not used in this example */ },
+                            axis_source: |_, _, _, _| { /* not used in this example */ },
+                            axis_discrete: |_, _, _, _, _| { /* not used in this example */ },
+                            axis_stop: |_, _, _, _, _| { /* not used in this example */ },
+                        }
+                    }
+
+                    let (display, mut event_queue) = match wayland_client::default_connect() {
+                        Ok(ret) => ret,
+                        Err(e) => panic!("Cannot connect to wayland server: {:?}", e)
+                    };
+
+                    let registry = display.get_registry();
+
+                    let env_token = EnvHandler::<WaylandEnv>::init(&mut event_queue, &registry);
+
+                    event_queue.sync_roundtrip().unwrap();
+
+                    // buffer (and window) width and height
+                    let buf_x: u32 = 320;
+                    let buf_y: u32 = 240;
+
+                    // create a tempfile to write the conents of the window on
+                    let mut tmp = tempfile::tempfile().ok()
+                                                      .expect("Unable to create a tempfile.");
+                    // write the contents to it, lets put a nice color gradient
+                    for i in 0..(buf_x * buf_y) {
+                        let x = (i % buf_x) as u32;
+                        let y = (i / buf_x) as u32;
+                        let r: u32 =
+                            min(((buf_x - x) * 0xFF) / buf_x, ((buf_y - y) * 0xFF) / buf_y);
+                        let g: u32 = min((x * 0xFF) / buf_x, ((buf_y - y) * 0xFF) / buf_y);
+                        let b: u32 = min(((buf_x - x) * 0xFF) / buf_x, (y * 0xFF) / buf_y);
+                        let _ =
+                            tmp.write_u32::<NativeEndian>((0xFF << 24) + (r << 16) + (g << 8) + b);
+                    }
+                    let _ = tmp.flush();
+
+                    // retrieve the env
+                    let env = event_queue.state().get(&env_token).clone_inner().unwrap();
+
+                    // prepare the wayland surface
+                    let surface = env.compositor.create_surface();
+                    let shell_surface = env.shell.get_shell_surface(&surface);
+
+                    let pool = env.shm.create_pool(tmp.as_raw_fd(), (buf_x * buf_y * 4) as i32);
+                    // match a buffer on the part we wrote on
+                    let buffer = pool.create_buffer(
+                        0,
+                        buf_x as i32,
+                        buf_y as i32,
+                        (buf_x * 4) as i32,
+                        wl_shm::Format::Argb8888,
+                    ).expect("The pool cannot be already dead");
+
+                    // make our surface as a toplevel one
+                    shell_surface.set_toplevel();
+                    // attach the buffer to it
+                    surface.attach(Some(&buffer), 0, 0);
+                    // commit
+                    surface.commit();
+
+                    //let pointer = env.seat
+                    //    .get_pointer()
+                    //    .expect("Seat cannot be already destroyed.");
+
+                    event_queue.register(&shell_surface, shell_surface_impl(), ());
+                    //event_queue.register(&pointer, pointer_impl(), ());
+
+                    loop {
+                        display.flush().unwrap();
+                        event_queue.dispatch().unwrap();
+                    }
+                });
             }
         }
     }

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -1,2 +1,3 @@
 pub mod key_events;
 pub mod pointer_events;
+pub mod wl_shell_events;

--- a/src/events/wl_shell_events.rs
+++ b/src/events/wl_shell_events.rs
@@ -1,0 +1,129 @@
+//! Events for Wayland shells
+
+use wlroots_sys::{wlr_wl_shell_surface_move_event, wlr_wl_shell_surface_resize_event,
+                  wlr_wl_shell_surface_set_fullscreen_event, wlr_wl_shell_surface_maximize_event,
+                  wl_shell_surface_resize, wl_shell_surface_fullscreen_method};
+
+
+use {WlShellSurfaceHandle, OutputHandle};
+
+/// Event that triggers when the surface has been moved in coordinate space.
+#[derive(Debug, Eq, PartialEq)]
+pub struct MoveEvent {
+    event: *mut wlr_wl_shell_surface_move_event
+}
+
+/// Event that triggers when the surface are has been resized.
+#[derive(Debug, Eq, PartialEq)]
+pub struct ResizeEvent {
+    event: *mut wlr_wl_shell_surface_resize_event
+}
+
+/// Event that triggers when the surface area has been requested to render on
+/// the entire screen.
+#[derive(Debug, Eq, PartialEq)]
+pub struct FullscreenEvent {
+    event: *mut wlr_wl_shell_surface_set_fullscreen_event
+}
+
+/// Event that triggers when the shell is requested to be maximized.
+#[derive(Debug, Eq, PartialEq)]
+pub struct MaximizeEvent {
+    event: *mut wlr_wl_shell_surface_maximize_event
+}
+
+// TODO Get seat client
+impl MoveEvent {
+    pub(crate) unsafe fn from_ptr(event: *mut wlr_wl_shell_surface_move_event) -> Self {
+        MoveEvent { event }
+    }
+    /// Gets the surface that is being moved.
+    pub fn surface(&mut self) -> WlShellSurfaceHandle {
+        unsafe {
+            WlShellSurfaceHandle::from_ptr((*self.event).surface)
+        }
+    }
+
+    /// TODO Document
+    pub fn serial(&self) -> u32 {
+        unsafe {
+            (*self.event).serial
+        }
+    }
+}
+
+// TODO Get seat client
+impl ResizeEvent {
+    pub(crate) unsafe fn from_ptr(event: *mut wlr_wl_shell_surface_resize_event) -> Self {
+        ResizeEvent { event }
+    }
+
+    /// Gets the surface that is being resized.
+    pub fn surface(&mut self) -> WlShellSurfaceHandle {
+        unsafe {
+            WlShellSurfaceHandle::from_ptr((*self.event).surface)
+        }
+    }
+
+    /// TODO Document
+    pub fn serial(&self) -> u32 {
+        unsafe {
+            (*self.event).serial
+        }
+    }
+
+    /// Get which edge(s) of the surface were resized from this event.
+    pub fn edges(&self) -> wl_shell_surface_resize {
+        unsafe {
+            (*self.event).edges
+        }
+    }
+}
+
+impl FullscreenEvent {
+    pub(crate) unsafe fn from_ptr(event: *mut wlr_wl_shell_surface_set_fullscreen_event) -> Self {
+        FullscreenEvent { event }
+    }
+
+    /// Gets the surface that wants to be a fullscreen
+    pub fn surface(&mut self) -> WlShellSurfaceHandle {
+        unsafe {
+            WlShellSurfaceHandle::from_ptr((*self.event).surface)
+        }
+    }
+
+    /// Get the method that should be used to make the surface fullscreen.
+    pub fn method(&self) -> wl_shell_surface_fullscreen_method {
+        unsafe { (*self.event).method }
+    }
+
+    /// TODO Document
+    pub fn framerate(&self) -> u32 {
+        unsafe { (*self.event).framerate }
+    }
+
+    /// Get the output that the surface wants to be fullscreen on.
+    pub fn output(&self) -> OutputHandle {
+        unsafe {
+            OutputHandle::from_ptr((*self.event).output)
+        }
+    }
+}
+
+impl MaximizeEvent {
+    pub(crate) unsafe fn from_ptr(event: *mut wlr_wl_shell_surface_maximize_event) -> Self {
+        MaximizeEvent { event }
+    }
+
+    /// Gets the surface that wants to be maximized.
+    pub fn surface(&mut self) -> WlShellSurfaceHandle {
+        unsafe {
+            WlShellSurfaceHandle::from_ptr((*self.event).surface)
+        }
+    }
+
+    /// Get the output that the surface wants to be maximized on.
+    pub fn output(&self) -> OutputHandle {
+        unsafe { OutputHandle::from_ptr((*self.event).output )}
+    }
+}

--- a/src/events/wl_shell_events.rs
+++ b/src/events/wl_shell_events.rs
@@ -1,11 +1,10 @@
 //! Events for Wayland shells
 
-use wlroots_sys::{wlr_wl_shell_surface_move_event, wlr_wl_shell_surface_resize_event,
-                  wlr_wl_shell_surface_set_fullscreen_event, wlr_wl_shell_surface_maximize_event,
-                  wl_shell_surface_resize, wl_shell_surface_fullscreen_method};
+use wlroots_sys::{wl_shell_surface_fullscreen_method, wl_shell_surface_resize,
+                  wlr_wl_shell_surface_maximize_event, wlr_wl_shell_surface_move_event,
+                  wlr_wl_shell_surface_resize_event, wlr_wl_shell_surface_set_fullscreen_event};
 
-
-use {WlShellSurfaceHandle, OutputHandle};
+use {OutputHandle, WlShellSurfaceHandle};
 
 /// Event that triggers when the surface has been moved in coordinate space.
 #[derive(Debug, Eq, PartialEq)]
@@ -39,16 +38,12 @@ impl MoveEvent {
     }
     /// Gets the surface that is being moved.
     pub fn surface(&mut self) -> WlShellSurfaceHandle {
-        unsafe {
-            WlShellSurfaceHandle::from_ptr((*self.event).surface)
-        }
+        unsafe { WlShellSurfaceHandle::from_ptr((*self.event).surface) }
     }
 
     /// TODO Document
     pub fn serial(&self) -> u32 {
-        unsafe {
-            (*self.event).serial
-        }
+        unsafe { (*self.event).serial }
     }
 }
 
@@ -60,23 +55,17 @@ impl ResizeEvent {
 
     /// Gets the surface that is being resized.
     pub fn surface(&mut self) -> WlShellSurfaceHandle {
-        unsafe {
-            WlShellSurfaceHandle::from_ptr((*self.event).surface)
-        }
+        unsafe { WlShellSurfaceHandle::from_ptr((*self.event).surface) }
     }
 
     /// TODO Document
     pub fn serial(&self) -> u32 {
-        unsafe {
-            (*self.event).serial
-        }
+        unsafe { (*self.event).serial }
     }
 
     /// Get which edge(s) of the surface were resized from this event.
     pub fn edges(&self) -> wl_shell_surface_resize {
-        unsafe {
-            (*self.event).edges
-        }
+        unsafe { (*self.event).edges }
     }
 }
 
@@ -87,9 +76,7 @@ impl FullscreenEvent {
 
     /// Gets the surface that wants to be a fullscreen
     pub fn surface(&mut self) -> WlShellSurfaceHandle {
-        unsafe {
-            WlShellSurfaceHandle::from_ptr((*self.event).surface)
-        }
+        unsafe { WlShellSurfaceHandle::from_ptr((*self.event).surface) }
     }
 
     /// Get the method that should be used to make the surface fullscreen.
@@ -104,9 +91,7 @@ impl FullscreenEvent {
 
     /// Get the output that the surface wants to be fullscreen on.
     pub fn output(&self) -> OutputHandle {
-        unsafe {
-            OutputHandle::from_ptr((*self.event).output)
-        }
+        unsafe { OutputHandle::from_ptr((*self.event).output) }
     }
 }
 
@@ -117,13 +102,11 @@ impl MaximizeEvent {
 
     /// Gets the surface that wants to be maximized.
     pub fn surface(&mut self) -> WlShellSurfaceHandle {
-        unsafe {
-            WlShellSurfaceHandle::from_ptr((*self.event).surface)
-        }
+        unsafe { WlShellSurfaceHandle::from_ptr((*self.event).surface) }
     }
 
     /// Get the output that the surface wants to be maximized on.
     pub fn output(&self) -> OutputHandle {
-        unsafe { OutputHandle::from_ptr((*self.event).output )}
+        unsafe { OutputHandle::from_ptr((*self.event).output) }
     }
 }

--- a/src/events/wl_shell_events.rs
+++ b/src/events/wl_shell_events.rs
@@ -4,7 +4,7 @@ use wlroots_sys::{wl_shell_surface_fullscreen_method, wl_shell_surface_resize,
                   wlr_wl_shell_surface_maximize_event, wlr_wl_shell_surface_move_event,
                   wlr_wl_shell_surface_resize_event, wlr_wl_shell_surface_set_fullscreen_event};
 
-use {OutputHandle, WlShellSurfaceHandle};
+use {OutputHandle, SeatClient, WlShellSurfaceHandle};
 
 /// Event that triggers when the surface has been moved in coordinate space.
 #[derive(Debug, Eq, PartialEq)]
@@ -31,11 +31,16 @@ pub struct MaximizeEvent {
     event: *mut wlr_wl_shell_surface_maximize_event
 }
 
-// TODO Get seat client
 impl MoveEvent {
     pub(crate) unsafe fn from_ptr(event: *mut wlr_wl_shell_surface_move_event) -> Self {
         MoveEvent { event }
     }
+
+    /// Get the Wayland seat client.
+    pub fn seat_client(&mut self) -> SeatClient {
+        unsafe { SeatClient::from_ptr((*self.event).seat) }
+    }
+
     /// Gets the surface that is being moved.
     pub fn surface(&mut self) -> WlShellSurfaceHandle {
         unsafe { WlShellSurfaceHandle::from_ptr((*self.event).surface) }
@@ -47,10 +52,14 @@ impl MoveEvent {
     }
 }
 
-// TODO Get seat client
 impl ResizeEvent {
     pub(crate) unsafe fn from_ptr(event: *mut wlr_wl_shell_surface_resize_event) -> Self {
         ResizeEvent { event }
+    }
+
+    /// Get the Wayland seat client.
+    pub fn seat_client(&mut self) -> SeatClient {
+        unsafe { SeatClient::from_ptr((*self.event).seat) }
     }
 
     /// Gets the surface that is being resized.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ pub mod render;
 pub mod utils;
 
 pub use self::compositor::{terminate, Compositor, CompositorBuilder};
-pub use self::events::{key_events, pointer_events};
+pub use self::events::{key_events, pointer_events, wl_shell_events};
 pub use key_events::Key;
 pub use pointer_events::ButtonState;
 pub use self::manager::{InputManagerHandler, KeyboardHandler, OutputBuilder, OutputBuilderResult,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,17 +9,10 @@
 //! ```rust,no_run
 //! extern crate wlroots;
 //!
-//! struct InputManager;
-//! struct OutputManager;
-//!
-//! impl wlroots::OutputManagerHandler for OutputManager {}
-//! impl wlroots::InputManagerHandler for InputManager {}
-//!
 //! fn main() {
 //!     wlroots::CompositorBuilder::new()
 //!          .build_auto((), // Dummy state
-//!                      Box::new(InputManager),
-//!                      Box::new(OutputManager))
+//!                      None, None, None)
 //!          .run()
 //! }
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,8 @@ pub use self::compositor::{terminate, Compositor, CompositorBuilder};
 pub use self::events::key_events::*;
 pub use self::events::pointer_events::*;
 pub use self::manager::{InputManagerHandler, KeyboardHandler, OutputBuilder, OutputBuilderResult,
-                        OutputHandler, OutputManagerHandler, PointerHandler};
+                        OutputHandler, OutputManagerHandler, PointerHandler, WlShellHandler,
+                        WlShellManagerHandler};
 pub use self::types::area::*;
 pub use self::types::cursor::*;
 pub use self::types::input_device::*;
@@ -58,6 +59,7 @@ pub use self::types::output::output::*;
 pub use self::types::output::output_layout::*;
 pub use self::types::pointer::*;
 pub use self::types::seat::*;
+pub use self::types::shell::*;
 pub use self::types::surface::*;
 
 pub use self::errors::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,8 +46,9 @@ pub mod render;
 pub mod utils;
 
 pub use self::compositor::{terminate, Compositor, CompositorBuilder};
-pub use self::events::key_events::*;
-pub use self::events::pointer_events::*;
+pub use self::events::{key_events, pointer_events};
+pub use key_events::Key;
+pub use pointer_events::ButtonState;
 pub use self::manager::{InputManagerHandler, KeyboardHandler, OutputBuilder, OutputBuilderResult,
                         OutputHandler, OutputManagerHandler, PointerHandler, WlShellHandler,
                         WlShellManagerHandler};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,8 +47,6 @@ pub mod utils;
 
 pub use self::compositor::{terminate, Compositor, CompositorBuilder};
 pub use self::events::{key_events, pointer_events, wl_shell_events};
-pub use key_events::Key;
-pub use pointer_events::ButtonState;
 pub use self::manager::{InputManagerHandler, KeyboardHandler, OutputBuilder, OutputBuilderResult,
                         OutputHandler, OutputManagerHandler, PointerHandler, WlShellHandler,
                         WlShellManagerHandler};
@@ -62,5 +60,7 @@ pub use self::types::pointer::*;
 pub use self::types::seat::*;
 pub use self::types::shell::*;
 pub use self::types::surface::*;
+pub use key_events::Key;
+pub use pointer_events::ButtonState;
 
 pub use self::errors::*;

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -3,6 +3,8 @@ mod output_manager;
 mod keyboard_handler;
 mod pointer_handler;
 mod output_handler;
+mod wl_shell_manager;
+mod wl_shell_handler;
 
 pub use self::input_manager::{InputManager, InputManagerHandler};
 pub use self::keyboard_handler::{KeyboardHandler, KeyboardWrapper};
@@ -10,3 +12,5 @@ pub use self::output_handler::{OutputHandler, UserOutput};
 pub use self::output_manager::{OutputBuilder, OutputBuilderResult, OutputManager,
                                OutputManagerHandler};
 pub use self::pointer_handler::{PointerHandler, PointerWrapper};
+pub use self::wl_shell_handler::*;
+pub use self::wl_shell_manager::*;

--- a/src/manager/wl_shell_handler.rs
+++ b/src/manager/wl_shell_handler.rs
@@ -5,7 +5,7 @@ use wayland_sys::server::WAYLAND_SERVER_HANDLE;
 
 use WlShellSurface;
 use compositor::{Compositor, COMPOSITOR_PTR};
-use wl_shell_events::{MoveEvent, ResizeEvent, FullscreenEvent, MaximizeEvent};
+use wl_shell_events::{FullscreenEvent, MaximizeEvent, MoveEvent, ResizeEvent};
 
 /// Handles events from client Wayland shells.
 pub trait WlShellHandler {
@@ -20,22 +20,13 @@ pub trait WlShellHandler {
     fn move_request(&mut self, &mut Compositor, &mut WlShellSurface, &mut MoveEvent) {}
 
     /// Called when there is a request to resize the shell surface.
-    fn resize_request(&mut self,
-                      &mut Compositor,
-                      &mut WlShellSurface, &mut ResizeEvent) {
-    }
+    fn resize_request(&mut self, &mut Compositor, &mut WlShellSurface, &mut ResizeEvent) {}
 
     /// Called when there is a request to make the shell surface fullscreen.
-    fn fullscreen_request(&mut self,
-                          &mut Compositor,
-                          &mut WlShellSurface, &mut FullscreenEvent) {
-    }
+    fn fullscreen_request(&mut self, &mut Compositor, &mut WlShellSurface, &mut FullscreenEvent) {}
 
     /// Called when there is a request to make the shell surface maximized.
-    fn maximize_request(&mut self,
-                        &mut Compositor,
-                        &mut WlShellSurface, &mut MaximizeEvent) {
-    }
+    fn maximize_request(&mut self, &mut Compositor, &mut WlShellSurface, &mut MaximizeEvent) {}
 
     /// Called when there is a request to change the state of the Wayland shell.
     fn state_change(&mut self, &mut Compositor, &mut WlShellSurface) {}

--- a/src/manager/wl_shell_handler.rs
+++ b/src/manager/wl_shell_handler.rs
@@ -1,0 +1,155 @@
+//! Handler for Wayland shell clients.
+
+use libc;
+use wayland_sys::server::WAYLAND_SERVER_HANDLE;
+
+use WlShellSurface;
+use compositor::{Compositor, COMPOSITOR_PTR};
+
+/// Handles events from client Wayland shells.
+pub trait WlShellHandler {
+    /// Called when the Wayland shell is destroyed (e.g by the user)
+    fn destroy(&mut self, &mut Compositor, &mut WlShellSurface) {}
+
+    /// Called when the ping request timed out. This usually indicates something
+    /// is wrong with the client
+    fn ping_timeout(&mut self, &mut Compositor, &mut WlShellSurface) {}
+
+    /// Called when there is a request to move the shell surface somewhere else.
+    fn move_request(&mut self, &mut Compositor, &mut WlShellSurface /* TODO Move event */) {}
+
+    /// Called when there is a request to resize the shell surface.
+    fn resize_request(&mut self,
+                      &mut Compositor,
+                      &mut WlShellSurface /* TODO resize event */) {
+    }
+
+    /// Called when there is a request to make the shell surface fullscreen.
+    fn fullscreen_request(&mut self,
+                          &mut Compositor,
+                          &mut WlShellSurface /* TODO Fullscreen event */) {
+    }
+
+    /// Called when there is a request to make the shell surface maximized.
+    fn maximize_request(&mut self,
+                        &mut Compositor,
+                        &mut WlShellSurface /* TODO Maximize request */) {
+    }
+
+    /// Called when there is a request to change the state of the Wayland shell.
+    fn state_change(&mut self, &mut Compositor, &mut WlShellSurface) {}
+
+    /// Called when there is a request to change the title of the Wayland shell.
+    fn title_change(&mut self, &mut Compositor, &mut WlShellSurface) {}
+
+    /// Called when there is a request to change the class of the Wayland shell.
+    fn class_change(&mut self, &mut Compositor, &mut WlShellSurface) {}
+}
+
+wayland_listener!(WlShell, (WlShellSurface, Box<WlShellHandler>), [
+    destroy_listener => destroy_notify: |this: &mut WlShell, _data: *mut libc::c_void,|
+    unsafe {
+        // TODO NLL
+        {
+            let (ref mut shell_surface, ref mut manager) = this.data;
+            let compositor = &mut *COMPOSITOR_PTR;
+            shell_surface.set_lock(true);
+            manager.destroy(compositor, shell_surface);
+            shell_surface.set_lock(false);
+        }
+        ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                      wl_list_remove,
+                      &mut (*this.destroy_listener()).link as *mut _ as _);
+        ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                      wl_list_remove,
+                      &mut (*this.ping_timeout_listener()).link as *mut _ as _);
+        ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                      wl_list_remove,
+                      &mut (*this.request_move_listener()).link as *mut _ as _);
+        ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                      wl_list_remove,
+                      &mut (*this.request_resize_listener()).link as *mut _ as _);
+        ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                      wl_list_remove,
+                      &mut (*this.request_fullscreen_listener()).link as *mut _ as _);
+        ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                      wl_list_remove,
+                      &mut (*this.request_maximize_listener()).link as *mut _ as _);
+        ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                      wl_list_remove,
+                      &mut (*this.set_state_listener()).link as *mut _ as _);
+        ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                      wl_list_remove,
+                      &mut (*this.set_title_listener()).link as *mut _ as _);
+        ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                      wl_list_remove,
+                      &mut (*this.set_class_listener()).link as *mut _ as _);
+    };
+    ping_timeout_listener => ping_timeout_notify: |this: &mut WlShell, _data: *mut libc::c_void,|
+    unsafe {
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let compositor = &mut *COMPOSITOR_PTR;
+        shell_surface.set_lock(true);
+        manager.ping_timeout(compositor, shell_surface);
+        shell_surface.set_lock(false);
+    };
+    request_move_listener => request_move_notify: |this: &mut WlShell, _data: *mut libc::c_void,|
+    unsafe {
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let compositor = &mut *COMPOSITOR_PTR;
+        shell_surface.set_lock(true);
+        manager.move_request(compositor, shell_surface);
+        shell_surface.set_lock(false);
+    };
+    request_resize_listener => request_resize_notify: |this: &mut WlShell,
+                                                       _data: *mut libc::c_void,|
+    unsafe {
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let compositor = &mut *COMPOSITOR_PTR;
+        shell_surface.set_lock(true);
+        manager.resize_request(compositor, shell_surface);
+        shell_surface.set_lock(false);
+    };
+    request_fullscreen_listener => request_fullscreen_notify: |this: &mut WlShell,
+                                                               _data: *mut libc::c_void,|
+    unsafe {
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let compositor = &mut *COMPOSITOR_PTR;
+        shell_surface.set_lock(true);
+        manager.fullscreen_request(compositor, shell_surface);
+        shell_surface.set_lock(false);
+    };
+    request_maximize_listener => request_maximize_notify: |this: &mut WlShell,
+                                                           _data: *mut libc::c_void,|
+    unsafe {
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let compositor = &mut *COMPOSITOR_PTR;
+        shell_surface.set_lock(true);
+        manager.maximize_request(compositor, shell_surface);
+        shell_surface.set_lock(false);
+    };
+    set_state_listener => set_state_notify: |this: &mut WlShell, _data: *mut libc::c_void,|
+    unsafe {
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let compositor = &mut *COMPOSITOR_PTR;
+        shell_surface.set_lock(true);
+        manager.state_change(compositor, shell_surface);
+        shell_surface.set_lock(false);
+    };
+    set_title_listener => set_title_notify: |this: &mut WlShell, _data: *mut libc::c_void,|
+    unsafe {
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let compositor = &mut *COMPOSITOR_PTR;
+        shell_surface.set_lock(true);
+        manager.title_change(compositor, shell_surface);
+        shell_surface.set_lock(false);
+    };
+    set_class_listener => set_class_notify: |this: &mut WlShell, _data: *mut libc::c_void,|
+    unsafe {
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let compositor = &mut *COMPOSITOR_PTR;
+        shell_surface.set_lock(true);
+        manager.class_change(compositor, shell_surface);
+        shell_surface.set_lock(false);
+    };
+]);

--- a/src/manager/wl_shell_handler.rs
+++ b/src/manager/wl_shell_handler.rs
@@ -85,6 +85,12 @@ wayland_listener!(WlShell, (WlShellSurface, Box<WlShellHandler>), [
         ffi_dispatch!(WAYLAND_SERVER_HANDLE,
                       wl_list_remove,
                       &mut (*this.set_class_listener()).link as *mut _ as _);
+        let shell_ptr = this as *mut _;
+        drop(this);
+        // Destroy the WlShell data. This is necessary because WlShellManager doesn't
+        // have an event to listen to Wayland shell destruction.
+        // NOTE **DO NOT** use `this` after this line.
+        let _ = Box::from_raw(shell_ptr);
     };
     ping_timeout_listener => ping_timeout_notify: |this: &mut WlShell, _data: *mut libc::c_void,|
     unsafe {

--- a/src/manager/wl_shell_manager.rs
+++ b/src/manager/wl_shell_manager.rs
@@ -1,0 +1,66 @@
+//! Manager for wl_shell clients.
+
+use libc;
+use wayland_sys::server::signal::wl_signal_add;
+use wlroots_sys::wlr_wl_shell_surface;
+
+use super::wl_shell_handler::WlShell;
+use {WlShellHandler, WlShellSurface};
+use compositor::{Compositor, COMPOSITOR_PTR};
+
+/// Handles making new Wayland shells as reported by clients.
+pub trait WlShellManagerHandler {
+    fn new_surface(&mut self, &mut Compositor, &mut WlShellSurface) -> Option<Box<WlShellHandler>>;
+}
+
+wayland_listener!(WlShellManager, Box<WlShellManagerHandler>, [
+    add_listener => add_notify: |this: &mut WlShellManager, data: *mut libc::c_void,| unsafe {
+        let manager = &mut this.data;
+        let data = data as *mut wlr_wl_shell_surface;
+        wlr_log!(L_DEBUG, "New wl_shell_surface request {:p}", data);
+        let compositor = &mut *COMPOSITOR_PTR;
+        let mut shell_surface = WlShellSurface::new(data);
+        let new_surface_res = manager.new_surface(compositor, &mut shell_surface);
+        if let Some(shell_surface_handler) = new_surface_res {
+            let mut shell_surface = WlShell::new((shell_surface, shell_surface_handler));
+            // Add the destroy event to this handler.
+            wl_signal_add(&mut (*data).events.destroy as *mut _ as _,
+                          shell_surface.destroy_listener() as _);
+
+            // Add the ping timeout event to this handler.
+            wl_signal_add(&mut (*data).events.ping_timeout as *mut _ as _,
+                          shell_surface.ping_timeout_listener() as _);
+
+            // Add the move request event to this handler.
+            wl_signal_add(&mut (*data).events.request_move as *mut _ as _,
+                          shell_surface.request_move_listener() as _);
+
+            // Add the resize request event to this handler.
+            wl_signal_add(&mut (*data).events.request_resize as *mut _ as _,
+                          shell_surface.request_resize_listener() as _);
+
+            // Add the fullscreen request event to this handler.
+            wl_signal_add(&mut (*data).events.request_fullscreen as *mut _ as _,
+                          shell_surface.request_fullscreen_listener() as _);
+
+            // Add the maximize request event to this handler.
+            wl_signal_add(&mut (*data).events.request_maximize as *mut _ as _,
+                          shell_surface.request_maximize_listener() as _);
+
+            // Add the set state request event to this handler.
+            wl_signal_add(&mut (*data).events.set_state as *mut _ as _,
+                          shell_surface.set_state_listener() as _);
+
+            // Add the set title request event to this handler.
+            wl_signal_add(&mut (*data).events.set_title as *mut _ as _,
+                          shell_surface.set_title_listener() as _);
+
+            // Add the set class request event to this handler.
+            wl_signal_add(&mut (*data).events.set_class as *mut _ as _,
+                          shell_surface.set_class_listener() as _);
+
+            // TODO Shouldn't we try to clean this up somehow?
+            ::std::mem::forget(shell_surface);
+        }
+    };
+]);

--- a/src/manager/wl_shell_manager.rs
+++ b/src/manager/wl_shell_manager.rs
@@ -59,7 +59,7 @@ wayland_listener!(WlShellManager, Box<WlShellManagerHandler>, [
             wl_signal_add(&mut (*data).events.set_class as *mut _ as _,
                           shell_surface.set_class_listener() as _);
 
-            // TODO Shouldn't we try to clean this up somehow?
+            // NOTE This is cleaned up in the wl_shell_handler::destroy signal.
             ::std::mem::forget(shell_surface);
         }
     };

--- a/src/render/gles2.rs
+++ b/src/render/gles2.rs
@@ -43,6 +43,10 @@ impl GLES2 {
     pub fn create_texture(&mut self) -> Option<Texture> {
         unsafe { create_texture(self.renderer) }
     }
+
+    pub(crate) unsafe fn as_ptr(&self) -> *mut wlr_renderer {
+        self.renderer
+    }
 }
 
 impl<'output> GLES2Renderer<'output> {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -6,6 +6,7 @@ pub mod output;
 pub mod area;
 pub mod seat;
 pub mod surface;
+pub mod shell;
 
 pub use self::area::*;
 pub use self::cursor::*;
@@ -14,4 +15,5 @@ pub use self::keyboard::*;
 pub use self::output::*;
 pub use self::pointer::*;
 pub use self::seat::*;
+pub use self::shell::*;
 pub use self::surface::*;

--- a/src/types/seat/mod.rs
+++ b/src/types/seat/mod.rs
@@ -2,3 +2,8 @@ pub mod seat_client;
 pub mod seat;
 pub mod grab;
 pub mod touch_point;
+
+pub use self::seat_client::*;
+pub use self::seat::*;
+pub use self::grab::*;
+pub use self::touch_point::*;

--- a/src/types/seat/mod.rs
+++ b/src/types/seat/mod.rs
@@ -3,7 +3,7 @@ pub mod seat;
 pub mod grab;
 pub mod touch_point;
 
-pub use self::seat_client::*;
-pub use self::seat::*;
 pub use self::grab::*;
+pub use self::seat::*;
+pub use self::seat_client::*;
 pub use self::touch_point::*;

--- a/src/types/shell/mod.rs
+++ b/src/types/shell/mod.rs
@@ -1,0 +1,3 @@
+pub mod wl_shell;
+
+pub use self::wl_shell::*;

--- a/src/types/shell/wl_shell.rs
+++ b/src/types/shell/wl_shell.rs
@@ -1,0 +1,219 @@
+//! TODO Documentation
+
+use std::{panic, ptr};
+use std::rc::{Rc, Weak};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use wlroots_sys::{wl_shell_surface_resize, wlr_wl_shell_surface, wlr_wl_shell_surface_configure,
+                  wlr_wl_shell_surface_ping, wlr_wl_shell_surface_popup_at};
+
+use errors::{UpgradeHandleErr, UpgradeHandleResult};
+use utils::c_to_rust_string;
+
+pub type WlShellSurfaceResize = wl_shell_surface_resize;
+
+struct WlShellSurfaceState {
+    handle: Weak<AtomicBool>
+}
+
+#[derive(Debug)]
+pub struct WlShellSurface {
+    liveliness: Option<Rc<AtomicBool>>,
+    shell_surface: *mut wlr_wl_shell_surface
+}
+
+#[derive(Debug, Clone)]
+pub struct WlShellSurfaceHandle {
+    handle: Weak<AtomicBool>,
+    shell_surface: *mut wlr_wl_shell_surface
+}
+
+impl WlShellSurface {
+    pub(crate) unsafe fn new(shell_surface: *mut wlr_wl_shell_surface) -> Self {
+        // TODO FIXME Free state in drop impl when Rc == 1
+        (*shell_surface).data = ptr::null_mut();
+        let liveliness = Rc::new(AtomicBool::new(false));
+        let state = Box::new(WlShellSurfaceState { handle: Rc::downgrade(&liveliness) });
+        (*shell_surface).data = Box::into_raw(state) as *mut _;
+        WlShellSurface { liveliness: Some(liveliness),
+                         shell_surface }
+    }
+
+    unsafe fn from_handle(handle: &WlShellSurfaceHandle) -> Self {
+        WlShellSurface { liveliness: None,
+                         shell_surface: handle.as_ptr() }
+    }
+
+    /// Determines if this Wayland shell surface has been configured or not.
+    pub fn configured(&self) -> bool {
+        unsafe { (*self.shell_surface).configured }
+    }
+
+    pub fn popup_mapped(&self) -> bool {
+        unsafe { (*self.shell_surface).popup_mapped }
+    }
+
+    pub fn ping_serial(&self) -> u32 {
+        unsafe { (*self.shell_surface).ping_serial }
+    }
+
+    /// Get the title associated with this Wayland shell.
+    pub fn title(&self) -> String {
+        unsafe {
+            c_to_rust_string((*self.shell_surface).title).expect("Could not parse class as UTF-8")
+        }
+    }
+
+    /// Get the class associated with this Wayland shell.
+    pub fn class(&self) -> String {
+        unsafe {
+            c_to_rust_string((*self.shell_surface).class).expect("Could not parse class as UTF-8")
+        }
+    }
+
+    /// Send a ping to the surface.
+    ///
+    /// If the surface does not respond with a pong within a reasonable amount of time,
+    /// the ping timeout event will be emitted.
+    pub fn ping(&mut self) {
+        unsafe {
+            wlr_wl_shell_surface_ping(self.shell_surface);
+        }
+    }
+    /// Request that the surface configure itself to be the given size.
+    pub fn configure(&mut self, edges: WlShellSurfaceResize, width: i32, height: i32) {
+        unsafe {
+            wlr_wl_shell_surface_configure(self.shell_surface, edges, width, height);
+        }
+    }
+
+    /// Find a popup within this surface at the surface-local coordinates.
+    ///
+    /// Returns the popup and coordinates in the topmost surface coordinate system
+    /// or None if no popup is found at that location.
+    pub fn popup_at(&mut self,
+                    sx: f64,
+                    sy: f64,
+                    popup_sx: &mut f64,
+                    popup_sy: &mut f64)
+                    -> Option<WlShellSurfaceHandle> {
+        unsafe {
+            let popup_surface =
+                wlr_wl_shell_surface_popup_at(self.shell_surface, sx, sy, popup_sx, popup_sy);
+            if popup_surface.is_null() {
+                None
+            } else {
+                Some(WlShellSurfaceHandle::from_ptr(popup_surface))
+            }
+        }
+    }
+
+    /// Creates a weak reference to an `WlShellSurface`.
+    ///
+    /// # Panics
+    /// If this `WlShellSurface` is a previously upgraded `WlShellSurfaceHandle`,
+    /// then this function will panic.
+    pub fn weak_reference(&self) -> WlShellSurfaceHandle {
+        let arc = self.liveliness.as_ref()
+                      .expect("Cannot dowgrade a previously upgraded WlShellSurfaceHandle");
+        WlShellSurfaceHandle { handle: Rc::downgrade(arc),
+                               shell_surface: self.shell_surface }
+    }
+
+    /// Manually set the lock used to determine if a double-borrow is
+    /// occuring on this structure.
+    ///
+    /// # Panics
+    /// Panics when trying to set the lock on an upgraded handle.
+    pub(crate) unsafe fn set_lock(&self, val: bool) {
+        self.liveliness.as_ref()
+            .expect("Tried to set lock on borrowed WlShellSurface")
+            .store(val, Ordering::Release);
+    }
+}
+
+impl WlShellSurfaceHandle {
+    /// Creates a WlShellSurfaceHandle from the raw pointer, using the saved
+    /// user data to recreate the memory model.
+    pub(crate) unsafe fn from_ptr(shell_surface: *mut wlr_wl_shell_surface) -> Self {
+        let data = (*shell_surface).data as *mut WlShellSurfaceState;
+        if data.is_null() {
+            panic!("Cannot construct handle from a shell surface that has not been set up!");
+        }
+        let handle = (*data).handle.clone();
+        WlShellSurfaceHandle { handle,
+                               shell_surface }
+    }
+
+    /// Upgrades the wayland shell handle to a reference to the backing `WlShellSurface`.
+    ///
+    /// # Unsafety
+    /// This function is unsafe, because it creates an unbound `WlShellSurface`
+    /// which may live forever..
+    /// But no surface lives forever and might be disconnected at any time.
+    pub(crate) unsafe fn upgrade(&self) -> UpgradeHandleResult<WlShellSurface> {
+        self.handle.upgrade()
+            .ok_or(UpgradeHandleErr::AlreadyDropped)
+            // NOTE
+            // We drop the Rc here because having two would allow a dangling
+            // pointer to exist!
+            .and_then(|check| {
+                let shell_surface = WlShellSurface::from_handle(self);
+                if check.load(Ordering::Acquire) {
+                    return Err(UpgradeHandleErr::AlreadyBorrowed)
+                }
+                check.store(true, Ordering::Release);
+                Ok(shell_surface)
+            })
+    }
+
+    /// Run a function on the referenced WlShellSurface, if it still exists
+    ///
+    /// Returns the result of the function, if successful
+    ///
+    /// # Safety
+    /// By enforcing a rather harsh limit on the lifetime of the output
+    /// to a short lived scope of an anonymous function,
+    /// this function ensures the WlShellSurface does not live longer
+    /// than it exists.
+    ///
+    /// # Panics
+    /// This function will panic if multiple mutable borrows are detected.
+    /// This will happen if you call `upgrade` directly within this callback,
+    /// or if you run this function within the another run to the same `Output`.
+    ///
+    /// So don't nest `run` calls and everything will be ok :).
+    pub fn run<F, R>(&mut self, runner: F) -> UpgradeHandleResult<R>
+        where F: FnOnce(&mut WlShellSurface) -> R
+    {
+        let mut wl_shell_surface = unsafe { self.upgrade()? };
+        let res = panic::catch_unwind(panic::AssertUnwindSafe(|| runner(&mut wl_shell_surface)));
+        self.handle.upgrade().map(|check| {
+                                      // Sanity check that it hasn't been tampered with.
+                                      if !check.load(Ordering::Acquire) {
+                                          wlr_log!(L_ERROR,
+                                                   "After running WlShellSurface callback, \
+                                                    mutable lock was false for: {:?}",
+                                                   wl_shell_surface);
+                                          panic!("Lock in incorrect state!");
+                                      }
+                                      check.store(false, Ordering::Release);
+                                  });
+        match res {
+            Ok(res) => Ok(res),
+            Err(err) => panic::resume_unwind(err)
+        }
+    }
+
+    unsafe fn as_ptr(&self) -> *mut wlr_wl_shell_surface {
+        self.shell_surface
+    }
+}
+
+impl PartialEq for WlShellSurfaceHandle {
+    fn eq(&self, other: &WlShellSurfaceHandle) -> bool {
+        self.shell_surface == other.shell_surface
+    }
+}
+
+impl Eq for WlShellSurfaceHandle {}


### PR DESCRIPTION
Fixes #23.

Adds the ability to make a Wayland shell handler that handles incoming requests from clients.

Currently we don't have anything beyond a minimal wrapper for `Surface`s so there's no drawing done but the client and wlroots-rs can communicate over Wayland so it's a start.

# Compositor
* Added `WlShellManagerHandler` to builder.
* Made all of the handlers optional.
* Modified the setup process significantly.
  - Passes the Wayland shell manager the render pointer if GLES2 is enabled
  - Handles the cases where some number of the managers aren't enabled
  - Correctly set `WAYLAND_DISPLAY` so that clients can talk to the compositor

# WlShell
* Added `WlShellManagerHandler`, a way to manage incoming shell connections
* Added `WlShellHandler`, a trait you implement on the state you want to have for each Wayland shell client.
* Added the events for Wayland shells

# TODO
- [x] Make `wl_shell_test.rs` reproducible outside of my dev environment (e.g use the wayland client library here to spawn a client).
- [x] Add ability to get `SeatClient` from some of the events.
  - This type should be stubbed out, but should be finished in a different PR to ultimately do #32. 