### PR TITLE
Implemented Seat

### DIFF
--- a/examples/wl_shell_test.rs
+++ b/examples/wl_shell_test.rs
@@ -26,7 +26,7 @@ struct State {
     xcursor_theme: XCursorTheme,
     layout: OutputLayout,
     shells: Vec<WlShellSurfaceHandle>,
-    seat: Option<Seat>
+    seat: Option<Box<Seat>>
 }
 
 impl State {
@@ -304,7 +304,7 @@ fn main() {
                                                              Some(Box::new(InputManager)),
                                                              Some(Box::new(OutputManager)),
                                                              Some(Box::new(WlShellManager)));
-    let seat = Seat::new(&mut compositor, "Main Seat".into(), Box::new(SeatHandlerEx))
+    let seat = Seat::create(&mut compositor, "Main Seat".into(), Box::new(SeatHandlerEx))
         .expect("Could not allocate the global seat");
     {
         let state: &mut State = (&mut compositor).into();

--- a/examples/wl_shell_test.rs
+++ b/examples/wl_shell_test.rs
@@ -274,8 +274,8 @@ impl OutputHandler for ExOutput {
             return
         }
         let renderer = compositor.renderer
-            .as_mut()
-            .expect("Compositor was not loaded with a renderer");
+                                 .as_mut()
+                                 .expect("Compositor was not loaded with a renderer");
         render_shells(state, &mut renderer.render(output));
     }
 }

--- a/examples/wl_shell_test.rs
+++ b/examples/wl_shell_test.rs
@@ -25,8 +25,7 @@ struct State {
     default_color: [f32; 4],
     xcursor_theme: XCursorTheme,
     layout: OutputLayout,
-    shells: Vec<WlShellSurfaceHandle>,
-    seat: Option<Box<Seat>>
+    shells: Vec<WlShellSurfaceHandle>
 }
 
 impl State {
@@ -35,8 +34,7 @@ impl State {
                 default_color: [0.25, 0.25, 0.25, 1.0],
                 xcursor_theme,
                 layout,
-                shells: vec![],
-                seat: None }
+                shells: vec![] }
     }
 }
 
@@ -304,12 +302,8 @@ fn main() {
                                                              Some(Box::new(InputManager)),
                                                              Some(Box::new(OutputManager)),
                                                              Some(Box::new(WlShellManager)));
-    let seat = Seat::create(&mut compositor, "Main Seat".into(), Box::new(SeatHandlerEx))
+    Seat::create(&mut compositor, "Main Seat".into(), Box::new(SeatHandlerEx))
         .expect("Could not allocate the global seat");
-    {
-        let state: &mut State = (&mut compositor).into();
-        state.seat = Some(seat);
-    }
     compositor.run();
 }
 

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -31,7 +31,7 @@ pub struct Compositor {
     /// This is stored here due to their complicated memory model.
     ///
     /// Please refer to the `Seat` documentation to learn how to use this.
-    seats: HashMap<String, Box<Seat>>,
+    pub seats: HashMap<String, Box<Seat>>,
     /// Manager for the inputs.
     input_manager: Option<Box<InputManager>>,
     /// Manager for the outputs.
@@ -224,11 +224,6 @@ impl Compositor {
         }
     }
 
