### PR TITLE
Wlroots update

### DIFF
--- a/examples/pointer.rs
+++ b/examples/pointer.rs
@@ -111,7 +111,7 @@ impl OutputHandler for ExOutput {
             output.make_current();
             gl::ClearColor(state.color[0], state.color[1], state.color[2], 1.0);
             gl::Clear(gl::COLOR_BUFFER_BIT);
-            output.swap_buffers();
+            output.swap_buffers(None, None);
         }
     }
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -83,7 +83,7 @@ impl OutputHandler for ExOutput {
             output.make_current();
             gl::ClearColor(self.color[0], self.color[1], self.color[2], 1.0);
             gl::Clear(gl::COLOR_BUFFER_BIT);
-            output.swap_buffers()
+            output.swap_buffers(None, None);
         }
     }
 }

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -123,20 +123,16 @@ impl CompositorBuilder {
             // Set up input manager, if the user provided it.
             let input_manager = input_manager_handler.map(|handler| {
                 let mut input_manager = InputManager::new((vec![], handler));
-                wl_signal_add(&mut (*backend).events.input_add as *mut _ as _,
+                wl_signal_add(&mut (*backend).events.new_input as *mut _ as _,
                               input_manager.add_listener() as *mut _ as _);
-                wl_signal_add(&mut (*backend).events.input_remove as *mut _ as _,
-                              input_manager.remove_listener() as *mut _ as _);
                 input_manager
             });
 
             // Set up output manager, if the user provided it.
             let output_manager = output_manager_handler.map(|handler| {
                 let mut output_manager = OutputManager::new((vec![], handler));
-                wl_signal_add(&mut (*backend).events.output_add as *mut _ as _,
+                wl_signal_add(&mut (*backend).events.new_output as *mut _ as _,
                               output_manager.add_listener() as *mut _ as _);
-                wl_signal_add(&mut (*backend).events.output_remove as *mut _ as _,
-                              output_manager.remove_listener() as *mut _ as _);
                 output_manager
             });
 

--- a/src/manager/input_manager.rs
+++ b/src/manager/input_manager.rs
@@ -68,6 +68,7 @@ pub trait InputManagerHandler {
 wayland_listener!(InputManager, (Vec<Input>, Box<InputManagerHandler>), [
     add_listener => add_notify: |this: &mut InputManager, data: *mut libc::c_void,| unsafe {
         let data = data as *mut wlr_input_device;
+        let remove_listener = this.remove_listener()  as *mut _ as _;
         let (ref mut inputs, ref mut manager) = this.data;
         use self::wlr_input_device_type::*;
         let mut dev = InputDevice::from_ptr(data);
@@ -127,6 +128,8 @@ wayland_listener!(InputManager, (Vec<Input>, Box<InputManagerHandler>), [
             }
             manager.input_added(compositor, &mut dev)
         }));
+        wl_signal_add(&mut (*dev.as_ptr()).events.destroy as *mut _ as _,
+                      remove_listener);
         match res {
             Ok(_) => {},
             // NOTE

--- a/src/manager/output_handler.rs
+++ b/src/manager/output_handler.rs
@@ -23,9 +23,6 @@ pub trait OutputHandler {
 
     /// Called every time the buffers are swapped on an output.
     fn on_buffers_swapped(&mut self, &mut Compositor, &mut Output) {}
-
-    /// Called when an output is destroyed.
-    fn on_destroy(&mut self, &mut Compositor, &mut Output) {}
 }
 
 wayland_listener!(UserOutput, (Output, Box<OutputHandler>), [
@@ -72,14 +69,6 @@ wayland_listener!(UserOutput, (Output, Box<OutputHandler>), [
         let compositor = &mut *COMPOSITOR_PTR;
         output.set_lock(true);
         manager.on_buffers_swapped(compositor, output);
-        output.set_lock(false);
-    };
-    destroy_listener => destroy_notify: |this: &mut UserOutput, _output: *mut libc::c_void,|
-    unsafe {
-        let (ref mut output, ref mut manager) = this.data;
-        let compositor = &mut *COMPOSITOR_PTR;
-        output.set_lock(true);
-        manager.on_destroy(compositor, output);
         output.set_lock(false);
     };
 ]);

--- a/src/manager/output_manager.rs
+++ b/src/manager/output_manager.rs
@@ -66,6 +66,7 @@ impl<'output> OutputDestruction<'output> {
 
 wayland_listener!(OutputManager, (Vec<Box<UserOutput>>, Box<OutputManagerHandler>), [
     add_listener => add_notify: |this: &mut OutputManager, data: *mut libc::c_void,| unsafe {
+        let remove_listener = this.remove_listener()  as *mut _ as _;
         let (ref mut outputs, ref mut manager) = this.data;
         let data = data as *mut wlr_output;
         let mut output = Output::new(data as *mut wlr_output);
@@ -118,7 +119,7 @@ wayland_listener!(OutputManager, (Vec<Box<UserOutput>>, Box<OutputManagerHandler
                           output.swap_buffers_listener() as _);
             // Add the output destroy event to this manager
             wl_signal_add(&mut (*data).events.destroy as *mut _ as _,
-                          output.destroy_listener() as _);
+                          remove_listener);
             // Store the user UserOutput, free later in remove listener
             outputs.push(output);
         }

--- a/src/render/renderer.rs
+++ b/src/render/renderer.rs
@@ -105,7 +105,8 @@ impl<'output> Drop for Renderer<'output> {
     fn drop(&mut self) {
         unsafe {
             wlr_renderer_end(self.renderer);
-            self.output.swap_buffers();
+            // TODO What about damage tracking?
+            self.output.swap_buffers(None, None);
         }
     }
 }

--- a/src/types/area.rs
+++ b/src/types/area.rs
@@ -128,10 +128,10 @@ impl Area {
     /// output transformation.
     ///
     /// e.g: If it's `WL_OUTPUT_TRANSFORM_90` then it will flip the Area 90° clockwise.
-    pub fn transform(&mut self, transform: wl_output_transform) -> Area {
+    pub fn transform(&mut self, transform: wl_output_transform, width: c_int, height: c_int) -> Area {
         unsafe {
             let mut res = Area::default();
-            wlr_box_transform(&mut self.0, transform, &mut res.0);
+            wlr_box_transform(&mut self.0, transform, width, height, &mut res.0);
             res
         }
     }

--- a/src/types/area.rs
+++ b/src/types/area.rs
@@ -128,7 +128,11 @@ impl Area {
     /// output transformation.
     ///
     /// e.g: If it's `WL_OUTPUT_TRANSFORM_90` then it will flip the Area 90° clockwise.
-    pub fn transform(&mut self, transform: wl_output_transform, width: c_int, height: c_int) -> Area {
+    pub fn transform(&mut self,
+                     transform: wl_output_transform,
+                     width: c_int,
+                     height: c_int)
+                     -> Area {
         unsafe {
             let mut res = Area::default();
             wlr_box_transform(&mut self.0, transform, width, height, &mut res.0);

--- a/src/types/keyboard.rs
+++ b/src/types/keyboard.rs
@@ -9,6 +9,7 @@ use wlroots_sys::{wlr_input_device, wlr_key_state, wlr_keyboard, wlr_keyboard_ge
                   wlr_keyboard_modifiers, wlr_keyboard_set_keymap};
 
 use xkbcommon::xkb::{self, Keycode, Keymap, LedIndex, ModIndex};
+use xkbcommon::xkb::ffi::{xkb_keymap, xkb_state};
 
 use InputDevice;
 
@@ -104,7 +105,7 @@ impl Keyboard {
     /// Get the XKB keymap associated with this Keyboard.
     pub fn get_keymap(&mut self) -> Option<Keymap> {
         unsafe {
-            let keymap_ptr = (*self.keyboard).keymap as *mut _;
+            let keymap_ptr = (*self.keyboard).keymap as *mut xkb_keymap;
             if keymap_ptr.is_null() {
                 None
             } else {
@@ -144,7 +145,7 @@ impl Keyboard {
     /// Get the XKB state associated with this `Keyboard`.
     pub fn get_xkb_state(&mut self) -> Option<xkb::State> {
         unsafe {
-            let xkb_state_ptr = (*self.keyboard).xkb_state as *mut _;
+            let xkb_state_ptr = (*self.keyboard).xkb_state as *mut xkb_state;
             if xkb_state_ptr.is_null() {
                 None
             } else {

--- a/src/types/output/output.rs
+++ b/src/types/output/output.rs
@@ -1,19 +1,19 @@
 //! TODO Documentation
 
 use std::{panic, ptr};
-use std::time::Duration;
 use std::ffi::CStr;
 use std::rc::{Rc, Weak};
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 
 use libc::{c_float, c_int};
 use wayland_sys::server::WAYLAND_SERVER_HANDLE;
-use wlroots_sys::{wl_list, wl_output_subpixel, wl_output_transform, wlr_output,
+use wlroots_sys::{timespec, wl_list, wl_output_subpixel, wl_output_transform, wlr_output,
                   wlr_output_effective_resolution, wlr_output_enable, wlr_output_get_gamma_size,
                   wlr_output_make_current, wlr_output_mode, wlr_output_set_custom_mode,
                   wlr_output_set_fullscreen_surface, wlr_output_set_gamma, wlr_output_set_mode,
                   wlr_output_set_position, wlr_output_set_scale, wlr_output_set_transform,
-                  wlr_output_swap_buffers, pixman_region32_t, timespec};
+                  wlr_output_swap_buffers, pixman_region32_t};
 
 use super::output_layout::OutputLayoutHandle;
 use super::output_mode::OutputMode;
@@ -303,13 +303,16 @@ impl Output {
     /// You should try to use a `GenericRenderer`, but sometimes it's necessary to
     /// do your own manual rendering in a compositor. In that case, call `make_current`,
     /// do your rendering, and then call this function.
-    pub unsafe fn swap_buffers(&mut self, when: Option<Duration>, damage: Option<*mut pixman_region32_t>) -> bool {
-        let when = when.map(|duration|
-                            timespec { tv_sec: duration.as_secs() as i64,
-                                       tv_nsec: duration.subsec_nanos() as i64
+    pub unsafe fn swap_buffers(&mut self,
+                               when: Option<Duration>,
+                               damage: Option<*mut pixman_region32_t>)
+                               -> bool {
+        let when = when.map(|duration| {
+                                timespec { tv_sec: duration.as_secs() as i64,
+                                           tv_nsec: duration.subsec_nanos() as i64 }
                             });
-        let when_ptr = when.map(|mut duration| &mut duration as *mut _)
-            .unwrap_or_else(|| ptr::null_mut());
+        let when_ptr =
+            when.map(|mut duration| &mut duration as *mut _).unwrap_or_else(|| ptr::null_mut());
         let damage = damage.unwrap_or_else(|| ptr::null_mut());
         wlr_output_swap_buffers(self.output, when_ptr, damage)
     }

--- a/src/types/surface.rs
+++ b/src/types/surface.rs
@@ -149,12 +149,12 @@ impl Surface {
     /// Returns the surface and coordinates in the topmost surface coordinate system
     /// or None if no subsurface is found at that location.
     pub fn subsurface_at(&mut self,
-                         sx: f32,
-                         sy: f32,
-                         sub_x: &mut f32,
-                         sub_y: &mut f32)
+                         _sx: f32,
+                         _sy: f32,
+                         _sub_x: &mut f32,
+                         _sub_y: &mut f32)
                          -> Option<SubsurfaceHandle> {
-        None
+        unimplemented!()
     }
 
     /// Create the subsurface implementation for this surface.


### PR DESCRIPTION
# wlroots
* Updated wlroots to 7da653bbb4569d41ce1a46c97e3b10c675f73741

# OutputManager
* No longer has a callback for a destruction of any output (it was made redundant)

# Buffers
* `swap_buffers` now takes in optional values used for damage tracking, which are currently not utilized by wlroots-rs.
* `make_current` now returns information useful for damage tracking.
* Renderer does not do damage tracking, an API to enable this gracefully will be added in the future.

# Area
* `Area::transform` now takes a `width` and `height`.