-    /// Returns a list of the seats.
-    pub fn seat(&mut self, name: &str) -> Option<&mut Box<Seat>> {
-        self.seats.get_mut(name)
-    }
-
     /// Adds a seat to the list and then returns a reference to it.
     pub(crate) fn add_seat(&mut self, seat: Box<Seat>) -> &mut Box<Seat> {
         let name = seat.name().expect("Could not get seat name");
@@ -236,26 +231,12 @@ impl Compositor {
         self.seats.get_mut(name.as_str()).unwrap()
     }
 
-    /// Drops the seat associated with the provided name.
-    // TODO FIXME Better result types
-    pub fn drop_seat(&mut self, name: &str) -> Result<(), ()> {
-        match self.seats.remove(name) {
-            None => return Err(()), // TODO Better error here
-            Some(_seat) => Ok(())
-        }
-    }
-
     /// Takes the seat from the list and returns it.
     ///
     /// In its place it places a borrow, so that we can return it afterwards
     /// using `replace_seat`.
-    ///
-    /// # Panics
-    /// Panics if the `SeatId` is invalid or already borrowed.
-    // TODO Better errors, don't panic on these things
-    pub(crate) fn take_seat(&mut self, name: &str) -> Box<Seat> {
+    pub(crate) fn take_seat(&mut self, name: &str) -> Option<Box<Seat>> {
         self.seats.remove(name)
-            .expect("Seat did not exist, or was already borrowed")
     }
 
     /// Replaces the Borrowed in the list with the seat.

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -4,8 +4,8 @@
 use std::{env, ptr};
 use std::any::Any;
 use std::cell::UnsafeCell;
-use std::ffi::CStr;
 use std::collections::HashMap;
+use std::ffi::CStr;
 
 use extensions::server_decoration::ServerDecorationManager;
 use manager::{InputManager, InputManagerHandler, OutputManager, OutputManagerHandler,
@@ -254,7 +254,8 @@ impl Compositor {
     /// Panics if the `SeatId` is invalid or already borrowed.
     // TODO Better errors, don't panic on these things
     pub(crate) fn take_seat(&mut self, name: &str) -> Box<Seat> {
-        self.seats.remove(name).expect("Seat did not exist, or was already borrowed")
+        self.seats.remove(name)
+            .expect("Seat did not exist, or was already borrowed")
     }
 
     /// Replaces the Borrowed in the list with the seat.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,14 +7,6 @@
 //!
 //! # Example
 //! ```rust,no_run
-//! extern crate wlroots;
-//!
-//! fn main() {
-//!     wlroots::CompositorBuilder::new()
-//!          .build_auto((), // Dummy state
-//!                      None, None, None)
-//!          .run()
-//! }
 //! ```
 
 #![allow(unused_unsafe)]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -170,12 +170,12 @@ macro_rules! wayland_listener {
                 })
             }
 
-            $($(pub unsafe extern "C" fn $listener(&mut self)
+            $($(pub(crate) unsafe extern "C" fn $listener(&mut self)
                                                    -> *mut $crate::wlroots_sys::wl_listener {
                 &mut self.$listener as *mut _
             })*)*
 
-            $($(pub unsafe extern "C" fn $listener_func(listener:
+            $($(pub(crate) unsafe extern "C" fn $listener_func(listener:
                                                         *mut $crate::wlroots_sys::wl_listener,
                                                         data: *mut libc::c_void) {
                 let manager: &mut $struct_name = &mut (*container_of!(listener,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -151,7 +151,7 @@ macro_rules! wayland_listener {
         }
 
         impl $struct_name {
-            pub fn new(data: $data) -> Box<$struct_name> {
+            pub(crate) fn new(data: $data) -> Box<$struct_name> {
                 use $crate::wayland_sys::server::WAYLAND_SERVER_HANDLE;
                 Box::new($struct_name {
                     data,

--- a/src/manager/input_manager.rs
+++ b/src/manager/input_manager.rs
@@ -145,6 +145,10 @@ wayland_listener!(InputManager, (Vec<Input>, Box<InputManagerHandler>), [
     remove_listener => remove_notify: |this: &mut InputManager, data: *mut libc::c_void,| unsafe {
         let data = data as *mut wlr_input_device;
         let (ref mut inputs, ref mut manager) = this.data;
+        if COMPOSITOR_PTR.is_null() {
+            // We are shutting down, do nothing.
+            return;
+        }
         let compositor = &mut *COMPOSITOR_PTR;
         manager.input_removed(compositor, &mut InputDevice::from_ptr(data));
         // Remove user output data

--- a/src/manager/wl_shell_handler.rs
+++ b/src/manager/wl_shell_handler.rs
@@ -60,6 +60,10 @@ wayland_listener!(WlShell, (WlShellSurface, Surface, Box<WlShellHandler>), [
         // TODO NLL
         {
             let (ref mut shell_surface, ref mut surface, ref mut manager) = this.data;
+            if COMPOSITOR_PTR.is_null() {
+                // We are shutting down, do nothing.
+                return;
+            }
             let compositor = &mut *COMPOSITOR_PTR;
             shell_surface.set_lock(true);
             surface.set_lock(true);

--- a/src/types/output/output.rs
+++ b/src/types/output/output.rs
@@ -10,10 +10,11 @@ use libc::{c_float, c_int};
 use wayland_sys::server::WAYLAND_SERVER_HANDLE;
 use wlroots_sys::{timespec, wl_list, wl_output_subpixel, wl_output_transform, wlr_output,
                   wlr_output_effective_resolution, wlr_output_enable, wlr_output_get_gamma_size,
-                  wlr_output_make_current, wlr_output_mode, wlr_output_set_custom_mode,
-                  wlr_output_set_fullscreen_surface, wlr_output_set_gamma, wlr_output_set_mode,
-                  wlr_output_set_position, wlr_output_set_scale, wlr_output_set_transform,
-                  wlr_output_swap_buffers, pixman_region32_t, wlr_output_schedule_frame};
+                  wlr_output_make_current, wlr_output_mode, wlr_output_schedule_frame,
+                  wlr_output_set_custom_mode, wlr_output_set_fullscreen_surface,
+                  wlr_output_set_gamma, wlr_output_set_mode, wlr_output_set_position,
+                  wlr_output_set_scale, wlr_output_set_transform, wlr_output_swap_buffers,
+                  pixman_region32_t};
 
 use super::output_layout::OutputLayoutHandle;
 use super::output_mode::OutputMode;

--- a/src/types/output/output.rs
+++ b/src/types/output/output.rs
@@ -13,7 +13,7 @@ use wlroots_sys::{timespec, wl_list, wl_output_subpixel, wl_output_transform, wl
                   wlr_output_make_current, wlr_output_mode, wlr_output_set_custom_mode,
                   wlr_output_set_fullscreen_surface, wlr_output_set_gamma, wlr_output_set_mode,
                   wlr_output_set_position, wlr_output_set_scale, wlr_output_set_transform,
-                  wlr_output_swap_buffers, pixman_region32_t};
+                  wlr_output_swap_buffers, pixman_region32_t, wlr_output_schedule_frame};
 
 use super::output_layout::OutputLayoutHandle;
 use super::output_mode::OutputMode;
@@ -266,6 +266,13 @@ impl Output {
     /// Get the transform information about the output.
     pub fn get_transform(&self) -> Transform {
         unsafe { (*self.output).transform }
+    }
+
+    /// Manually schedules a `frame` event.
+    ///
+    /// If a `frame` event is already pending, it is a no-op.
+    pub fn schedule_frame(&mut self) {
+        unsafe { wlr_output_schedule_frame(self.output) }
     }
 
     /// Make this output the current output.

--- a/src/types/seat/mod.rs
+++ b/src/types/seat/mod.rs
@@ -7,3 +7,46 @@ pub use self::grab::*;
 pub use self::seat::*;
 pub use self::seat_client::*;
 pub use self::touch_point::*;
+
+pub use seat::Seat;
+use std::collections::HashMap;
+
+/// A wrapper around the mapping of name -> `Seat`.
+///
+/// This is to ensure you can't move the Seat out of the box,
+/// or do other weird things to it.
+///
+/// To add a `Seat` to this, please use `Seat::create`
+#[derive(Debug, Default)]
+pub struct Seats(HashMap<String, Box<Seat>>);
+
+impl Seats {
+    /// Gets a mutable reference to a seat by name.
+    ///
+    /// To add a Seat, please use `Seat::create`.
+    ///
+    /// A seat cannot be accessed while it is in a callback. To use it,
+    /// you should instead use the Seat value that's passed in the callback.
+    ///
+    /// Returns `None` if the seat has been removed or the name is incorrect.
+    pub fn get(&mut self, name: &str) -> Option<&mut Box<Seat>> {
+        self.0.get_mut(name)
+    }
+
+    /// Add a new seat to the mapping.
+    pub(crate) fn insert(&mut self, seat: Box<Seat>) -> &mut Box<Seat> {
+        let name = seat.name().expect("Could not get seat name");
+        self.0.insert(name.clone(), seat);
+        self.0.get_mut(name.as_str()).unwrap()
+    }
+
+    /// Take the seat from the mapping.
+    ///
+    /// This is either done to destroy it (in the destroy callback)
+    /// or to borrow it uniquely for a time (e.g in all other Seat callbacks).
+    ///
+    /// If the seat does not exist, then `None` is returned.
+    pub(crate) fn remove(&mut self, name: &str) -> Option<Box<Seat>> {
+        self.0.remove(name)
+    }
+}

--- a/src/types/seat/seat.rs
+++ b/src/types/seat/seat.rs
@@ -3,7 +3,7 @@
 //!
 //! TODO This module could really use some examples, as the API surface is huge.
 
-use std::cell::RefCell;
+use std::cell::{RefCell, RefMut};
 use std::time::Duration;
 
 use libc;
@@ -38,123 +38,118 @@ use utils::ToMS;
 
 pub trait SeatHandler {
     /// Callback triggered when a client has grabbed a pointer.
-    fn pointer_grabbed(&mut self, &mut Compositor, &Seat, &mut PointerGrab) {}
+    fn pointer_grabbed(&mut self, &mut Compositor, &mut SeatInner, &mut PointerGrab) {}
 
     /// Callback triggered when a client has ended a pointer grab.
-    fn pointer_released(&mut self, &mut Compositor, &Seat, &mut PointerGrab) {}
+    fn pointer_released(&mut self, &mut Compositor, &mut SeatInner, &mut PointerGrab) {}
 
     /// Callback triggered when a client has grabbed a keyboard.
-    fn keyboard_grabbed(&mut self, &mut Compositor, &Seat, &mut KeyboardGrab) {}
+    fn keyboard_grabbed(&mut self, &mut Compositor, &mut SeatInner, &mut KeyboardGrab) {}
 
     /// Callback triggered when a client has ended a keyboard grab.
-    fn keyboard_released(&mut self, &mut Compositor, &Seat, &mut KeyboardGrab) {}
+    fn keyboard_released(&mut self, &mut Compositor, &mut SeatInner, &mut KeyboardGrab) {}
 
     /// Callback triggered when a client has grabbed a touch.
-    fn touch_grabbed(&mut self, &mut Compositor, &Seat, &mut TouchGrab) {}
+    fn touch_grabbed(&mut self, &mut Compositor, &mut SeatInner, &mut TouchGrab) {}
 
     /// Callback triggered when a client has ended a touch grab.
-    fn touch_released(&mut self, &mut Compositor, &Seat, &mut TouchGrab) {}
+    fn touch_released(&mut self, &mut Compositor, &mut SeatInner, &mut TouchGrab) {}
 
     /* TODO FIXME wlr_seat_pointer_request_set_cursor_event */
-    fn cursor_set(&mut self, &mut Compositor, &Seat) {}
+    fn cursor_set(&mut self, &mut Compositor, &mut SeatInner) {}
 
     /// The seat was provided with a selection by the client.
-    fn received_selection(&mut self, &mut Compositor, &Seat) {}
+    fn received_selection(&mut self, &mut Compositor, &mut SeatInner) {}
 
     /// The seat was provided with a selection from the primary buffer
     /// by the client.
-    fn primary_selection(&mut self, &mut Compositor, &Seat) {}
+    fn primary_selection(&mut self, &mut Compositor, &mut SeatInner) {}
 
     /// The seat is being destroyed.
-    fn destroy(&mut self, &mut Compositor, &Seat) {}
+    fn destroy(&mut self, &mut Compositor, &mut SeatInner) {}
 }
 
-/// The structure that contains all actual seat pointers.
+/// The structure that contains the actual seat pointer.
 ///
 /// This is here so that we can ensure unique access.
 pub struct SeatInner {
-    handler: Box<SeatHandler>,
     seat: *mut wlr_seat
 }
 
-// TODO FIXME This memory model is totally broken...
-// you can't even borrow the Seat properly in the callback,
-// so that's bogus
-
-wayland_listener!(Seat, RefCell<SeatInner>, [
+wayland_listener!(Seat, (RefCell<SeatInner>, Box<SeatHandler>), [
     pointer_grab_begin_listener => pointer_grab_begin_notify: |this: &mut Seat,
                                                                event: *mut libc::c_void,|
     unsafe {
-        let mut inner = this.data.borrow_mut();
+        let handler = &mut this.data.1;
         let compositor = &mut *COMPOSITOR_PTR;
         let pointer_grab = &mut *(event as *mut PointerGrab);
-        inner.handler.pointer_grabbed(compositor, &*this, pointer_grab);
+        handler.pointer_grabbed(compositor, &mut *this.data.0.borrow_mut(), pointer_grab);
     };
     pointer_grab_end_listener => pointer_grab_end_notify: |this: &mut Seat,
     event: *mut libc::c_void,|
     unsafe {
-        let mut inner = this.data.borrow_mut();
+        let handler = &mut this.data.1;
         let compositor = &mut *COMPOSITOR_PTR;
         let pointer_grab = &mut *(event as *mut PointerGrab);
-        inner.handler.pointer_released(compositor, &*this, pointer_grab);
+        handler.pointer_released(compositor, &mut *this.data.0.borrow_mut(), pointer_grab);
     };
     keyboard_grab_begin_listener => keyboard_grab_begin_notify: |this: &mut Seat,
     event: *mut libc::c_void,|
     unsafe {
-        let mut inner = this.data.borrow_mut();
+        let handler = &mut this.data.1;
         let compositor = &mut *COMPOSITOR_PTR;
         let keyboard_grab = &mut *(event as *mut KeyboardGrab);
-        inner.handler.keyboard_grabbed(compositor, &*this, keyboard_grab);
+        handler.keyboard_grabbed(compositor, &mut *this.data.0.borrow_mut(), keyboard_grab);
     };
     keyboard_grab_end_listener => keyboard_grab_end_notify: |this: &mut Seat,
     event: *mut libc::c_void,|
     unsafe {
-        let mut inner = this.data.borrow_mut();
+        let handler = &mut this.data.1;
         let compositor = &mut *COMPOSITOR_PTR;
         let keyboard_grab = &mut *(event as *mut KeyboardGrab);
-        inner.handler.keyboard_released(compositor, &*this, keyboard_grab);
+        handler.keyboard_released(compositor, &mut *this.data.0.borrow_mut(), keyboard_grab);
     };
     touch_grab_begin_listener => touch_grab_begin_notify: |this: &mut Seat,
     event: *mut libc::c_void,|
     unsafe {
-        let mut inner = this.data.borrow_mut();
+        let handler = &mut this.data.1;
         let compositor = &mut *COMPOSITOR_PTR;
         let touch_grab = &mut *(event as *mut TouchGrab);
-        inner.handler.touch_grabbed(compositor, &*this, touch_grab);
+        handler.touch_grabbed(compositor, &mut *this.data.0.borrow_mut(), touch_grab);
     };
     touch_grab_end_listener => touch_grab_end_notify: |this: &mut Seat,
     event: *mut libc::c_void,|
     unsafe {
-        let mut inner = this.data.borrow_mut();
+        let handler = &mut this.data.1;
         let compositor = &mut *COMPOSITOR_PTR;
         let touch_grab = &mut *(event as *mut TouchGrab);
-        inner.handler.touch_released(compositor, &*this, touch_grab);
+        handler.touch_released(compositor, &mut *this.data.0.borrow_mut(), touch_grab);
     };
     request_set_cursor_listener => request_set_cursor_notify: |this: &mut Seat,
     _event: *mut libc::c_void,|
     unsafe {
-        let mut inner = this.data.borrow_mut();
+        let handler = &mut this.data.1;
         let compositor = &mut *COMPOSITOR_PTR;
-        inner.handler.cursor_set(compositor, &*this);
+        handler.cursor_set(compositor, &mut *this.data.0.borrow_mut());
     };
     selection_listener => selection_notify: |this: &mut Seat, _event: *mut libc::c_void,|
     unsafe {
-        let mut inner = this.data.borrow_mut();
+        let handler = &mut this.data.1;
         let compositor = &mut *COMPOSITOR_PTR;
-        inner.handler.received_selection(compositor, &*this);
+        handler.received_selection(compositor, &mut *this.data.0.borrow_mut());
     };
     primary_selection_listener => primary_selection_notify: |this: &mut Seat,
     _event: *mut libc::c_void,|
     unsafe {
-        let mut inner = this.data.borrow_mut();
+        let handler = &mut this.data.1;
         let compositor = &mut *COMPOSITOR_PTR;
-        inner.handler.primary_selection(compositor, &*this);
+        handler.primary_selection(compositor, &mut *this.data.0.borrow_mut());
     };
     destroy_listener => destroy_notify: |this: &mut Seat, _event: *mut libc::c_void,|
     unsafe {
-        let mut inner = this.data.borrow_mut();
+        let handler = &mut this.data.1;
         let compositor = &mut *COMPOSITOR_PTR;
-        inner.handler.destroy(compositor, &*this);
+        handler.destroy(compositor, &mut *this.data.0.borrow_mut());
     };
 ]);
 
@@ -176,7 +171,7 @@ impl Seat {
             if seat.is_null() {
                 None
             } else {
-                let mut res = Seat::new(RefCell::new(SeatInner { seat, handler }));
+                let mut res = Seat::new((RefCell::new(SeatInner { seat }), handler));
                 wl_signal_add(&mut (*seat).events.pointer_grab_begin as *mut _ as _,
                               res.pointer_grab_begin_listener() as *mut _ as _);
                 wl_signal_add(&mut (*seat).events.pointer_grab_end as *mut _ as _,
@@ -202,11 +197,20 @@ impl Seat {
         }
     }
 
+    /// Gets the inner seat that is usable.
+    ///
+    /// This struct is behind a `RefCell`, don't call this multiple times
+    /// unless you want to panic!
+    pub fn inner(&self) -> RefMut<SeatInner> {
+        self.data.0.borrow_mut()
+    }
+}
+
+impl SeatInner {
     /// Get the name of the seat.
     pub fn name(&self) -> Option<String> {
-        let seat = self.data.borrow();
         unsafe {
-            let name_ptr = (*seat.seat).name;
+            let name_ptr = (*self.seat).name;
             if name_ptr.is_null() {
                 return None
             }
@@ -216,31 +220,27 @@ impl Seat {
 
     /// Updates the name of this seat.
     /// Will automatically send it to all clients.
-    pub fn set_name(&self, name: String) {
-        let seat = self.data.borrow();
+    pub fn set_name(&mut self, name: String) {
         let name = safe_as_cstring(name);
         unsafe {
-            wlr_seat_set_name(seat.seat, name.as_ptr());
+            wlr_seat_set_name(self.seat, name.as_ptr());
         }
     }
 
     /// Gets the capabilities of this seat.
     pub fn capabilities(&self) -> Capability {
-        let seat = self.data.borrow();
-        unsafe { Capability::from_raw((*seat.seat).capabilities).expect("Invalid capabilities") }
+        unsafe { Capability::from_raw((*self.seat).capabilities).expect("Invalid capabilities") }
     }
 
     /// Updates the capabilities available on this seat.
     /// Will automatically send it to all clients.
     pub fn set_capabilities(&self, capabilities: Capability) {
-        let seat = self.data.borrow();
-        unsafe { wlr_seat_set_capabilities(seat.seat, capabilities.bits()) }
+        unsafe { wlr_seat_set_capabilities(self.seat, capabilities.bits()) }
     }
 
     /// Determines if the surface has pointer focus.
     pub fn pointer_surface_has_focus(&self, surface: &mut Surface) -> bool {
-        let seat = self.data.borrow();
-        unsafe { wlr_seat_pointer_surface_has_focus(seat.seat, surface.as_ptr()) }
+        unsafe { wlr_seat_pointer_surface_has_focus(self.seat, surface.as_ptr()) }
     }
 
     // Sends a pointer enter event to the given surface and considers it to be
@@ -253,17 +253,15 @@ impl Seat {
     // Compositor should use `Seat::pointer_notify_enter` to
     // change pointer focus to respect pointer grabs.
     pub fn pointer_enter(&self, surface: &mut Surface, sx: f64, sy: f64) {
-        let seat = self.data.borrow();
         unsafe {
-            wlr_seat_pointer_enter(seat.seat, surface.as_ptr(), sx, sy);
+            wlr_seat_pointer_enter(self.seat, surface.as_ptr(), sx, sy);
         }
     }
 
     /// Clears the focused surface for the pointer and leaves all entered
     /// surfaces.
     pub fn clear_focus(&self) {
-        let seat = self.data.borrow();
-        unsafe { wlr_seat_pointer_clear_focus(seat.seat) }
+        unsafe { wlr_seat_pointer_clear_focus(self.seat) }
     }
 
     /// Sends a motion event to the surface with pointer focus.
@@ -273,8 +271,7 @@ impl Seat {
     /// Compositors should use `Seat::notify_motion` to
     /// send motion events to the respect pointer grabs.
     pub fn send_motion(&self, time: Duration, sx: f64, sy: f64) {
-        let seat = self.data.borrow();
-        unsafe { wlr_seat_pointer_send_motion(seat.seat, time.to_ms(), sx, sy) }
+        unsafe { wlr_seat_pointer_send_motion(self.seat, time.to_ms(), sx, sy) }
     }
 
     // TODO Button and State should probably be wrapped in some sort of type...
@@ -288,8 +285,7 @@ impl Seat {
     /// Compositors should use `Seat::notify_button` to
     /// send button events to respect pointer grabs.
     pub fn send_button(&self, time: Duration, button: u32, state: u32) -> u32 {
-        let seat = self.data.borrow();
-        unsafe { wlr_seat_pointer_send_button(seat.seat, time.to_ms(), button, state) }
+        unsafe { wlr_seat_pointer_send_button(self.seat, time.to_ms(), button, state) }
     }
 
     /// Send an axis event to the surface with pointer focus.
@@ -297,37 +293,32 @@ impl Seat {
     /// Compositors should use `Seat::notify_axis` to
     /// send axis events to respect pointer grabs.
     pub fn send_axis(&self, time: Duration, orientation: wlr_axis_orientation, value: f64) {
-        let seat = self.data.borrow();
         unsafe {
-            wlr_seat_pointer_send_axis(seat.seat, time.to_ms(), orientation, value);
+            wlr_seat_pointer_send_axis(self.seat, time.to_ms(), orientation, value);
         }
     }
 
     /// Start a grab of the pointer of this seat. The grabber is responsible for
     /// handling all pointer events until the grab ends.
     pub fn pointer_start_grab(&self, grab: PointerGrab) {
-        let seat = self.data.borrow();
-        unsafe { wlr_seat_pointer_start_grab(seat.seat, grab.as_ptr()) }
+        unsafe { wlr_seat_pointer_start_grab(self.seat, grab.as_ptr()) }
     }
 
     /// End the grab of the pointer of this seat. This reverts the grab back to the
     /// default grab for the pointer.
     pub fn pointer_end_grab(&self) {
-        let seat = self.data.borrow();
-        unsafe { wlr_seat_pointer_end_grab(seat.seat) }
+        unsafe { wlr_seat_pointer_end_grab(self.seat) }
     }
 
     /// Whether or not the pointer has a grab other than the default grab.
     pub fn pointer_has_grab(&self) -> bool {
-        let seat = self.data.borrow();
-        unsafe { wlr_seat_pointer_has_grab(seat.seat) }
+        unsafe { wlr_seat_pointer_has_grab(self.seat) }
     }
 
     /// Clear the focused surface for the pointer and leave all entered
     /// surfaces.
     pub fn pointer_clear_focus(&self) {
-        let seat = self.data.borrow();
-        unsafe { wlr_seat_pointer_clear_focus(seat.seat) }
+        unsafe { wlr_seat_pointer_clear_focus(self.seat) }
     }
 
     /// Notify the seat of a pointer enter event to the given surface and request it
@@ -335,16 +326,14 @@ impl Seat {
     ///
     /// Pass surface-local coordinates where the enter occurred.
     pub fn pointer_notify_enter(&self, surface: &mut Surface, sx: f64, sy: f64) {
-        let seat = self.data.borrow();
-        unsafe { wlr_seat_pointer_notify_enter(seat.seat, surface.as_ptr(), sx, sy) }
+        unsafe { wlr_seat_pointer_notify_enter(self.seat, surface.as_ptr(), sx, sy) }
     }
 
     /// Notify the seat of motion over the given surface.
     ///
     /// Pass surface-local coordinates where the pointer motion occurred.
     pub fn pointer_notify_motion(&self, time: Duration, sx: f64, sy: f64) {
-        let seat = self.data.borrow();
-        unsafe { wlr_seat_pointer_notify_motion(seat.seat, time.to_ms(), sx, sy) }
+        unsafe { wlr_seat_pointer_notify_motion(self.seat, time.to_ms(), sx, sy) }
     }
 
     // TODO Wrapper type around Button and State
@@ -353,8 +342,7 @@ impl Seat {
     ///
     /// Returns the serial of the button press or zero if no button press was sent.
     pub fn pointer_notify_button(&self, time: Duration, button: u32, state: u32) -> u32 {
-        let seat = self.data.borrow();
-        unsafe { wlr_seat_pointer_notify_button(seat.seat, time.to_ms(), button, state) }
+        unsafe { wlr_seat_pointer_notify_button(self.seat, time.to_ms(), button, state) }
     }
 
     /// Notify the seat of an axis event.
@@ -362,14 +350,12 @@ impl Seat {
                                time: Duration,
                                orientation: wlr_axis_orientation,
                                value: f64) {
-        let seat = self.data.borrow();
-        unsafe { wlr_seat_pointer_notify_axis(seat.seat, time.to_ms(), orientation, value) }
+        unsafe { wlr_seat_pointer_notify_axis(self.seat, time.to_ms(), orientation, value) }
     }
 
     /// Set this keyboard as the active keyboard for the seat.
     pub fn set_keyboard(&self, dev: InputDevice) {
-        let seat = self.data.borrow();
-        unsafe { wlr_seat_set_keyboard(seat.seat, dev.as_ptr()) }
+        unsafe { wlr_seat_set_keyboard(self.seat, dev.as_ptr()) }
     }
 
     // TODO Point to the correct function name in this documentation.
@@ -378,16 +364,14 @@ impl Seat {
     ///
     /// Compositors should use `wlr_seat_notify_key()` to respect keyboard grabs.
     pub fn keyboard_send_key(&self, time: Duration, key: u32, state: u32) {
-        let seat = self.data.borrow();
-        unsafe { wlr_seat_keyboard_send_key(seat.seat, time.to_ms(), key, state) }
+        unsafe { wlr_seat_keyboard_send_key(self.seat, time.to_ms(), key, state) }
     }
 
     /// Send the modifier state to focused keyboard resources.
     ///
     /// Compositors should use `Seat::keyboard_notify_modifiers()` to respect any keyboard grabs.
     pub fn keyboard_send_modifiers(&self, modifiers: &mut KeyboardModifiers) {
-        let seat = self.data.borrow();
-        unsafe { wlr_seat_keyboard_send_modifiers(seat.seat, modifiers) }
+        unsafe { wlr_seat_keyboard_send_modifiers(self.seat, modifiers) }
     }
 
     /// Send a keyboard enter event to the given surface and consider it to be the
@@ -401,10 +385,9 @@ impl Seat {
                           surface: &mut Surface,
                           keycodes: &mut [Keycode],
                           modifiers: &mut KeyboardModifiers) {
-        let seat = self.data.borrow();
         let keycodes_length = keycodes.len();
         unsafe {
-            wlr_seat_keyboard_enter(seat.seat,
+            wlr_seat_keyboard_enter(self.seat,
                                     surface.as_ptr(),
                                     keycodes.as_mut_ptr(),
                                     keycodes_length,
@@ -415,36 +398,31 @@ impl Seat {
     /// Start a grab of the keyboard of this seat. The grabber is responsible for
     /// handling all keyboard events until the grab ends.
     pub fn keyboard_start_grab(&self, grab: KeyboardGrab) {
-        let seat = self.data.borrow();
-        unsafe { wlr_seat_keyboard_start_grab(seat.seat, grab.as_ptr()) }
+        unsafe { wlr_seat_keyboard_start_grab(self.seat, grab.as_ptr()) }
     }
 
     /// End the grab of the keyboard of this seat. This reverts the grab back to the
     /// default grab for the keyboard.
     pub fn keyboard_end_grab(&self) {
-        let seat = self.data.borrow();
-        unsafe { wlr_seat_keyboard_end_grab(seat.seat) }
+        unsafe { wlr_seat_keyboard_end_grab(self.seat) }
     }
 
     /// Whether or not the keyboard has a grab other than the default grab
     pub fn keyboard_has_grab(&self) -> bool {
-        let seat = self.data.borrow();
-        unsafe { wlr_seat_keyboard_has_grab(seat.seat) }
+        unsafe { wlr_seat_keyboard_has_grab(self.seat) }
     }
 
     /// Clear the focused surface for the keyboard and leave all entered
     /// surfaces.
     pub fn keyboard_clear_focus(&self) {
-        let seat = self.data.borrow();
-        unsafe { wlr_seat_keyboard_clear_focus(seat.seat) }
+        unsafe { wlr_seat_keyboard_clear_focus(self.seat) }
     }
 
     /// Notify the seat that the modifiers for the keyboard have changed.
     ///
     /// Defers to any keyboard grabs.
     pub fn keyboard_notify_modifiers(&self, modifiers: &mut KeyboardModifiers) {
-        let seat = self.data.borrow();
-        unsafe { wlr_seat_keyboard_notify_modifiers(seat.seat, modifiers) }
+        unsafe { wlr_seat_keyboard_notify_modifiers(self.seat, modifiers) }
     }
 
     /// Notify the seat that the keyboard focus has changed and request it to be the
@@ -455,10 +433,9 @@ impl Seat {
                                  surface: &mut Surface,
                                  keycodes: &mut [Keycode],
                                  modifiers: &mut KeyboardModifiers) {
-        let seat = self.data.borrow();
         let keycodes_length = keycodes.len();
         unsafe {
-            wlr_seat_keyboard_notify_enter(seat.seat,
+            wlr_seat_keyboard_notify_enter(self.seat,
                                            surface.as_ptr(),
                                            keycodes.as_mut_ptr(),
                                            keycodes_length,
@@ -472,42 +449,36 @@ impl Seat {
     ///
     /// Defers to any keyboard grabs.
     pub fn keyboard_notify_key(&self, time: Duration, key: u32, state: u32) {
-        let seat = self.data.borrow();
-        unsafe { wlr_seat_keyboard_notify_key(seat.seat, time.to_ms(), key, state) }
+        unsafe { wlr_seat_keyboard_notify_key(self.seat, time.to_ms(), key, state) }
     }
 
     /// How many touch ponits are currently down for the seat.
     pub fn touch_num_points(&self) -> i32 {
-        let seat = self.data.borrow();
-        unsafe { wlr_seat_touch_num_points(seat.seat) }
+        unsafe { wlr_seat_touch_num_points(self.seat) }
     }
 
     /// Start a grab of the touch device of this seat. The grabber is responsible for
     /// handling all touch events until the grab ends.
     pub fn touch_start_grab(&self, grab: TouchGrab) {
-        let seat = self.data.borrow();
-        unsafe { wlr_seat_touch_start_grab(seat.seat, grab.as_ptr()) }
+        unsafe { wlr_seat_touch_start_grab(self.seat, grab.as_ptr()) }
     }
 
     /// End the grab of the touch device of this seat. This reverts the grab back to
     /// the default grab for the touch device.
     pub fn touch_end_grab(&self) {
-        let seat = self.data.borrow();
-        unsafe { wlr_seat_touch_end_grab(seat.seat) }
+        unsafe { wlr_seat_touch_end_grab(self.seat) }
     }
 
     /// Whether or not the seat has a touch grab other than the default grab.
     pub fn touch_has_grab(&self) -> bool {
-        let seat = self.data.borrow();
-        unsafe { wlr_seat_touch_has_grab(seat.seat) }
+        unsafe { wlr_seat_touch_has_grab(self.seat) }
     }
 
     // Get the active touch point with the given `touch_id`. If the touch point does
     // not exist or is no longer active, returns None.
     pub fn get_touch_point(&self, touch_id: TouchId) -> Option<TouchPoint> {
-        let seat = self.data.borrow();
         unsafe {
-            let touch_point = wlr_seat_touch_get_point(seat.seat, touch_id.into());
+            let touch_point = wlr_seat_touch_get_point(self.seat, touch_id.into());
             if touch_point.is_null() {
                 return None
             } else {
@@ -526,9 +497,8 @@ impl Seat {
                              touch_id: TouchId,
                              sx: f64,
                              sy: f64) {
-        let seat = self.data.borrow();
         unsafe {
-            wlr_seat_touch_point_focus(seat.seat,
+            wlr_seat_touch_point_focus(self.seat,
                                        surface.as_ptr(),
                                        time.to_ms(),
                                        touch_id.into(),
@@ -539,8 +509,7 @@ impl Seat {
 
     //// Clear the focused surface for the touch point given by `touch_id`.
     pub fn touch_point_clear_focus(&self, time: Duration, touch_id: TouchId) {
-        let seat = self.data.borrow();
-        unsafe { wlr_seat_touch_point_clear_focus(seat.seat, time.to_ms(), touch_id.into()) }
+        unsafe { wlr_seat_touch_point_clear_focus(self.seat, time.to_ms(), touch_id.into()) }
     }
 
     /// Send a touch down event to the client of the given surface.
@@ -562,9 +531,8 @@ impl Seat {
                            sx: f64,
                            sy: f64)
                            -> u32 {
-        let seat = self.data.borrow();
         unsafe {
-            wlr_seat_touch_send_down(seat.seat,
+            wlr_seat_touch_send_down(self.seat,
                                      surface.as_ptr(),
                                      time.to_ms(),
                                      touch_id.into(),
@@ -583,8 +551,7 @@ impl Seat {
     /// Compositors should use `Seat::touch_notify_up()` to
     /// respect any grabs of the touch device.
     pub fn touch_send_up(&self, time: Duration, touch_id: TouchId) {
-        let seat = self.data.borrow();
-        unsafe { wlr_seat_touch_send_up(seat.seat, time.to_ms(), touch_id.into()) }
+        unsafe { wlr_seat_touch_send_up(self.seat, time.to_ms(), touch_id.into()) }
     }
 
     /// Send a touch motion event for the touch point given by the `touch_id`.
@@ -595,8 +562,7 @@ impl Seat {
     /// Compositors should use `Seat::touch_notify_motion()` to
     /// respect any grabs of the touch device.
     pub fn touch_send_motion(&self, time: Duration, touch_id: TouchId, sx: f64, sy: f64) {
-        let seat = self.data.borrow();
-        unsafe { wlr_seat_touch_send_motion(seat.seat, time.to_ms(), touch_id.into(), sx, sy) }
+        unsafe { wlr_seat_touch_send_motion(self.seat, time.to_ms(), touch_id.into(), sx, sy) }
     }
 
     // TODO Should this be returning a u32? Should I wrap whatever that number is?
@@ -610,9 +576,8 @@ impl Seat {
                              sx: f64,
                              sy: f64)
                              -> u32 {
-        let seat = self.data.borrow();
         unsafe {
-            wlr_seat_touch_notify_down(seat.seat,
+            wlr_seat_touch_notify_down(self.seat,
                                        surface.as_ptr(),
                                        time.to_ms(),
                                        touch_id.into(),
@@ -624,8 +589,7 @@ impl Seat {
     /// Notify the seat that the touch point given by `touch_id` is up. Defers to any
     /// grab of the touch device.
     pub fn touch_notify_up(&self, time: Duration, touch_id: TouchId) {
-        let seat = self.data.borrow();
-        unsafe { wlr_seat_touch_notify_up(seat.seat, time.to_ms(), touch_id.into()) }
+        unsafe { wlr_seat_touch_notify_up(self.seat, time.to_ms(), touch_id.into()) }
     }
 
     /// Notify the seat that the touch point given by `touch_id` has moved.
@@ -635,19 +599,17 @@ impl Seat {
     /// The seat should be notified of touch motion even if the surface is
     /// not the owner of the touch point for processing by grabs.
     pub fn touch_notify_motion(&self, time: Duration, touch_id: TouchId, sx: f64, sy: f64) {
-        let seat = self.data.borrow();
-        unsafe { wlr_seat_touch_notify_motion(seat.seat, time.to_ms(), touch_id.into(), sx, sy) }
+        unsafe { wlr_seat_touch_notify_motion(self.seat, time.to_ms(), touch_id.into(), sx, sy) }
     }
 
     pub(crate) unsafe fn as_ptr(&mut self) -> *mut wlr_seat {
-        let inner = self.data.get_mut();
-        inner.seat
+        self.seat
     }
 }
 
 impl Drop for Seat {
     fn drop(&mut self) {
-        let inner = self.data.get_mut();
+        let inner = self.data.0.get_mut();
         unsafe { wlr_seat_destroy(inner.seat) }
     }
 }

--- a/src/types/seat/seat.rs
+++ b/src/types/seat/seat.rs
@@ -252,17 +252,7 @@ impl Seat {
             if name_ptr.is_null() {
                 return None
             }
-            c_to_rust_string(name_ptr)
-        }
-    }
-
-    /// Updates the name of this seat.
-    /// Will automatically send it to all clients.
-    // TODO FIXME Setting this could de-sync it with what's in the hashmap...
-    pub fn set_name(&mut self, name: String) {
-        let name = safe_as_cstring(name);
-        unsafe {
-            wlr_seat_set_name(self.data.0, name.as_ptr());
+                c_to_rust_string(name_ptr)
         }
     }
 

--- a/src/types/seat/seat.rs
+++ b/src/types/seat/seat.rs
@@ -77,6 +77,10 @@ pub struct SeatInner {
     seat: *mut wlr_seat
 }
 
+// TODO FIXME This memory model is totally broken...
+// you can't even borrow the Seat properly in the callback,
+// so that's bogus
+
 wayland_listener!(Seat, RefCell<SeatInner>, [
     pointer_grab_begin_listener => pointer_grab_begin_notify: |this: &mut Seat,
                                                                event: *mut libc::c_void,|

--- a/src/types/seat/seat.rs
+++ b/src/types/seat/seat.rs
@@ -44,10 +44,19 @@ pub trait SeatHandler {
     // TODO
 }
 
-/// A wrapper around `wlr_seat`.
-pub struct Seat {
+/// The structure that contains all actual seat pointers.
+///
+/// This is here so that we can ensure unique access.
+struct SeatInner {
     handler: Box<SeatHandler>,
     seat: *mut wlr_seat
+}
+
+/// A wrapper around `wlr_seat`.
+#[repr(C)]
+pub struct Seat {
+    inner: RefCell<SeatInner>
+    // TODO Listeners
 }
 
 impl Seat {
@@ -55,25 +64,29 @@ impl Seat {
     ///
     /// Puts the seat in a `RefCell` so that it's safe to use both in your
     /// state wherever and in the callback provided by the handler.
+    ///
+    /// Puts the seat in an `Rc` so that the address is static for internal
+    /// purposes.
     pub fn new(compositor: &mut Compositor,
-                  name: String,
-                  handler: Box<SeatHandler>)
-                  -> Option<RefCell<Self>> {
+               name: String,
+               handler: Box<SeatHandler>)
+               -> Option<Self> {
         unsafe {
             let name = safe_as_cstring(name);
             let seat = wlr_seat_create(compositor.display() as _, name.as_ptr());
             if seat.is_null() {
                 None
             } else {
-                Some(RefCell::new(Seat { seat, handler }))
+                Some(Seat { inner: RefCell::new(SeatInner { seat, handler }) })
             }
         }
     }
 
     /// Get the name of the seat.
     pub fn name(&self) -> Option<String> {
+        let seat = self.inner.borrow();
         unsafe {
-            let name_ptr = (*self.seat).name;
+            let name_ptr = (*seat.seat).name;
             if name_ptr.is_null() {
                 return None
             }
@@ -83,27 +96,31 @@ impl Seat {
 
     /// Updates the name of this seat.
     /// Will automatically send it to all clients.
-    pub fn set_name(&mut self, name: String) {
+    pub fn set_name(&self, name: String) {
+        let seat = self.inner.borrow();
         let name = safe_as_cstring(name);
         unsafe {
-            wlr_seat_set_name(self.seat, name.as_ptr());
+            wlr_seat_set_name(seat.seat, name.as_ptr());
         }
     }
 
     /// Gets the capabilities of this seat.
     pub fn capabilities(&self) -> Capability {
-        unsafe { Capability::from_raw((*self.seat).capabilities).expect("Invalid capabilities") }
+        let seat = self.inner.borrow();
+        unsafe { Capability::from_raw((*seat.seat).capabilities).expect("Invalid capabilities") }
     }
 
     /// Updates the capabilities available on this seat.
     /// Will automatically send it to all clients.
-    pub fn set_capabilities(&mut self, capabilities: Capability) {
-        unsafe { wlr_seat_set_capabilities(self.seat, capabilities.bits()) }
+    pub fn set_capabilities(&self, capabilities: Capability) {
+        let seat = self.inner.borrow();
+        unsafe { wlr_seat_set_capabilities(seat.seat, capabilities.bits()) }
     }
 
     /// Determines if the surface has pointer focus.
-    pub fn pointer_surface_has_focus(&mut self, surface: Surface) -> bool {
-        unsafe { wlr_seat_pointer_surface_has_focus(self.seat, surface.as_ptr()) }
+    pub fn pointer_surface_has_focus(&self, surface: Surface) -> bool {
+        let seat = self.inner.borrow();
+        unsafe { wlr_seat_pointer_surface_has_focus(seat.seat, surface.as_ptr()) }
     }
 
     // Sends a pointer enter event to the given surface and considers it to be
@@ -115,16 +132,18 @@ impl Seat {
     //
     // Compositor should use `Seat::pointer_notify_enter` to
     // change pointer focus to respect pointer grabs.
-    pub fn pointer_enter(&mut self, surface: Surface, sx: f64, sy: f64) {
+    pub fn pointer_enter(&self, surface: Surface, sx: f64, sy: f64) {
+        let seat = self.inner.borrow();
         unsafe {
-            wlr_seat_pointer_enter(self.seat, surface.as_ptr(), sx, sy);
+            wlr_seat_pointer_enter(seat.seat, surface.as_ptr(), sx, sy);
         }
     }
 
     /// Clears the focused surface for the pointer and leaves all entered
     /// surfaces.
-    pub fn clear_focus(&mut self) {
-        unsafe { wlr_seat_pointer_clear_focus(self.seat) }
+    pub fn clear_focus(&self) {
+        let seat = self.inner.borrow();
+        unsafe { wlr_seat_pointer_clear_focus(seat.seat) }
     }
 
     /// Sends a motion event to the surface with pointer focus.
@@ -133,8 +152,9 @@ impl Seat {
     ///
     /// Compositors should use `Seat::notify_motion` to
     /// send motion events to the respect pointer grabs.
-    pub fn send_motion(&mut self, time: Duration, sx: f64, sy: f64) {
-        unsafe { wlr_seat_pointer_send_motion(self.seat, time.to_ms(), sx, sy) }
+    pub fn send_motion(&self, time: Duration, sx: f64, sy: f64) {
+        let seat = self.inner.borrow();
+        unsafe { wlr_seat_pointer_send_motion(seat.seat, time.to_ms(), sx, sy) }
     }
 
     // TODO Button and State should probably be wrapped in some sort of type...
@@ -147,56 +167,64 @@ impl Seat {
     ///
     /// Compositors should use `Seat::notify_button` to
     /// send button events to respect pointer grabs.
-    pub fn send_button(&mut self, time: Duration, button: u32, state: u32) -> u32 {
-        unsafe { wlr_seat_pointer_send_button(self.seat, time.to_ms(), button, state) }
+    pub fn send_button(&self, time: Duration, button: u32, state: u32) -> u32 {
+        let seat = self.inner.borrow();
+        unsafe { wlr_seat_pointer_send_button(seat.seat, time.to_ms(), button, state) }
     }
 
     /// Send an axis event to the surface with pointer focus.
     ///
     /// Compositors should use `Seat::notify_axis` to
     /// send axis events to respect pointer grabs.
-    pub fn send_axis(&mut self, time: Duration, orientation: wlr_axis_orientation, value: f64) {
+    pub fn send_axis(&self, time: Duration, orientation: wlr_axis_orientation, value: f64) {
+        let seat = self.inner.borrow();
         unsafe {
-            wlr_seat_pointer_send_axis(self.seat, time.to_ms(), orientation, value);
+            wlr_seat_pointer_send_axis(seat.seat, time.to_ms(), orientation, value);
         }
     }
 
     /// Start a grab of the pointer of this seat. The grabber is responsible for
     /// handling all pointer events until the grab ends.
-    pub fn pointer_start_grab(&mut self, grab: PointerGrab) {
-        unsafe { wlr_seat_pointer_start_grab(self.seat, grab.as_ptr()) }
+    pub fn pointer_start_grab(&self, grab: PointerGrab) {
+        let seat = self.inner.borrow();
+        unsafe { wlr_seat_pointer_start_grab(seat.seat, grab.as_ptr()) }
     }
 
     /// End the grab of the pointer of this seat. This reverts the grab back to the
     /// default grab for the pointer.
-    pub fn pointer_end_grab(&mut self) {
-        unsafe { wlr_seat_pointer_end_grab(self.seat) }
+    pub fn pointer_end_grab(&self) {
+        let seat = self.inner.borrow();
+        unsafe { wlr_seat_pointer_end_grab(seat.seat) }
     }
 
     /// Whether or not the pointer has a grab other than the default grab.
     pub fn pointer_has_grab(&self) -> bool {
-        unsafe { wlr_seat_pointer_has_grab(self.seat) }
+        let seat = self.inner.borrow();
+        unsafe { wlr_seat_pointer_has_grab(seat.seat) }
     }
 
     /// Clear the focused surface for the pointer and leave all entered
     /// surfaces.
-    pub fn pointer_clear_focus(&mut self) {
-        unsafe { wlr_seat_pointer_clear_focus(self.seat) }
+    pub fn pointer_clear_focus(&self) {
+        let seat = self.inner.borrow();
+        unsafe { wlr_seat_pointer_clear_focus(seat.seat) }
     }
 
     /// Notify the seat of a pointer enter event to the given surface and request it
     /// to be the focused surface for the pointer.
     ///
     /// Pass surface-local coordinates where the enter occurred.
-    pub fn pointer_notify_enter(&mut self, surface: Surface, sx: f64, sy: f64) {
-        unsafe { wlr_seat_pointer_notify_enter(self.seat, surface.as_ptr(), sx, sy) }
+    pub fn pointer_notify_enter(&self, surface: Surface, sx: f64, sy: f64) {
+        let seat = self.inner.borrow();
+        unsafe { wlr_seat_pointer_notify_enter(seat.seat, surface.as_ptr(), sx, sy) }
     }
 
     /// Notify the seat of motion over the given surface.
     ///
     /// Pass surface-local coordinates where the pointer motion occurred.
-    pub fn pointer_notify_motion(&mut self, time: Duration, sx: f64, sy: f64) {
-        unsafe { wlr_seat_pointer_notify_motion(self.seat, time.to_ms(), sx, sy) }
+    pub fn pointer_notify_motion(&self, time: Duration, sx: f64, sy: f64) {
+        let seat = self.inner.borrow();
+        unsafe { wlr_seat_pointer_notify_motion(seat.seat, time.to_ms(), sx, sy) }
     }
 
     // TODO Wrapper type around Button and State
@@ -204,21 +232,24 @@ impl Seat {
     /// Notify the seat that a button has been pressed.
     ///
     /// Returns the serial of the button press or zero if no button press was sent.
-    pub fn pointer_notify_button(&mut self, time: Duration, button: u32, state: u32) -> u32 {
-        unsafe { wlr_seat_pointer_notify_button(self.seat, time.to_ms(), button, state) }
+    pub fn pointer_notify_button(&self, time: Duration, button: u32, state: u32) -> u32 {
+        let seat = self.inner.borrow();
+        unsafe { wlr_seat_pointer_notify_button(seat.seat, time.to_ms(), button, state) }
     }
 
     /// Notify the seat of an axis event.
-    pub fn pointer_notify_axis(&mut self,
+    pub fn pointer_notify_axis(&self,
                                time: Duration,
                                orientation: wlr_axis_orientation,
                                value: f64) {
-        unsafe { wlr_seat_pointer_notify_axis(self.seat, time.to_ms(), orientation, value) }
+        let seat = self.inner.borrow();
+        unsafe { wlr_seat_pointer_notify_axis(seat.seat, time.to_ms(), orientation, value) }
     }
 
     /// Set this keyboard as the active keyboard for the seat.
-    pub fn set_keyboard(&mut self, dev: InputDevice) {
-        unsafe { wlr_seat_set_keyboard(self.seat, dev.as_ptr()) }
+    pub fn set_keyboard(&self, dev: InputDevice) {
+        let seat = self.inner.borrow();
+        unsafe { wlr_seat_set_keyboard(seat.seat, dev.as_ptr()) }
     }
 
     // TODO Point to the correct function name in this documentation.
@@ -226,15 +257,17 @@ impl Seat {
     /// Send the keyboard key to focused keyboard resources.
     ///
     /// Compositors should use `wlr_seat_notify_key()` to respect keyboard grabs.
-    pub fn keyboard_send_key(&mut self, time: Duration, key: u32, state: u32) {
-        unsafe { wlr_seat_keyboard_send_key(self.seat, time.to_ms(), key, state) }
+    pub fn keyboard_send_key(&self, time: Duration, key: u32, state: u32) {
+        let seat = self.inner.borrow();
+        unsafe { wlr_seat_keyboard_send_key(seat.seat, time.to_ms(), key, state) }
     }
 
     /// Send the modifier state to focused keyboard resources.
     ///
     /// Compositors should use `Seat::keyboard_notify_modifiers()` to respect any keyboard grabs.
-    pub fn keyboard_send_modifiers(&mut self, modifiers: &mut KeyboardModifiers) {
-        unsafe { wlr_seat_keyboard_send_modifiers(self.seat, modifiers) }
+    pub fn keyboard_send_modifiers(&self, modifiers: &mut KeyboardModifiers) {
+        let seat = self.inner.borrow();
+        unsafe { wlr_seat_keyboard_send_modifiers(seat.seat, modifiers) }
     }
 
     /// Send a keyboard enter event to the given surface and consider it to be the
@@ -244,13 +277,14 @@ impl Seat {
     ///
     /// Compositors should use `Seat::keyboard_notify_enter()` to
     /// change keyboard focus to respect keyboard grabs.
-    pub fn keyboard_enter(&mut self,
+    pub fn keyboard_enter(&self,
                           surface: Surface,
                           keycodes: &mut [Keycode],
                           modifiers: &mut KeyboardModifiers) {
+        let seat = self.inner.borrow();
         let keycodes_length = keycodes.len();
         unsafe {
-            wlr_seat_keyboard_enter(self.seat,
+            wlr_seat_keyboard_enter(seat.seat,
                                     surface.as_ptr(),
                                     keycodes.as_mut_ptr(),
                                     keycodes_length,
@@ -260,45 +294,51 @@ impl Seat {
 
     /// Start a grab of the keyboard of this seat. The grabber is responsible for
     /// handling all keyboard events until the grab ends.
-    pub fn keyboard_start_grab(&mut self, grab: KeyboardGrab) {
-        unsafe { wlr_seat_keyboard_start_grab(self.seat, grab.as_ptr()) }
+    pub fn keyboard_start_grab(&self, grab: KeyboardGrab) {
+        let seat = self.inner.borrow();
+        unsafe { wlr_seat_keyboard_start_grab(seat.seat, grab.as_ptr()) }
     }
 
     /// End the grab of the keyboard of this seat. This reverts the grab back to the
     /// default grab for the keyboard.
-    pub fn keyboard_end_grab(&mut self) {
-        unsafe { wlr_seat_keyboard_end_grab(self.seat) }
+    pub fn keyboard_end_grab(&self) {
+        let seat = self.inner.borrow();
+        unsafe { wlr_seat_keyboard_end_grab(seat.seat) }
     }
 
     /// Whether or not the keyboard has a grab other than the default grab
     pub fn keyboard_has_grab(&self) -> bool {
-        unsafe { wlr_seat_keyboard_has_grab(self.seat) }
+        let seat = self.inner.borrow();
+        unsafe { wlr_seat_keyboard_has_grab(seat.seat) }
     }
 
     /// Clear the focused surface for the keyboard and leave all entered
     /// surfaces.
-    pub fn keyboard_clear_focus(&mut self) {
-        unsafe { wlr_seat_keyboard_clear_focus(self.seat) }
+    pub fn keyboard_clear_focus(&self) {
+        let seat = self.inner.borrow();
+        unsafe { wlr_seat_keyboard_clear_focus(seat.seat) }
     }
 
     /// Notify the seat that the modifiers for the keyboard have changed.
     ///
     /// Defers to any keyboard grabs.
-    pub fn keyboard_notify_modifiers(&mut self, modifiers: &mut KeyboardModifiers) {
-        unsafe { wlr_seat_keyboard_notify_modifiers(self.seat, modifiers) }
+    pub fn keyboard_notify_modifiers(&self, modifiers: &mut KeyboardModifiers) {
+        let seat = self.inner.borrow();
+        unsafe { wlr_seat_keyboard_notify_modifiers(seat.seat, modifiers) }
     }
 
     /// Notify the seat that the keyboard focus has changed and request it to be the
     /// focused surface for this keyboard.
     ///
     /// Defers to any current grab of the seat's keyboard.
-    pub fn keyboard_notify_enter(&mut self,
+    pub fn keyboard_notify_enter(&self,
                                  surface: Surface,
                                  keycodes: &mut [Keycode],
                                  modifiers: &mut KeyboardModifiers) {
+        let seat = self.inner.borrow();
         let keycodes_length = keycodes.len();
         unsafe {
-            wlr_seat_keyboard_notify_enter(self.seat,
+            wlr_seat_keyboard_notify_enter(seat.seat,
                                            surface.as_ptr(),
                                            keycodes.as_mut_ptr(),
                                            keycodes_length,
@@ -311,37 +351,43 @@ impl Seat {
     /// Notify the seat that a key has been pressed on the keyboard.
     ///
     /// Defers to any keyboard grabs.
-    pub fn keyboard_notify_key(&mut self, time: Duration, key: u32, state: u32) {
-        unsafe { wlr_seat_keyboard_notify_key(self.seat, time.to_ms(), key, state) }
+    pub fn keyboard_notify_key(&self, time: Duration, key: u32, state: u32) {
+        let seat = self.inner.borrow();
+        unsafe { wlr_seat_keyboard_notify_key(seat.seat, time.to_ms(), key, state) }
     }
 
     /// How many touch ponits are currently down for the seat.
-    pub fn touch_num_points(&mut self) -> i32 {
-        unsafe { wlr_seat_touch_num_points(self.seat) }
+    pub fn touch_num_points(&self) -> i32 {
+        let seat = self.inner.borrow();
+        unsafe { wlr_seat_touch_num_points(seat.seat) }
     }
 
     /// Start a grab of the touch device of this seat. The grabber is responsible for
     /// handling all touch events until the grab ends.
-    pub fn touch_start_grab(&mut self, grab: TouchGrab) {
-        unsafe { wlr_seat_touch_start_grab(self.seat, grab.as_ptr()) }
+    pub fn touch_start_grab(&self, grab: TouchGrab) {
+        let seat = self.inner.borrow();
+        unsafe { wlr_seat_touch_start_grab(seat.seat, grab.as_ptr()) }
     }
 
     /// End the grab of the touch device of this seat. This reverts the grab back to
     /// the default grab for the touch device.
-    pub fn touch_end_grab(&mut self) {
-        unsafe { wlr_seat_touch_end_grab(self.seat) }
+    pub fn touch_end_grab(&self) {
+        let seat = self.inner.borrow();
+        unsafe { wlr_seat_touch_end_grab(seat.seat) }
     }
 
     /// Whether or not the seat has a touch grab other than the default grab.
     pub fn touch_has_grab(&self) -> bool {
-        unsafe { wlr_seat_touch_has_grab(self.seat) }
+        let seat = self.inner.borrow();
+        unsafe { wlr_seat_touch_has_grab(seat.seat) }
     }
 
     // Get the active touch point with the given `touch_id`. If the touch point does
     // not exist or is no longer active, returns None.
     pub fn get_touch_point(&self, touch_id: TouchId) -> Option<TouchPoint> {
+        let seat = self.inner.borrow();
         unsafe {
-            let touch_point = wlr_seat_touch_get_point(self.seat, touch_id.into());
+            let touch_point = wlr_seat_touch_get_point(seat.seat, touch_id.into());
             if touch_point.is_null() {
                 return None
             } else {
@@ -354,14 +400,15 @@ impl Seat {
     /// surface.
     ///
     /// The surface is required. To clear focus, use `Seat::touch_point_clear_focus()`.
-    pub fn touch_point_focus(&mut self,
+    pub fn touch_point_focus(&self,
                              surface: Surface,
                              time: Duration,
                              touch_id: TouchId,
                              sx: f64,
                              sy: f64) {
+        let seat = self.inner.borrow();
         unsafe {
-            wlr_seat_touch_point_focus(self.seat,
+            wlr_seat_touch_point_focus(seat.seat,
                                        surface.as_ptr(),
                                        time.to_ms(),
                                        touch_id.into(),
@@ -371,8 +418,9 @@ impl Seat {
     }
 
     //// Clear the focused surface for the touch point given by `touch_id`.
-    pub fn touch_point_clear_focus(&mut self, time: Duration, touch_id: TouchId) {
-        unsafe { wlr_seat_touch_point_clear_focus(self.seat, time.to_ms(), touch_id.into()) }
+    pub fn touch_point_clear_focus(&self, time: Duration, touch_id: TouchId) {
+        let seat = self.inner.borrow();
+        unsafe { wlr_seat_touch_point_clear_focus(seat.seat, time.to_ms(), touch_id.into()) }
     }
 
     /// Send a touch down event to the client of the given surface.
@@ -387,15 +435,16 @@ impl Seat {
     ///
     /// Compositors should use `Seat::touch_notify_down()` to
     /// respect any grabs of the touch device.
-    pub fn touch_send_down(&mut self,
+    pub fn touch_send_down(&self,
                            surface: Surface,
                            time: Duration,
                            touch_id: TouchId,
                            sx: f64,
                            sy: f64)
                            -> u32 {
+        let seat = self.inner.borrow();
         unsafe {
-            wlr_seat_touch_send_down(self.seat,
+            wlr_seat_touch_send_down(seat.seat,
                                      surface.as_ptr(),
                                      time.to_ms(),
                                      touch_id.into(),
@@ -413,8 +462,9 @@ impl Seat {
     ///
     /// Compositors should use `Seat::touch_notify_up()` to
     /// respect any grabs of the touch device.
-    pub fn touch_send_up(&mut self, time: Duration, touch_id: TouchId) {
-        unsafe { wlr_seat_touch_send_up(self.seat, time.to_ms(), touch_id.into()) }
+    pub fn touch_send_up(&self, time: Duration, touch_id: TouchId) {
+        let seat = self.inner.borrow();
+        unsafe { wlr_seat_touch_send_up(seat.seat, time.to_ms(), touch_id.into()) }
     }
 
     /// Send a touch motion event for the touch point given by the `touch_id`.
@@ -424,23 +474,25 @@ impl Seat {
     ///
     /// Compositors should use `Seat::touch_notify_motion()` to
     /// respect any grabs of the touch device.
-    pub fn touch_send_motion(&mut self, time: Duration, touch_id: TouchId, sx: f64, sy: f64) {
-        unsafe { wlr_seat_touch_send_motion(self.seat, time.to_ms(), touch_id.into(), sx, sy) }
+    pub fn touch_send_motion(&self, time: Duration, touch_id: TouchId, sx: f64, sy: f64) {
+        let seat = self.inner.borrow();
+        unsafe { wlr_seat_touch_send_motion(seat.seat, time.to_ms(), touch_id.into(), sx, sy) }
     }
 
     // TODO Should this be returning a u32? Should I wrap whatever that number is?
 
     /// Notify the seat of a touch down on the given surface. Defers to any grab of
     /// the touch device.
-    pub fn touch_notify_down(&mut self,
+    pub fn touch_notify_down(&self,
                              surface: Surface,
                              time: Duration,
                              touch_id: TouchId,
                              sx: f64,
                              sy: f64)
                              -> u32 {
+        let seat = self.inner.borrow();
         unsafe {
-            wlr_seat_touch_notify_down(self.seat,
+            wlr_seat_touch_notify_down(seat.seat,
                                        surface.as_ptr(),
                                        time.to_ms(),
                                        touch_id.into(),
@@ -451,8 +503,9 @@ impl Seat {
 
     /// Notify the seat that the touch point given by `touch_id` is up. Defers to any
     /// grab of the touch device.
-    pub fn touch_notify_up(&mut self, time: Duration, touch_id: TouchId) {
-        unsafe { wlr_seat_touch_notify_up(self.seat, time.to_ms(), touch_id.into()) }
+    pub fn touch_notify_up(&self, time: Duration, touch_id: TouchId) {
+        let seat = self.inner.borrow();
+        unsafe { wlr_seat_touch_notify_up(seat.seat, time.to_ms(), touch_id.into()) }
     }
 
     /// Notify the seat that the touch point given by `touch_id` has moved.
@@ -461,17 +514,20 @@ impl Seat {
     ///
     /// The seat should be notified of touch motion even if the surface is
     /// not the owner of the touch point for processing by grabs.
-    pub fn touch_notify_motion(&mut self, time: Duration, touch_id: TouchId, sx: f64, sy: f64) {
-        unsafe { wlr_seat_touch_notify_motion(self.seat, time.to_ms(), touch_id.into(), sx, sy) }
+    pub fn touch_notify_motion(&self, time: Duration, touch_id: TouchId, sx: f64, sy: f64) {
+        let seat = self.inner.borrow();
+        unsafe { wlr_seat_touch_notify_motion(seat.seat, time.to_ms(), touch_id.into(), sx, sy) }
     }
 
-    pub(crate) unsafe fn as_ptr(&self) -> *mut wlr_seat {
-        self.seat
+    pub(crate) unsafe fn as_ptr(&mut self) -> *mut wlr_seat {
+        let inner = self.inner.get_mut();
+        inner.seat
     }
 }
 
 impl Drop for Seat {
     fn drop(&mut self) {
-        unsafe { wlr_seat_destroy(self.seat) }
+        let inner = self.inner.get_mut();
+        unsafe { wlr_seat_destroy(inner.seat) }
     }
 }

--- a/src/types/seat/seat.rs
+++ b/src/types/seat/seat.rs
@@ -55,7 +55,7 @@ impl Seat {
     ///
     /// Puts the seat in a `RefCell` so that it's safe to use both in your
     /// state wherever and in the callback provided by the handler.
-    pub fn create(compositor: &mut Compositor,
+    pub fn new(compositor: &mut Compositor,
                   name: String,
                   handler: Box<SeatHandler>)
                   -> Option<RefCell<Self>> {

--- a/src/types/seat/seat.rs
+++ b/src/types/seat/seat.rs
@@ -77,10 +77,11 @@ wayland_listener!(Seat, (*mut wlr_seat, Box<SeatHandler>), [
         let compositor = &mut *COMPOSITOR_PTR;
         let seat_name = c_to_rust_string((*seat_ptr).name)
             .expect("Bad name for seat");
-        let mut seat = compositor.take_seat(seat_name.as_str());
-        let pointer_grab = &mut *(event as *mut PointerGrab);
-        handler.pointer_grabbed(compositor, &mut seat, pointer_grab);
-        compositor.replace_seat(seat);
+        if let Some(mut seat) = compositor.take_seat(seat_name.as_str()) {
+            let pointer_grab = &mut *(event as *mut PointerGrab);
+            handler.pointer_grabbed(compositor, &mut seat, pointer_grab);
+            compositor.replace_seat(seat);
+        }
     };
 
     pointer_grab_end_listener => pointer_grab_end_notify: |this: &mut Seat,
@@ -90,10 +91,11 @@ wayland_listener!(Seat, (*mut wlr_seat, Box<SeatHandler>), [
         let compositor = &mut *COMPOSITOR_PTR;
         let seat_name = c_to_rust_string((*seat_ptr).name)
             .expect("Bad name for seat");
-        let mut seat = compositor.take_seat(seat_name.as_str());
-        let pointer_grab = &mut *(event as *mut PointerGrab);
-        handler.pointer_released(compositor, &mut seat, pointer_grab);
-        compositor.replace_seat(seat);
+        if let Some(mut seat) = compositor.take_seat(seat_name.as_str()) {
+            let pointer_grab = &mut *(event as *mut PointerGrab);
+            handler.pointer_released(compositor, &mut seat, pointer_grab);
+            compositor.replace_seat(seat);
+        }
     };
     keyboard_grab_begin_listener => keyboard_grab_begin_notify: |this: &mut Seat,
     event: *mut libc::c_void,|
@@ -102,10 +104,11 @@ wayland_listener!(Seat, (*mut wlr_seat, Box<SeatHandler>), [
         let compositor = &mut *COMPOSITOR_PTR;
         let seat_name = c_to_rust_string((*seat_ptr).name)
             .expect("Bad name for seat");
-        let mut seat = compositor.take_seat(seat_name.as_str());
-        let keyboard_grab = &mut *(event as *mut KeyboardGrab);
-        handler.keyboard_grabbed(compositor, &mut seat, keyboard_grab);
-        compositor.replace_seat(seat);
+        if let Some(mut seat) = compositor.take_seat(seat_name.as_str()) {
+            let keyboard_grab = &mut *(event as *mut KeyboardGrab);
+            handler.keyboard_grabbed(compositor, &mut seat, keyboard_grab);
+            compositor.replace_seat(seat);
+        }
     };
     keyboard_grab_end_listener => keyboard_grab_end_notify: |this: &mut Seat,
     event: *mut libc::c_void,|
@@ -114,10 +117,11 @@ wayland_listener!(Seat, (*mut wlr_seat, Box<SeatHandler>), [
         let compositor = &mut *COMPOSITOR_PTR;
         let seat_name = c_to_rust_string((*seat_ptr).name)
             .expect("Bad name for seat");
-        let mut seat = compositor.take_seat(seat_name.as_str());
-        let keyboard_grab = &mut *(event as *mut KeyboardGrab);
-        handler.keyboard_released(compositor, &mut seat, keyboard_grab);
-        compositor.replace_seat(seat);
+        if let Some(mut seat) = compositor.take_seat(seat_name.as_str()) {
+            let keyboard_grab = &mut *(event as *mut KeyboardGrab);
+            handler.keyboard_released(compositor, &mut seat, keyboard_grab);
+            compositor.replace_seat(seat);
+        }
     };
     touch_grab_begin_listener => touch_grab_begin_notify: |this: &mut Seat,
     event: *mut libc::c_void,|
@@ -126,10 +130,11 @@ wayland_listener!(Seat, (*mut wlr_seat, Box<SeatHandler>), [
         let compositor = &mut *COMPOSITOR_PTR;
         let seat_name = c_to_rust_string((*seat_ptr).name)
             .expect("Bad name for seat");
-        let mut seat = compositor.take_seat(seat_name.as_str());
-        let touch_grab = &mut *(event as *mut TouchGrab);
-        handler.touch_grabbed(compositor, &mut seat, touch_grab);
-        compositor.replace_seat(seat);
+        if let Some(mut seat) = compositor.take_seat(seat_name.as_str()) {
+            let touch_grab = &mut *(event as *mut TouchGrab);
+            handler.touch_grabbed(compositor, &mut seat, touch_grab);
+            compositor.replace_seat(seat);
+        }
     };
     touch_grab_end_listener => touch_grab_end_notify: |this: &mut Seat,
     event: *mut libc::c_void,|
@@ -138,10 +143,11 @@ wayland_listener!(Seat, (*mut wlr_seat, Box<SeatHandler>), [
         let compositor = &mut *COMPOSITOR_PTR;
         let seat_name = c_to_rust_string((*seat_ptr).name)
             .expect("Bad name for seat");
-        let mut seat = compositor.take_seat(seat_name.as_str());
-        let touch_grab = &mut *(event as *mut TouchGrab);
-        handler.touch_released(compositor, &mut seat, touch_grab);
-        compositor.replace_seat(seat);
+        if let Some(mut seat) = compositor.take_seat(seat_name.as_str()) {
+            let touch_grab = &mut *(event as *mut TouchGrab);
+            handler.touch_released(compositor, &mut seat, touch_grab);
+            compositor.replace_seat(seat);
+        }
     };
     request_set_cursor_listener => request_set_cursor_notify: |this: &mut Seat,
     _event: *mut libc::c_void,|
@@ -150,9 +156,10 @@ wayland_listener!(Seat, (*mut wlr_seat, Box<SeatHandler>), [
         let compositor = &mut *COMPOSITOR_PTR;
         let seat_name = c_to_rust_string((*seat_ptr).name)
             .expect("Bad name for seat");
-        let mut seat = compositor.take_seat(seat_name.as_str());
-        handler.cursor_set(compositor, &mut seat);
-        compositor.replace_seat(seat);
+        if let Some(mut seat) = compositor.take_seat(seat_name.as_str()) {
+            handler.cursor_set(compositor, &mut seat);
+            compositor.replace_seat(seat);
+        }
     };
     selection_listener => selection_notify: |this: &mut Seat, _event: *mut libc::c_void,|
     unsafe {
@@ -160,9 +167,10 @@ wayland_listener!(Seat, (*mut wlr_seat, Box<SeatHandler>), [
         let compositor = &mut *COMPOSITOR_PTR;
         let seat_name = c_to_rust_string((*seat_ptr).name)
             .expect("Bad name for seat");
-        let mut seat = compositor.take_seat(seat_name.as_str());
-        handler.received_selection(compositor, &mut seat);
-        compositor.replace_seat(seat);
+        if let Some(mut seat) = compositor.take_seat(seat_name.as_str()) {
+            handler.received_selection(compositor, &mut seat);
+            compositor.replace_seat(seat);
+        }
     };
     primary_selection_listener => primary_selection_notify: |this: &mut Seat,
     _event: *mut libc::c_void,|
@@ -171,9 +179,10 @@ wayland_listener!(Seat, (*mut wlr_seat, Box<SeatHandler>), [
         let compositor = &mut *COMPOSITOR_PTR;
         let seat_name = c_to_rust_string((*seat_ptr).name)
             .expect("Bad name for seat");
-        let mut seat = compositor.take_seat(seat_name.as_str());
-        handler.primary_selection(compositor, &mut seat);
-        compositor.replace_seat(seat);
+        if let Some(mut seat) = compositor.take_seat(seat_name.as_str()) {
+            handler.primary_selection(compositor, &mut seat);
+            compositor.replace_seat(seat);
+        }
     };
     destroy_listener => destroy_notify: |this: &mut Seat, _event: *mut libc::c_void,|
     unsafe {
@@ -185,9 +194,10 @@ wayland_listener!(Seat, (*mut wlr_seat, Box<SeatHandler>), [
         let compositor = &mut *COMPOSITOR_PTR;
         let seat_name = c_to_rust_string((*seat_ptr).name)
             .expect("Bad name for seat");
-        let mut seat = compositor.take_seat(seat_name.as_str());
-        handler.destroy(compositor, &mut seat);
-        compositor.replace_seat(seat);
+        if let Some(mut seat) = compositor.take_seat(seat_name.as_str()) {
+            handler.destroy(compositor, &mut seat);
+            compositor.replace_seat(seat);
+        }
     };
 ]);
 

--- a/src/types/seat/seat.rs
+++ b/src/types/seat/seat.rs
@@ -212,7 +212,7 @@ impl Seat {
     }
 
     /// Determines if the surface has pointer focus.
-    pub fn pointer_surface_has_focus(&self, surface: Surface) -> bool {
+    pub fn pointer_surface_has_focus(&self, surface: &mut Surface) -> bool {
         let seat = self.data.borrow();
         unsafe { wlr_seat_pointer_surface_has_focus(seat.seat, surface.as_ptr()) }
     }
@@ -226,7 +226,7 @@ impl Seat {
     //
     // Compositor should use `Seat::pointer_notify_enter` to
     // change pointer focus to respect pointer grabs.
-    pub fn pointer_enter(&self, surface: Surface, sx: f64, sy: f64) {
+    pub fn pointer_enter(&self, surface: &mut Surface, sx: f64, sy: f64) {
         let seat = self.data.borrow();
         unsafe {
             wlr_seat_pointer_enter(seat.seat, surface.as_ptr(), sx, sy);
@@ -308,7 +308,7 @@ impl Seat {
     /// to be the focused surface for the pointer.
     ///
     /// Pass surface-local coordinates where the enter occurred.
-    pub fn pointer_notify_enter(&self, surface: Surface, sx: f64, sy: f64) {
+    pub fn pointer_notify_enter(&self, surface: &mut Surface, sx: f64, sy: f64) {
         let seat = self.data.borrow();
         unsafe { wlr_seat_pointer_notify_enter(seat.seat, surface.as_ptr(), sx, sy) }
     }
@@ -372,7 +372,7 @@ impl Seat {
     /// Compositors should use `Seat::keyboard_notify_enter()` to
     /// change keyboard focus to respect keyboard grabs.
     pub fn keyboard_enter(&self,
-                          surface: Surface,
+                          surface: &mut Surface,
                           keycodes: &mut [Keycode],
                           modifiers: &mut KeyboardModifiers) {
         let seat = self.data.borrow();
@@ -426,7 +426,7 @@ impl Seat {
     ///
     /// Defers to any current grab of the seat's keyboard.
     pub fn keyboard_notify_enter(&self,
-                                 surface: Surface,
+                                 surface: &mut Surface,
                                  keycodes: &mut [Keycode],
                                  modifiers: &mut KeyboardModifiers) {
         let seat = self.data.borrow();
@@ -495,7 +495,7 @@ impl Seat {
     ///
     /// The surface is required. To clear focus, use `Seat::touch_point_clear_focus()`.
     pub fn touch_point_focus(&self,
-                             surface: Surface,
+                             surface: &mut Surface,
                              time: Duration,
                              touch_id: TouchId,
                              sx: f64,
@@ -530,7 +530,7 @@ impl Seat {
     /// Compositors should use `Seat::touch_notify_down()` to
     /// respect any grabs of the touch device.
     pub fn touch_send_down(&self,
-                           surface: Surface,
+                           surface: &mut Surface,
                            time: Duration,
                            touch_id: TouchId,
                            sx: f64,
@@ -578,7 +578,7 @@ impl Seat {
     /// Notify the seat of a touch down on the given surface. Defers to any grab of
     /// the touch device.
     pub fn touch_notify_down(&self,
-                             surface: Surface,
+                             surface: &mut Surface,
                              time: Duration,
                              touch_id: TouchId,
                              sx: f64,

--- a/src/types/seat/seat.rs
+++ b/src/types/seat/seat.rs
@@ -177,8 +177,6 @@ wayland_listener!(Seat, (*mut wlr_seat, Box<SeatHandler>), [
     };
     destroy_listener => destroy_notify: |this: &mut Seat, _event: *mut libc::c_void,|
     unsafe {
-        // TODO FIXME
-        // Should we just pass `Seat` here and destroy it that way?
         let (seat_ptr, ref mut handler) = this.data;
         if COMPOSITOR_PTR.is_null() {
             // We are shutting down, don't try to grab the pointer.

--- a/src/types/seat/seat.rs
+++ b/src/types/seat/seat.rs
@@ -36,24 +36,6 @@ use compositor::COMPOSITOR_PTR;
 use utils::{c_to_rust_string, safe_as_cstring};
 use utils::ToMS;
 
-/// The different states a seat can be in globally.
-///
-/// Either we are not in a seat callback, and you can safely use
-/// the seat how you wish (including dropping it),
-/// or we are in a seat callback and it's currently borrowed.
-#[derive(Debug)]
-pub enum MaybeSeat {
-    /// The seat is available for use or for dropping.
-    Seat(Seat),
-    /// The seat has been borrowed and cannot be dropped.
-    Borrowed(*mut wlr_seat)
-}
-
-/// A unique identifier (really just the pointer) to the seat.
-///
-/// Used to drop it from the list, if it is not currently borrowed.
-pub struct SeatId(pub(crate) *mut wlr_seat);
-
 pub trait SeatHandler {
     /// Callback triggered when a client has grabbed a pointer.
     fn pointer_grabbed(&mut self, &mut Compositor, &mut Seat, &mut PointerGrab) {}
@@ -93,7 +75,9 @@ wayland_listener!(Seat, (*mut wlr_seat, Box<SeatHandler>), [
     unsafe {
         let (seat_ptr, ref mut handler) = this.data;
         let compositor = &mut *COMPOSITOR_PTR;
-        let mut seat = compositor.take_seat(SeatId(seat_ptr));
+        let seat_name = c_to_rust_string((*seat_ptr).name)
+            .expect("Bad name for seat");
+        let mut seat = compositor.take_seat(seat_name.as_str());
         let pointer_grab = &mut *(event as *mut PointerGrab);
         handler.pointer_grabbed(compositor, &mut seat, pointer_grab);
         compositor.replace_seat(seat);
@@ -104,7 +88,9 @@ wayland_listener!(Seat, (*mut wlr_seat, Box<SeatHandler>), [
     unsafe {
         let (seat_ptr, ref mut handler) = this.data;
         let compositor = &mut *COMPOSITOR_PTR;
-        let mut seat = compositor.take_seat(SeatId(seat_ptr));
+        let seat_name = c_to_rust_string((*seat_ptr).name)
+            .expect("Bad name for seat");
+        let mut seat = compositor.take_seat(seat_name.as_str());
         let pointer_grab = &mut *(event as *mut PointerGrab);
         handler.pointer_released(compositor, &mut seat, pointer_grab);
         compositor.replace_seat(seat);
@@ -114,7 +100,9 @@ wayland_listener!(Seat, (*mut wlr_seat, Box<SeatHandler>), [
     unsafe {
         let (seat_ptr, ref mut handler) = this.data;
         let compositor = &mut *COMPOSITOR_PTR;
-        let mut seat = compositor.take_seat(SeatId(seat_ptr));
+        let seat_name = c_to_rust_string((*seat_ptr).name)
+            .expect("Bad name for seat");
+        let mut seat = compositor.take_seat(seat_name.as_str());
         let keyboard_grab = &mut *(event as *mut KeyboardGrab);
         handler.keyboard_grabbed(compositor, &mut seat, keyboard_grab);
         compositor.replace_seat(seat);
@@ -124,7 +112,9 @@ wayland_listener!(Seat, (*mut wlr_seat, Box<SeatHandler>), [
     unsafe {
         let (seat_ptr, ref mut handler) = this.data;
         let compositor = &mut *COMPOSITOR_PTR;
-        let mut seat = compositor.take_seat(SeatId(seat_ptr));
+        let seat_name = c_to_rust_string((*seat_ptr).name)
+            .expect("Bad name for seat");
+        let mut seat = compositor.take_seat(seat_name.as_str());
         let keyboard_grab = &mut *(event as *mut KeyboardGrab);
         handler.keyboard_released(compositor, &mut seat, keyboard_grab);
         compositor.replace_seat(seat);
@@ -134,7 +124,9 @@ wayland_listener!(Seat, (*mut wlr_seat, Box<SeatHandler>), [
     unsafe {
         let (seat_ptr, ref mut handler) = this.data;
         let compositor = &mut *COMPOSITOR_PTR;
-        let mut seat = compositor.take_seat(SeatId(seat_ptr));
+        let seat_name = c_to_rust_string((*seat_ptr).name)
+            .expect("Bad name for seat");
+        let mut seat = compositor.take_seat(seat_name.as_str());
         let touch_grab = &mut *(event as *mut TouchGrab);
         handler.touch_grabbed(compositor, &mut seat, touch_grab);
         compositor.replace_seat(seat);
@@ -144,7 +136,9 @@ wayland_listener!(Seat, (*mut wlr_seat, Box<SeatHandler>), [
     unsafe {
         let (seat_ptr, ref mut handler) = this.data;
         let compositor = &mut *COMPOSITOR_PTR;
-        let mut seat = compositor.take_seat(SeatId(seat_ptr));
+        let seat_name = c_to_rust_string((*seat_ptr).name)
+            .expect("Bad name for seat");
+        let mut seat = compositor.take_seat(seat_name.as_str());
         let touch_grab = &mut *(event as *mut TouchGrab);
         handler.touch_released(compositor, &mut seat, touch_grab);
         compositor.replace_seat(seat);
@@ -154,7 +148,9 @@ wayland_listener!(Seat, (*mut wlr_seat, Box<SeatHandler>), [
     unsafe {
         let (seat_ptr, ref mut handler) = this.data;
         let compositor = &mut *COMPOSITOR_PTR;
-        let mut seat = compositor.take_seat(SeatId(seat_ptr));
+        let seat_name = c_to_rust_string((*seat_ptr).name)
+            .expect("Bad name for seat");
+        let mut seat = compositor.take_seat(seat_name.as_str());
         handler.cursor_set(compositor, &mut seat);
         compositor.replace_seat(seat);
     };
@@ -162,7 +158,9 @@ wayland_listener!(Seat, (*mut wlr_seat, Box<SeatHandler>), [
     unsafe {
         let (seat_ptr, ref mut handler) = this.data;
         let compositor = &mut *COMPOSITOR_PTR;
-        let mut seat = compositor.take_seat(SeatId(seat_ptr));
+        let seat_name = c_to_rust_string((*seat_ptr).name)
+            .expect("Bad name for seat");
+        let mut seat = compositor.take_seat(seat_name.as_str());
         handler.received_selection(compositor, &mut seat);
         compositor.replace_seat(seat);
     };
@@ -171,7 +169,9 @@ wayland_listener!(Seat, (*mut wlr_seat, Box<SeatHandler>), [
     unsafe {
         let (seat_ptr, ref mut handler) = this.data;
         let compositor = &mut *COMPOSITOR_PTR;
-        let mut seat = compositor.take_seat(SeatId(seat_ptr));
+        let seat_name = c_to_rust_string((*seat_ptr).name)
+            .expect("Bad name for seat");
+        let mut seat = compositor.take_seat(seat_name.as_str());
         handler.primary_selection(compositor, &mut seat);
         compositor.replace_seat(seat);
     };
@@ -183,7 +183,9 @@ wayland_listener!(Seat, (*mut wlr_seat, Box<SeatHandler>), [
             return
         }
         let compositor = &mut *COMPOSITOR_PTR;
-        let mut seat = compositor.take_seat(SeatId(seat_ptr));
+        let seat_name = c_to_rust_string((*seat_ptr).name)
+            .expect("Bad name for seat");
+        let mut seat = compositor.take_seat(seat_name.as_str());
         handler.destroy(compositor, &mut seat);
         compositor.replace_seat(seat);
     };
@@ -200,7 +202,7 @@ impl Seat {
     pub fn create(compositor: &mut Compositor,
                   name: String,
                   handler: Box<SeatHandler>)
-                  -> Option<Box<Self>> {
+                  -> Option<&mut Box<Self>> {
         unsafe {
             let name = safe_as_cstring(name);
             let seat = wlr_seat_create(compositor.display() as _, name.as_ptr());
@@ -228,7 +230,7 @@ impl Seat {
                               res.primary_selection_listener() as *mut _ as _);
                 wl_signal_add(&mut (*seat).events.destroy as *mut _ as _,
                               res.destroy_listener() as *mut _ as _);
-                Some(res)
+                Some(compositor.add_seat(res))
             }
         }
     }
@@ -246,6 +248,7 @@ impl Seat {
 
     /// Updates the name of this seat.
     /// Will automatically send it to all clients.
+    // TODO FIXME Setting this could de-sync it with what's in the hashmap...
     pub fn set_name(&mut self, name: String) {
         let name = safe_as_cstring(name);
         unsafe {

--- a/src/types/seat/seat.rs
+++ b/src/types/seat/seat.rs
@@ -7,7 +7,7 @@ use std::cell::RefCell;
 use std::time::Duration;
 
 use xkbcommon::xkb::Keycode;
-
+use libc;
 use wlroots_sys::{wlr_axis_orientation, wlr_seat, wlr_seat_create, wlr_seat_destroy,
                   wlr_seat_keyboard_clear_focus, wlr_seat_keyboard_end_grab,
                   wlr_seat_keyboard_enter, wlr_seat_keyboard_has_grab,
@@ -29,35 +29,129 @@ use wlroots_sys::{wlr_axis_orientation, wlr_seat, wlr_seat_create, wlr_seat_dest
                   wlr_seat_touch_start_grab};
 use wlroots_sys::wayland_server::protocol::wl_seat::Capability;
 
-use compositor::Compositor;
+use compositor::COMPOSITOR_PTR;
 use utils::{c_to_rust_string, safe_as_cstring};
-
-use super::grab::{KeyboardGrab, PointerGrab, TouchGrab};
-use super::touch_point::{TouchId, TouchPoint};
-use types::input_device::InputDevice;
-use types::surface::Surface;
 use utils::ToMS;
-
-use KeyboardModifiers;
+use {Compositor, InputDevice, KeyboardGrab, KeyboardModifiers, PointerGrab, Surface, TouchGrab,
+     TouchId, TouchPoint};
 
 pub trait SeatHandler {
-    // TODO
+    /// Callback triggered when a client has grabbed a pointer.
+    fn pointer_grabbed(&mut self, &mut Compositor, &Seat, &mut PointerGrab) {}
+
+    /// Callback triggered when a client has ended a pointer grab.
+    fn pointer_released(&mut self, &mut Compositor, &Seat, &mut PointerGrab) {}
+
+    /// Callback triggered when a client has grabbed a keyboard.
+    fn keyboard_grabbed(&mut self, &mut Compositor, &Seat, &mut KeyboardGrab) {}
+
+    /// Callback triggered when a client has ended a keyboard grab.
+    fn keyboard_released(&mut self, &mut Compositor, &Seat, &mut KeyboardGrab) {}
+
+    /// Callback triggered when a client has grabbed a touch.
+    fn touch_grabbed(&mut self, &mut Compositor, &Seat, &mut TouchGrab) {}
+
+    /// Callback triggered when a client has ended a touch grab.
+    fn touch_released(&mut self, &mut Compositor, &Seat, &mut TouchGrab) {}
+
+    /* TODO FIXME wlr_seat_pointer_request_set_cursor_event */
+    fn cursor_set(&mut self, &mut Compositor, &Seat) {}
+
+    /// The seat was provided with a selection by the client.
+    fn received_selection(&mut self, &mut Compositor, &Seat) {}
+
+    /// The seat was provided with a selection from the primary buffer
+    /// by the client.
+    fn primary_selection(&mut self, &mut Compositor, &Seat) {}
+
+    /// The seat is being destroyed.
+    fn destroy(&mut self, &mut Compositor, &Seat) {}
 }
 
 /// The structure that contains all actual seat pointers.
 ///
 /// This is here so that we can ensure unique access.
-struct SeatInner {
+pub struct SeatInner {
     handler: Box<SeatHandler>,
-    seat: *mut wlr_seat
+    seat: *mut wlr_seat,
 }
 
-/// A wrapper around `wlr_seat`.
-#[repr(C)]
-pub struct Seat {
-    inner: RefCell<SeatInner>
-    // TODO Listeners
-}
+wayland_listener!(Seat, RefCell<SeatInner>, [
+    pointer_grab_begin_listener => pointer_grab_begin_notify: |this: &mut Seat,
+                                                               event: *mut libc::c_void,|
+    unsafe {
+        let mut inner = this.data.borrow_mut();
+        let compositor = &mut *COMPOSITOR_PTR;
+        let pointer_grab = &mut *(event as *mut PointerGrab);
+        inner.handler.pointer_grabbed(compositor, &*this, pointer_grab);
+    };
+    pointer_grab_end_listener => pointer_grab_end_notify: |this: &mut Seat,
+    event: *mut libc::c_void,|
+    unsafe {
+        let mut inner = this.data.borrow_mut();
+        let compositor = &mut *COMPOSITOR_PTR;
+        let pointer_grab = &mut *(event as *mut PointerGrab);
+        inner.handler.pointer_released(compositor, &*this, pointer_grab);
+    };
+    keyboard_grab_begin_listener => keyboard_grab_begin_notify: |this: &mut Seat,
+    event: *mut libc::c_void,|
+    unsafe {
+        let mut inner = this.data.borrow_mut();
+        let compositor = &mut *COMPOSITOR_PTR;
+        let keyboard_grab = &mut *(event as *mut KeyboardGrab);
+        inner.handler.keyboard_grabbed(compositor, &*this, keyboard_grab);
+    };
+    keyboard_grab_end_listener => keyboard_grab_end_notify: |this: &mut Seat,
+    event: *mut libc::c_void,|
+    unsafe {
+        let mut inner = this.data.borrow_mut();
+        let compositor = &mut *COMPOSITOR_PTR;
+        let keyboard_grab = &mut *(event as *mut KeyboardGrab);
+        inner.handler.keyboard_released(compositor, &*this, keyboard_grab);
+    };
+    touch_grab_begin_listener => touch_grab_begin_notify: |this: &mut Seat,
+    event: *mut libc::c_void,|
+    unsafe {
+        let mut inner = this.data.borrow_mut();
+        let compositor = &mut *COMPOSITOR_PTR;
+        let touch_grab = &mut *(event as *mut TouchGrab);
+        inner.handler.touch_grabbed(compositor, &*this, touch_grab);
+    };
+    touch_grab_end_listener => touch_grab_end_notify: |this: &mut Seat,
+    event: *mut libc::c_void,|
+    unsafe {
+        let mut inner = this.data.borrow_mut();
+        let compositor = &mut *COMPOSITOR_PTR;
+        let touch_grab = &mut *(event as *mut TouchGrab);
+        inner.handler.touch_released(compositor, &*this, touch_grab);
+    };
+    request_set_cursor_listener => request_set_cursor_notify: |this: &mut Seat,
+    _event: *mut libc::c_void,|
+    unsafe {
+        let mut inner = this.data.borrow_mut();
+        let compositor = &mut *COMPOSITOR_PTR;
+        inner.handler.cursor_set(compositor, &*this);
+    };
+    selection_listener => selection_notify: |this: &mut Seat, _event: *mut libc::c_void,|
+    unsafe {
+        let mut inner = this.data.borrow_mut();
+        let compositor = &mut *COMPOSITOR_PTR;
+        inner.handler.received_selection(compositor, &*this);
+    };
+    primary_selection_listener => primary_selection_notify: |this: &mut Seat,
+    _event: *mut libc::c_void,|
+    unsafe {
+        let mut inner = this.data.borrow_mut();
+        let compositor = &mut *COMPOSITOR_PTR;
+        inner.handler.primary_selection(compositor, &*this);
+    };
+    destroy_listener => destroy_notify: |this: &mut Seat, _event: *mut libc::c_void,|
+    unsafe {
+        let mut inner = this.data.borrow_mut();
+        let compositor = &mut *COMPOSITOR_PTR;
+        inner.handler.destroy(compositor, &*this);
+    };
+]);
 
 impl Seat {
     /// Allocates a new `wlr_seat` and adds a wl_seat global to the display.
@@ -67,24 +161,24 @@ impl Seat {
     ///
     /// Puts the seat in an `Rc` so that the address is static for internal
     /// purposes.
-    pub fn new(compositor: &mut Compositor,
+    pub fn create(compositor: &mut Compositor,
                name: String,
                handler: Box<SeatHandler>)
-               -> Option<Self> {
+               -> Option<Box<Self>> {
         unsafe {
             let name = safe_as_cstring(name);
             let seat = wlr_seat_create(compositor.display() as _, name.as_ptr());
             if seat.is_null() {
                 None
             } else {
-                Some(Seat { inner: RefCell::new(SeatInner { seat, handler }) })
+                Some(Seat::new(RefCell::new(SeatInner { seat, handler })))
             }
         }
     }
 
     /// Get the name of the seat.
     pub fn name(&self) -> Option<String> {
-        let seat = self.inner.borrow();
+        let seat = self.data.borrow();
         unsafe {
             let name_ptr = (*seat.seat).name;
             if name_ptr.is_null() {
@@ -97,7 +191,7 @@ impl Seat {
     /// Updates the name of this seat.
     /// Will automatically send it to all clients.
     pub fn set_name(&self, name: String) {
-        let seat = self.inner.borrow();
+        let seat = self.data.borrow();
         let name = safe_as_cstring(name);
         unsafe {
             wlr_seat_set_name(seat.seat, name.as_ptr());
@@ -106,20 +200,20 @@ impl Seat {
 
     /// Gets the capabilities of this seat.
     pub fn capabilities(&self) -> Capability {
-        let seat = self.inner.borrow();
+        let seat = self.data.borrow();
         unsafe { Capability::from_raw((*seat.seat).capabilities).expect("Invalid capabilities") }
     }
 
     /// Updates the capabilities available on this seat.
     /// Will automatically send it to all clients.
     pub fn set_capabilities(&self, capabilities: Capability) {
-        let seat = self.inner.borrow();
+        let seat = self.data.borrow();
         unsafe { wlr_seat_set_capabilities(seat.seat, capabilities.bits()) }
     }
 
     /// Determines if the surface has pointer focus.
     pub fn pointer_surface_has_focus(&self, surface: Surface) -> bool {
-        let seat = self.inner.borrow();
+        let seat = self.data.borrow();
         unsafe { wlr_seat_pointer_surface_has_focus(seat.seat, surface.as_ptr()) }
     }
 
@@ -133,7 +227,7 @@ impl Seat {
     // Compositor should use `Seat::pointer_notify_enter` to
     // change pointer focus to respect pointer grabs.
     pub fn pointer_enter(&self, surface: Surface, sx: f64, sy: f64) {
-        let seat = self.inner.borrow();
+        let seat = self.data.borrow();
         unsafe {
             wlr_seat_pointer_enter(seat.seat, surface.as_ptr(), sx, sy);
         }
@@ -142,7 +236,7 @@ impl Seat {
     /// Clears the focused surface for the pointer and leaves all entered
     /// surfaces.
     pub fn clear_focus(&self) {
-        let seat = self.inner.borrow();
+        let seat = self.data.borrow();
         unsafe { wlr_seat_pointer_clear_focus(seat.seat) }
     }
 
@@ -153,7 +247,7 @@ impl Seat {
     /// Compositors should use `Seat::notify_motion` to
     /// send motion events to the respect pointer grabs.
     pub fn send_motion(&self, time: Duration, sx: f64, sy: f64) {
-        let seat = self.inner.borrow();
+        let seat = self.data.borrow();
         unsafe { wlr_seat_pointer_send_motion(seat.seat, time.to_ms(), sx, sy) }
     }
 
@@ -168,7 +262,7 @@ impl Seat {
     /// Compositors should use `Seat::notify_button` to
     /// send button events to respect pointer grabs.
     pub fn send_button(&self, time: Duration, button: u32, state: u32) -> u32 {
-        let seat = self.inner.borrow();
+        let seat = self.data.borrow();
         unsafe { wlr_seat_pointer_send_button(seat.seat, time.to_ms(), button, state) }
     }
 
@@ -177,7 +271,7 @@ impl Seat {
     /// Compositors should use `Seat::notify_axis` to
     /// send axis events to respect pointer grabs.
     pub fn send_axis(&self, time: Duration, orientation: wlr_axis_orientation, value: f64) {
-        let seat = self.inner.borrow();
+        let seat = self.data.borrow();
         unsafe {
             wlr_seat_pointer_send_axis(seat.seat, time.to_ms(), orientation, value);
         }
@@ -186,27 +280,27 @@ impl Seat {
     /// Start a grab of the pointer of this seat. The grabber is responsible for
     /// handling all pointer events until the grab ends.
     pub fn pointer_start_grab(&self, grab: PointerGrab) {
-        let seat = self.inner.borrow();
+        let seat = self.data.borrow();
         unsafe { wlr_seat_pointer_start_grab(seat.seat, grab.as_ptr()) }
     }
 
     /// End the grab of the pointer of this seat. This reverts the grab back to the
     /// default grab for the pointer.
     pub fn pointer_end_grab(&self) {
-        let seat = self.inner.borrow();
+        let seat = self.data.borrow();
         unsafe { wlr_seat_pointer_end_grab(seat.seat) }
     }
 
     /// Whether or not the pointer has a grab other than the default grab.
     pub fn pointer_has_grab(&self) -> bool {
-        let seat = self.inner.borrow();
+        let seat = self.data.borrow();
         unsafe { wlr_seat_pointer_has_grab(seat.seat) }
     }
 
     /// Clear the focused surface for the pointer and leave all entered
     /// surfaces.
     pub fn pointer_clear_focus(&self) {
-        let seat = self.inner.borrow();
+        let seat = self.data.borrow();
         unsafe { wlr_seat_pointer_clear_focus(seat.seat) }
     }
 
@@ -215,7 +309,7 @@ impl Seat {
     ///
     /// Pass surface-local coordinates where the enter occurred.
     pub fn pointer_notify_enter(&self, surface: Surface, sx: f64, sy: f64) {
-        let seat = self.inner.borrow();
+        let seat = self.data.borrow();
         unsafe { wlr_seat_pointer_notify_enter(seat.seat, surface.as_ptr(), sx, sy) }
     }
 
@@ -223,7 +317,7 @@ impl Seat {
     ///
     /// Pass surface-local coordinates where the pointer motion occurred.
     pub fn pointer_notify_motion(&self, time: Duration, sx: f64, sy: f64) {
-        let seat = self.inner.borrow();
+        let seat = self.data.borrow();
         unsafe { wlr_seat_pointer_notify_motion(seat.seat, time.to_ms(), sx, sy) }
     }
 
@@ -233,7 +327,7 @@ impl Seat {
     ///
     /// Returns the serial of the button press or zero if no button press was sent.
     pub fn pointer_notify_button(&self, time: Duration, button: u32, state: u32) -> u32 {
-        let seat = self.inner.borrow();
+        let seat = self.data.borrow();
         unsafe { wlr_seat_pointer_notify_button(seat.seat, time.to_ms(), button, state) }
     }
 
@@ -242,13 +336,13 @@ impl Seat {
                                time: Duration,
                                orientation: wlr_axis_orientation,
                                value: f64) {
-        let seat = self.inner.borrow();
+        let seat = self.data.borrow();
         unsafe { wlr_seat_pointer_notify_axis(seat.seat, time.to_ms(), orientation, value) }
     }
 
     /// Set this keyboard as the active keyboard for the seat.
     pub fn set_keyboard(&self, dev: InputDevice) {
-        let seat = self.inner.borrow();
+        let seat = self.data.borrow();
         unsafe { wlr_seat_set_keyboard(seat.seat, dev.as_ptr()) }
     }
 
@@ -258,7 +352,7 @@ impl Seat {
     ///
     /// Compositors should use `wlr_seat_notify_key()` to respect keyboard grabs.
     pub fn keyboard_send_key(&self, time: Duration, key: u32, state: u32) {
-        let seat = self.inner.borrow();
+        let seat = self.data.borrow();
         unsafe { wlr_seat_keyboard_send_key(seat.seat, time.to_ms(), key, state) }
     }
 
@@ -266,7 +360,7 @@ impl Seat {
     ///
     /// Compositors should use `Seat::keyboard_notify_modifiers()` to respect any keyboard grabs.
     pub fn keyboard_send_modifiers(&self, modifiers: &mut KeyboardModifiers) {
-        let seat = self.inner.borrow();
+        let seat = self.data.borrow();
         unsafe { wlr_seat_keyboard_send_modifiers(seat.seat, modifiers) }
     }
 
@@ -281,7 +375,7 @@ impl Seat {
                           surface: Surface,
                           keycodes: &mut [Keycode],
                           modifiers: &mut KeyboardModifiers) {
-        let seat = self.inner.borrow();
+        let seat = self.data.borrow();
         let keycodes_length = keycodes.len();
         unsafe {
             wlr_seat_keyboard_enter(seat.seat,
@@ -295,27 +389,27 @@ impl Seat {
     /// Start a grab of the keyboard of this seat. The grabber is responsible for
     /// handling all keyboard events until the grab ends.
     pub fn keyboard_start_grab(&self, grab: KeyboardGrab) {
-        let seat = self.inner.borrow();
+        let seat = self.data.borrow();
         unsafe { wlr_seat_keyboard_start_grab(seat.seat, grab.as_ptr()) }
     }
 
     /// End the grab of the keyboard of this seat. This reverts the grab back to the
     /// default grab for the keyboard.
     pub fn keyboard_end_grab(&self) {
-        let seat = self.inner.borrow();
+        let seat = self.data.borrow();
         unsafe { wlr_seat_keyboard_end_grab(seat.seat) }
     }
 
     /// Whether or not the keyboard has a grab other than the default grab
     pub fn keyboard_has_grab(&self) -> bool {
-        let seat = self.inner.borrow();
+        let seat = self.data.borrow();
         unsafe { wlr_seat_keyboard_has_grab(seat.seat) }
     }
 
     /// Clear the focused surface for the keyboard and leave all entered
     /// surfaces.
     pub fn keyboard_clear_focus(&self) {
-        let seat = self.inner.borrow();
+        let seat = self.data.borrow();
         unsafe { wlr_seat_keyboard_clear_focus(seat.seat) }
     }
 
@@ -323,7 +417,7 @@ impl Seat {
     ///
     /// Defers to any keyboard grabs.
     pub fn keyboard_notify_modifiers(&self, modifiers: &mut KeyboardModifiers) {
-        let seat = self.inner.borrow();
+        let seat = self.data.borrow();
         unsafe { wlr_seat_keyboard_notify_modifiers(seat.seat, modifiers) }
     }
 
@@ -335,7 +429,7 @@ impl Seat {
                                  surface: Surface,
                                  keycodes: &mut [Keycode],
                                  modifiers: &mut KeyboardModifiers) {
-        let seat = self.inner.borrow();
+        let seat = self.data.borrow();
         let keycodes_length = keycodes.len();
         unsafe {
             wlr_seat_keyboard_notify_enter(seat.seat,
@@ -352,40 +446,40 @@ impl Seat {
     ///
     /// Defers to any keyboard grabs.
     pub fn keyboard_notify_key(&self, time: Duration, key: u32, state: u32) {
-        let seat = self.inner.borrow();
+        let seat = self.data.borrow();
         unsafe { wlr_seat_keyboard_notify_key(seat.seat, time.to_ms(), key, state) }
     }
 
     /// How many touch ponits are currently down for the seat.
     pub fn touch_num_points(&self) -> i32 {
-        let seat = self.inner.borrow();
+        let seat = self.data.borrow();
         unsafe { wlr_seat_touch_num_points(seat.seat) }
     }
 
     /// Start a grab of the touch device of this seat. The grabber is responsible for
     /// handling all touch events until the grab ends.
     pub fn touch_start_grab(&self, grab: TouchGrab) {
-        let seat = self.inner.borrow();
+        let seat = self.data.borrow();
         unsafe { wlr_seat_touch_start_grab(seat.seat, grab.as_ptr()) }
     }
 
     /// End the grab of the touch device of this seat. This reverts the grab back to
     /// the default grab for the touch device.
     pub fn touch_end_grab(&self) {
-        let seat = self.inner.borrow();
+        let seat = self.data.borrow();
         unsafe { wlr_seat_touch_end_grab(seat.seat) }
     }
 
     /// Whether or not the seat has a touch grab other than the default grab.
     pub fn touch_has_grab(&self) -> bool {
-        let seat = self.inner.borrow();
+        let seat = self.data.borrow();
         unsafe { wlr_seat_touch_has_grab(seat.seat) }
     }
 
     // Get the active touch point with the given `touch_id`. If the touch point does
     // not exist or is no longer active, returns None.
     pub fn get_touch_point(&self, touch_id: TouchId) -> Option<TouchPoint> {
-        let seat = self.inner.borrow();
+        let seat = self.data.borrow();
         unsafe {
             let touch_point = wlr_seat_touch_get_point(seat.seat, touch_id.into());
             if touch_point.is_null() {
@@ -406,7 +500,7 @@ impl Seat {
                              touch_id: TouchId,
                              sx: f64,
                              sy: f64) {
-        let seat = self.inner.borrow();
+        let seat = self.data.borrow();
         unsafe {
             wlr_seat_touch_point_focus(seat.seat,
                                        surface.as_ptr(),
@@ -419,7 +513,7 @@ impl Seat {
 
     //// Clear the focused surface for the touch point given by `touch_id`.
     pub fn touch_point_clear_focus(&self, time: Duration, touch_id: TouchId) {
-        let seat = self.inner.borrow();
+        let seat = self.data.borrow();
         unsafe { wlr_seat_touch_point_clear_focus(seat.seat, time.to_ms(), touch_id.into()) }
     }
 
@@ -442,7 +536,7 @@ impl Seat {
                            sx: f64,
                            sy: f64)
                            -> u32 {
-        let seat = self.inner.borrow();
+        let seat = self.data.borrow();
         unsafe {
             wlr_seat_touch_send_down(seat.seat,
                                      surface.as_ptr(),
@@ -463,7 +557,7 @@ impl Seat {
     /// Compositors should use `Seat::touch_notify_up()` to
     /// respect any grabs of the touch device.
     pub fn touch_send_up(&self, time: Duration, touch_id: TouchId) {
-        let seat = self.inner.borrow();
+        let seat = self.data.borrow();
         unsafe { wlr_seat_touch_send_up(seat.seat, time.to_ms(), touch_id.into()) }
     }
 
@@ -475,7 +569,7 @@ impl Seat {
     /// Compositors should use `Seat::touch_notify_motion()` to
     /// respect any grabs of the touch device.
     pub fn touch_send_motion(&self, time: Duration, touch_id: TouchId, sx: f64, sy: f64) {
-        let seat = self.inner.borrow();
+        let seat = self.data.borrow();
         unsafe { wlr_seat_touch_send_motion(seat.seat, time.to_ms(), touch_id.into(), sx, sy) }
     }
 
@@ -490,7 +584,7 @@ impl Seat {
                              sx: f64,
                              sy: f64)
                              -> u32 {
-        let seat = self.inner.borrow();
+        let seat = self.data.borrow();
         unsafe {
             wlr_seat_touch_notify_down(seat.seat,
                                        surface.as_ptr(),
@@ -504,7 +598,7 @@ impl Seat {
     /// Notify the seat that the touch point given by `touch_id` is up. Defers to any
     /// grab of the touch device.
     pub fn touch_notify_up(&self, time: Duration, touch_id: TouchId) {
-        let seat = self.inner.borrow();
+        let seat = self.data.borrow();
         unsafe { wlr_seat_touch_notify_up(seat.seat, time.to_ms(), touch_id.into()) }
     }
 
@@ -515,19 +609,19 @@ impl Seat {
     /// The seat should be notified of touch motion even if the surface is
     /// not the owner of the touch point for processing by grabs.
     pub fn touch_notify_motion(&self, time: Duration, touch_id: TouchId, sx: f64, sy: f64) {
-        let seat = self.inner.borrow();
+        let seat = self.data.borrow();
         unsafe { wlr_seat_touch_notify_motion(seat.seat, time.to_ms(), touch_id.into(), sx, sy) }
     }
 
     pub(crate) unsafe fn as_ptr(&mut self) -> *mut wlr_seat {
-        let inner = self.inner.get_mut();
+        let inner = self.data.get_mut();
         inner.seat
     }
 }
 
 impl Drop for Seat {
     fn drop(&mut self) {
-        let inner = self.inner.get_mut();
+        let inner = self.data.get_mut();
         unsafe { wlr_seat_destroy(inner.seat) }
     }
 }

--- a/src/types/seat/seat_client.rs
+++ b/src/types/seat/seat_client.rs
@@ -33,7 +33,7 @@ impl<'wlr_seat> SeatClient<'wlr_seat> {
     pub unsafe fn client_for_wl_client(seat: &'wlr_seat mut Seat,
                                        client: *mut wl_client)
                                        -> Option<SeatClient<'wlr_seat>> {
-        let client = wlr_seat_client_for_wl_client(seat.inner().as_ptr(), client);
+        let client = wlr_seat_client_for_wl_client(seat.as_ptr(), client);
         if client.is_null() {
             None
         } else {

--- a/src/types/seat/seat_client.rs
+++ b/src/types/seat/seat_client.rs
@@ -33,7 +33,7 @@ impl<'wlr_seat> SeatClient<'wlr_seat> {
     pub unsafe fn client_for_wl_client(seat: &'wlr_seat mut Seat,
                                        client: *mut wl_client)
                                        -> Option<SeatClient<'wlr_seat>> {
-        let client = wlr_seat_client_for_wl_client(seat.as_ptr(), client);
+        let client = wlr_seat_client_for_wl_client(seat.inner().as_ptr(), client);
         if client.is_null() {
             None
         } else {

--- a/src/types/surface.rs
+++ b/src/types/surface.rs
@@ -148,6 +148,7 @@ impl Surface {
     ///
     /// Returns the surface and coordinates in the topmost surface coordinate system
     /// or None if no subsurface is found at that location.
+    #[allow(unused_variables)]
     pub fn subsurface_at(&mut self,
                          _sx: f32,
                          _sy: f32,


### PR DESCRIPTION
# Seat
Implemented Seat, Fixes #37. Seats are spawned and managed by wlroots-rs and can be accessed by name.

# Misc
Added null checks to the global compositor pointer.

# Output
Added `Output::schedule_frame`

# Macros
Made the functions created by `wayland_listener!` `pub(crate)`

# TODO
- [x] Remove `set_name`
- [x] Make a wrapper around `HashMap` since you could take the `Seat` out of the `Box` and invoke UB if you're not careful.
- [x] Review memory model to ensure this is correct, both in theory and implementation