### PR TITLE
Cursor events

### DIFF
--- a/examples/wl_shell_test.rs
+++ b/examples/wl_shell_test.rs
@@ -9,7 +9,7 @@ use std::thread;
 use std::time::Duration;
 
 use wlroots::{matrix_mul, matrix_rotate, matrix_scale, matrix_translate, Area, Compositor,
-              CompositorBuilder, CursorBuilder, InputManagerHandler, Keyboard, KeyboardHandler,
+              CompositorBuilder, CursorBuilder, InputManagerHandler, Keyboard, KeyboardHandler, CursorHandler,
               Origin, Output, OutputBuilder, OutputBuilderResult, OutputHandler, OutputLayout,
               OutputManagerHandler, Pointer, PointerHandler, Renderer, Seat, SeatHandler, Size,
               Surface, WlShellHandler, WlShellManagerHandler, WlShellSurface,
@@ -41,6 +41,10 @@ impl State {
 compositor_data!(State);
 
 struct SeatHandlerEx;
+
+struct CursorEx;
+
+impl CursorHandler for CursorEx {}
 
 impl SeatHandler for SeatHandlerEx {
     // TODO
@@ -298,7 +302,7 @@ impl InputManagerHandler for InputManager {
 
 fn main() {
     init_logging(L_DEBUG, None);
-    let cursor = CursorBuilder::new().expect("Could not create cursor");
+    let cursor = CursorBuilder::new(Box::new(CursorEx)).expect("Could not create cursor");
     let xcursor_theme = XCursorTheme::load_theme(None, 16).expect("Could not load theme");
     let mut layout = OutputLayout::new().expect("Could not construct an output layout");
 

--- a/examples/wl_shell_test.rs
+++ b/examples/wl_shell_test.rs
@@ -9,11 +9,11 @@ use std::thread;
 use std::time::Duration;
 
 use wlroots::{matrix_mul, matrix_rotate, matrix_scale, matrix_translate, Area, Compositor,
-              CompositorBuilder, CursorBuilder, InputManagerHandler, Keyboard, KeyboardHandler, CursorHandler,
-              Origin, Output, OutputBuilder, OutputBuilderResult, OutputHandler, OutputLayout,
-              OutputManagerHandler, Pointer, PointerHandler, Renderer, Seat, SeatHandler, Size,
-              Surface, WlShellHandler, WlShellManagerHandler, WlShellSurface,
-              WlShellSurfaceHandle, XCursorTheme};
+              CompositorBuilder, CursorBuilder, CursorHandler, CursorId, InputManagerHandler,
+              Keyboard, KeyboardHandler, Origin, Output, OutputBuilder, OutputBuilderResult,
+              OutputHandler, OutputLayout, OutputManagerHandler, Pointer, PointerHandler,
+              Renderer, Seat, SeatHandler, Size, Surface, WlShellHandler, WlShellManagerHandler,
+              WlShellSurface, WlShellSurfaceHandle, XCursorTheme};
 use wlroots::key_events::KeyEvent;
 use wlroots::pointer_events::{AxisEvent, ButtonEvent, MotionEvent};
 use wlroots::utils::{init_logging, L_DEBUG};
@@ -25,15 +25,17 @@ struct State {
     default_color: [f32; 4],
     xcursor_theme: XCursorTheme,
     layout: OutputLayout,
+    cursor_id: CursorId,
     shells: Vec<WlShellSurfaceHandle>
 }
 
 impl State {
-    fn new(xcursor_theme: XCursorTheme, layout: OutputLayout) -> Self {
+    fn new(xcursor_theme: XCursorTheme, layout: OutputLayout, cursor_id: CursorId) -> Self {
         State { color: [0.25, 0.25, 0.25, 1.0],
                 default_color: [0.25, 0.25, 0.25, 1.0],
                 xcursor_theme,
                 layout,
+                cursor_id,
                 shells: vec![] }
     }
 }
@@ -92,7 +94,7 @@ impl OutputManagerHandler for OutputManager {
         let image = &xcursor.images()[0];
         // TODO use output config if present instead of auto
         state.layout.add_auto(result.output);
-        let cursor = &mut state.layout.cursors()[0];
+        let mut cursor = state.layout.cursor(state.cursor_id).unwrap();
         cursor.set_cursor_image(image);
         let (x, y) = cursor.coords();
         // https://en.wikipedia.org/wiki/Mouse_warping
@@ -243,7 +245,10 @@ impl PointerHandler for ExPointer {
     fn on_motion(&mut self, compositor: &mut Compositor, _: &mut Pointer, event: &MotionEvent) {
         let state: &mut State = compositor.into();
         let (delta_x, delta_y) = event.delta();
-        state.layout.cursors()[0].move_to(event.device(), delta_x, delta_y);
+        state.layout
+             .cursor(state.cursor_id)
+             .unwrap()
+             .move_to(event.device(), delta_x, delta_y);
     }
 
     fn on_button(&mut self, compositor: &mut Compositor, _: &mut Pointer, event: &ButtonEvent) {
@@ -306,12 +311,13 @@ fn main() {
     let xcursor_theme = XCursorTheme::load_theme(None, 16).expect("Could not load theme");
     let mut layout = OutputLayout::new().expect("Could not construct an output layout");
 
-    layout.attach_cursor(cursor);
-    let mut compositor = CompositorBuilder::new().gles2(true)
-                                                 .build_auto(State::new(xcursor_theme, layout),
-                                                             Some(Box::new(InputManager)),
-                                                             Some(Box::new(OutputManager)),
-                                                             Some(Box::new(WlShellManager)));
+    let cursor_id = layout.attach_cursor(cursor);
+    let mut compositor =
+        CompositorBuilder::new().gles2(true)
+                                .build_auto(State::new(xcursor_theme, layout, cursor_id),
+                                            Some(Box::new(InputManager)),
+                                            Some(Box::new(OutputManager)),
+                                            Some(Box::new(WlShellManager)));
     Seat::create(&mut compositor, "Main Seat".into(), Box::new(SeatHandlerEx))
         .expect("Could not allocate the global seat");
     compositor.run();

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -1,3 +1,5 @@
 pub mod key_events;
 pub mod pointer_events;
 pub mod wl_shell_events;
+pub mod tablet_tool_events;
+pub mod touch_events;

--- a/src/events/tablet_tool_events.rs
+++ b/src/events/tablet_tool_events.rs
@@ -1,0 +1,152 @@
+//! TODO Documentation
+
+use wlroots_sys::{wlr_button_state, wlr_event_tablet_tool_axis, wlr_event_tablet_tool_button,
+                  wlr_event_tablet_tool_proximity, wlr_event_tablet_tool_tip,
+                  wlr_tablet_tool_proximity_state, wlr_tablet_tool_tip_state};
+
+#[derive(Debug)]
+/// Event that is triggered when a tablet tool axis event occurs.
+pub struct AxisEvent {
+    event: *mut wlr_event_tablet_tool_axis
+}
+
+#[derive(Debug)]
+/// Event that is triggered when a tablet tool proximity event occurs.
+pub struct ProximityEvent {
+    event: *mut wlr_event_tablet_tool_proximity
+}
+
+/// Event that is triggered when a tablet tool tip event occurs.
+pub struct TipEvent {
+    event: *mut wlr_event_tablet_tool_tip
+}
+
+/// Event that is triggered when a tablet tool button event occurs.
+pub struct ButtonEvent {
+    event: *mut wlr_event_tablet_tool_button
+}
+
+impl AxisEvent {
+    pub(crate) unsafe fn from_ptr(event: *mut wlr_event_tablet_tool_axis) -> Self {
+        AxisEvent { event }
+    }
+
+    pub fn time_msec(&self) -> u32 {
+        unsafe { (*self.event).time_msec }
+    }
+
+    pub fn updated_axes(&self) -> u32 {
+        unsafe { (*self.event).updated_axes }
+    }
+
+    /// Gets the position of the event in mm.
+    ///
+    /// Return value is in (x, y) format.
+    pub fn position(&self) -> (f64, f64) {
+        unsafe { ((*self.event).x_mm, (*self.event).y_mm) }
+    }
+
+    /// Gets the size of the touch event in mm.
+    ///
+    /// Return value is in (w, h) format.
+    pub fn size(&self) -> (f64, f64) {
+        unsafe { ((*self.event).width_mm, (*self.event).height_mm) }
+    }
+
+    pub fn pressure(&self) -> f64 {
+        unsafe { (*self.event).pressure }
+    }
+
+    pub fn distance(&self) -> f64 {
+        unsafe { (*self.event).distance }
+    }
+
+    /// Gets the tilt of the event.
+    ///
+    /// Return value is in (x, y) format.
+    pub fn tilt(&self) -> (f64, f64) {
+        unsafe { ((*self.event).tilt_x, (*self.event).tilt_y) }
+    }
+
+    pub fn slider(&self) -> f64 {
+        unsafe { (*self.event).slider }
+    }
+
+    pub fn wheel_delta(&self) -> f64 {
+        unsafe { (*self.event).wheel_delta }
+    }
+}
+
+impl ProximityEvent {
+    pub(crate) unsafe fn from_ptr(event: *mut wlr_event_tablet_tool_proximity) -> Self {
+        ProximityEvent { event }
+    }
+
+    pub fn time_msec(&self) -> u32 {
+        unsafe { (*self.event).time_msec }
+    }
+
+    /// Gets the position of the event in mm.
+    ///
+    /// Return value is in (x, y) format.
+    pub fn position(&self) -> (f64, f64) {
+        unsafe { ((*self.event).x_mm, (*self.event).y_mm) }
+    }
+
+    /// Gets the size of the touch event in mm.
+    ///
+    /// Return value is in (w, h) format.
+    pub fn size(&self) -> (f64, f64) {
+        unsafe { ((*self.event).width_mm, (*self.event).height_mm) }
+    }
+
+    pub fn state(&self) -> wlr_tablet_tool_proximity_state {
+        unsafe { (*self.event).state }
+    }
+}
+
+impl TipEvent {
+    pub(crate) unsafe fn from_ptr(event: *mut wlr_event_tablet_tool_tip) -> Self {
+        TipEvent { event }
+    }
+
+    pub fn time_msec(&self) -> u32 {
+        unsafe { (*self.event).time_msec }
+    }
+
+    /// Gets the position of the event in mm.
+    ///
+    /// Return value is in (x, y) format.
+    pub fn position(&self) -> (f64, f64) {
+        unsafe { ((*self.event).x_mm, (*self.event).y_mm) }
+    }
+
+    /// Gets the size of the touch event in mm.
+    ///
+    /// Return value is in (w, h) format.
+    pub fn size(&self) -> (f64, f64) {
+        unsafe { ((*self.event).width_mm, (*self.event).height_mm) }
+    }
+
+    pub fn state(&self) -> wlr_tablet_tool_tip_state {
+        unsafe { (*self.event).state }
+    }
+}
+
+impl ButtonEvent {
+    pub(crate) unsafe fn from_ptr(event: *mut wlr_event_tablet_tool_button) -> Self {
+        ButtonEvent { event }
+    }
+
+    pub fn time_msec(&self) -> u32 {
+        unsafe { (*self.event).time_msec }
+    }
+
+    pub fn button(&self) -> u32 {
+        unsafe { (*self.event).button }
+    }
+
+    pub fn state(&self) -> wlr_button_state {
+        unsafe { (*self.event).state }
+    }
+}

--- a/src/events/touch_events.rs
+++ b/src/events/touch_events.rs
@@ -1,0 +1,122 @@
+//! TODO Documentation
+
+use wlroots_sys::{wlr_event_touch_cancel, wlr_event_touch_down, wlr_event_touch_motion,
+                  wlr_event_touch_up};
+
+#[derive(Debug)]
+/// Event that is triggered when a touch down event occurs.
+pub struct DownEvent {
+    event: *mut wlr_event_touch_down
+}
+
+#[derive(Debug)]
+/// Event that is triggered when a touch up event occurs.
+pub struct UpEvent {
+    event: *mut wlr_event_touch_up
+}
+
+#[derive(Debug)]
+/// Event that is triggered when a touch motion event occurs.
+pub struct MotionEvent {
+    event: *mut wlr_event_touch_motion
+}
+
+#[derive(Debug)]
+/// Event that is triggered when a touch cancel event occurs.
+pub struct CancelEvent {
+    event: *mut wlr_event_touch_cancel
+}
+
+impl DownEvent {
+    /// Constructs a `DownEvent` from a raw event pointer.
+    pub(crate) unsafe fn from_ptr(event: *mut wlr_event_touch_down) -> Self {
+        DownEvent { event }
+    }
+
+    /// Gets how long the touch event has been going on for.
+    pub fn time_msec(&self) -> u32 {
+        unsafe { (*self.event).time_msec }
+    }
+
+    /// Gets the touch id associated with this event.
+    pub fn touch_id(&self) -> i32 {
+        unsafe { (*self.event).touch_id }
+    }
+
+    /// Gets the location of the touch event in mm.
+    ///
+    /// Return value is in (x, y) format.
+    pub fn location(&self) -> (f64, f64) {
+        unsafe { ((*self.event).x_mm, (*self.event).y_mm) }
+    }
+
+    /// Gets the size of the touch event in mm.
+    ///
+    /// Return value is in (w, h) format.
+    pub fn size(&self) -> (f64, f64) {
+        unsafe { ((*self.event).width_mm, (*self.event).height_mm) }
+    }
+}
+
+impl UpEvent {
+    /// Constructs a `UpEvent` from a raw event pointer.
+    pub(crate) unsafe fn from_ptr(event: *mut wlr_event_touch_up) -> Self {
+        UpEvent { event }
+    }
+
+    pub fn time_msec(&self) -> u32 {
+        unsafe { (*self.event).time_msec }
+    }
+
+    /// Gets the touch id associated with this event.
+    pub fn touch_id(&self) -> i32 {
+        unsafe { (*self.event).touch_id }
+    }
+}
+
+impl MotionEvent {
+    /// Constructs a `MotionEvent` from a raw event pointer.
+    pub(crate) unsafe fn from_ptr(event: *mut wlr_event_touch_motion) -> Self {
+        MotionEvent { event }
+    }
+
+    /// Gets how long the touch event has been going on for.
+    pub fn time_msec(&self) -> u32 {
+        unsafe { (*self.event).time_msec }
+    }
+
+    /// Gets the touch id associated with this event.
+    pub fn touch_id(&self) -> i32 {
+        unsafe { (*self.event).touch_id }
+    }
+
+    /// Gets the location of the touch event in mm.
+    ///
+    /// Return value is in (x, y) format.
+    pub fn location(&self) -> (f64, f64) {
+        unsafe { ((*self.event).x_mm, (*self.event).y_mm) }
+    }
+
+    /// Gets the size of the touch event in mm.
+    ///
+    /// Return value is in (w, h) format.
+    pub fn size(&self) -> (f64, f64) {
+        unsafe { ((*self.event).width_mm, (*self.event).height_mm) }
+    }
+}
+
+impl CancelEvent {
+    /// Constructs a `CancelEvent` from a raw event pointe
+    pub(crate) unsafe fn from_ptr(event: *mut wlr_event_touch_cancel) -> Self {
+        CancelEvent { event }
+    }
+
+    pub fn time_msec(&self) -> u32 {
+        unsafe { (*self.event).time_msec }
+    }
+
+    /// Gets the touch id associated with this event.
+    pub fn touch_id(&self) -> i32 {
+        unsafe { (*self.event).touch_id }
+    }
+}

--- a/src/types/cursor/cursor.rs
+++ b/src/types/cursor/cursor.rs
@@ -1,7 +1,10 @@
 //! Wrapper for wlr_cursor
 
-use std::ptr;
+use std::{fmt, ptr};
 
+use libc;
+use wayland_sys::server::WAYLAND_SERVER_HANDLE;
+use wayland_sys::server::signal::wl_signal_add;
 use wlroots_sys::{wlr_cursor, wlr_cursor_absolute_to_layout_coords,
                   wlr_cursor_attach_input_device, wlr_cursor_create, wlr_cursor_destroy,
                   wlr_cursor_detach_input_device, wlr_cursor_map_input_to_output,
@@ -10,11 +13,63 @@ use wlroots_sys::{wlr_cursor, wlr_cursor_absolute_to_layout_coords,
                   wlr_cursor_set_surface, wlr_cursor_warp, wlr_cursor_warp_absolute};
 
 use {Area, InputDevice, Output, OutputHandle, OutputLayoutHandle, Surface, XCursorImage};
+use compositor::{Compositor, COMPOSITOR_PTR};
 use errors::UpgradeHandleErr;
+use events::{pointer_events, tablet_tool_events, touch_events};
 
-#[derive(Debug)]
 pub struct CursorBuilder {
-    cursor: *mut wlr_cursor
+    cursor: *mut wlr_cursor,
+    cursor_handler: Box<CursorHandler>
+}
+
+pub trait CursorHandler {
+    /// Callback that is triggered when the cursor moves.
+    fn on_pointer_motion(&mut self,
+                         &mut Compositor,
+                         &mut Cursor,
+                         &mut pointer_events::MotionEvent) {
+    }
+
+    fn on_pointer_motion_absolute(&mut self,
+                                  &mut Compositor,
+                                  &mut Cursor,
+                                  &mut pointer_events::AbsoluteMotionEvent) {
+    }
+
+    /// Callback that is triggered when the buttons on the pointer are pressed.
+    fn on_pointer_button(&mut self,
+                         &mut Compositor,
+                         &mut Cursor,
+                         &mut pointer_events::ButtonEvent) {
+    }
+
+    fn on_pointer_axis(&mut self, &mut Compositor, &mut Cursor, &mut pointer_events::AxisEvent) {}
+
+    fn on_touch_up(&mut self, &mut Compositor, &mut Cursor, &mut touch_events::UpEvent) {}
+    fn on_touch_down(&mut self, &mut Compositor, &mut Cursor, &mut touch_events::DownEvent) {}
+    fn on_touch_motion(&mut self, &mut Compositor, &mut Cursor, &mut touch_events::MotionEvent) {}
+    fn on_touch_cancel(&mut self, &mut Compositor, &mut Cursor, &mut touch_events::CancelEvent) {}
+
+    fn on_tablet_tool_axis(&mut self,
+                           &mut Compositor,
+                           &mut Cursor,
+                           &mut tablet_tool_events::AxisEvent) {
+    }
+    fn on_tablet_tool_proximity(&mut self,
+                                &mut Compositor,
+                                &mut Cursor,
+                                &mut tablet_tool_events::ProximityEvent) {
+    }
+    fn on_tablet_tool_tip(&mut self,
+                          &mut Compositor,
+                          &mut Cursor,
+                          &mut tablet_tool_events::TipEvent) {
+    }
+    fn on_tablet_tool_button(&mut self,
+                             &mut Compositor,
+                             &mut Cursor,
+                             &mut tablet_tool_events::ButtonEvent) {
+    }
 }
 
 #[derive(Debug)]
@@ -23,14 +78,128 @@ pub struct Cursor {
     output_layout: OutputLayoutHandle
 }
 
+wayland_listener!(CursorWrapper, (Cursor, Box<CursorHandler>), [
+    pointer_motion_listener => pointer_motion_notify:
+    |this: &mut CursorWrapper, event: *mut libc::c_void,|
+    unsafe {
+        let (ref mut cursor, ref mut cursor_handler) = this.data;
+        let mut event = pointer_events::MotionEvent::from_ptr(event as _);
+        let compositor = &mut *COMPOSITOR_PTR;
+        cursor_handler.on_pointer_motion(compositor, cursor, &mut event)
+    };
+    pointer_motion_absolute_listener => pointer_motion_absolute_notify:
+    |this: &mut CursorWrapper, event: *mut libc::c_void,|
+    unsafe {
+        let (ref mut cursor, ref mut cursor_handler) = this.data;
+        let mut event = pointer_events::AbsoluteMotionEvent::from_ptr(event as _);
+        let compositor = &mut *COMPOSITOR_PTR;
+        cursor_handler.on_pointer_motion_absolute(compositor, cursor, &mut event);
+    };
+    pointer_button_listener => pointer_button_notify:
+    |this: &mut CursorWrapper, event: *mut libc::c_void,|
+    unsafe {
+        let (ref mut cursor, ref mut cursor_handler) = this.data;
+        let mut event = pointer_events::ButtonEvent::from_ptr(event as _);
+        let compositor = &mut *COMPOSITOR_PTR;
+        cursor_handler.on_pointer_button(compositor, cursor, &mut event);
+    };
+    pointer_axis_listener => pointer_axis_notify:
+    |this: &mut CursorWrapper, event: *mut libc::c_void,|
+    unsafe {
+        let (ref mut cursor, ref mut cursor_handler) = this.data;
+        let mut event = pointer_events::AxisEvent::from_ptr(event as _);
+        let compositor = &mut *COMPOSITOR_PTR;
+        cursor_handler.on_pointer_axis(compositor, cursor, &mut event);
+    };
+    touch_up_listener => touch_up_notify: |this: &mut CursorWrapper, event: *mut libc::c_void,|
+    unsafe {
+        let (ref mut cursor, ref mut cursor_handler) = this.data;
+        let mut event = touch_events::UpEvent::from_ptr(event as _);
+        let compositor = &mut *COMPOSITOR_PTR;
+        cursor_handler.on_touch_up(compositor, cursor, &mut event);
+    };
+    touch_down_listener => touch_down_notify: |this: &mut CursorWrapper, event: *mut libc::c_void,|
+    unsafe {
+        let (ref mut cursor, ref mut cursor_handler) = this.data;
+        let mut event = touch_events::DownEvent::from_ptr(event as _);
+        let compositor = &mut *COMPOSITOR_PTR;
+        cursor_handler.on_touch_down(compositor, cursor, &mut event);
+    };
+    touch_motion_listener => touch_motion_notify:
+    |this: &mut CursorWrapper, event: *mut libc::c_void,|
+    unsafe {
+        let (ref mut cursor, ref mut cursor_handler) = this.data;
+        let mut event = touch_events::MotionEvent::from_ptr(event as _);
+        let compositor = &mut *COMPOSITOR_PTR;
+        cursor_handler.on_touch_motion(compositor, cursor, &mut event);
+    };
+    touch_cancel_listener => touch_cancel_notify:
+    |this: &mut CursorWrapper, event: *mut libc::c_void,|
+    unsafe {
+        let (ref mut cursor, ref mut cursor_handler) = this.data;
+        let mut event = touch_events::CancelEvent::from_ptr(event as _);
+        let compositor = &mut *COMPOSITOR_PTR;
+        cursor_handler.on_touch_cancel(compositor, cursor, &mut event);
+    };
+    tablet_tool_axis_listener => tablet_tool_axis_notify:
+    |this: &mut CursorWrapper, event: *mut libc::c_void,|
+    unsafe {
+        let (ref mut cursor, ref mut cursor_handler) = this.data;
+        let mut event = tablet_tool_events::AxisEvent::from_ptr(event as _);
+        let compositor = &mut *COMPOSITOR_PTR;
+        cursor_handler.on_tablet_tool_axis(compositor, cursor, &mut event);
+    };
+    tablet_tool_proximity_listener => tablet_tool_proximity_notify:
+    |this: &mut CursorWrapper, event: *mut libc::c_void,|
+    unsafe {
+        let (ref mut cursor, ref mut cursor_handler) = this.data;
+        let mut event = tablet_tool_events::ProximityEvent::from_ptr(event as _);
+        let compositor = &mut *COMPOSITOR_PTR;
+        cursor_handler.on_tablet_tool_proximity(compositor, cursor, &mut event);
+    };
+    tablet_tool_tip_listener => tablet_tool_tip_notify:
+    |this: &mut CursorWrapper, event: *mut libc::c_void,|
+    unsafe {
+        let (ref mut cursor, ref mut cursor_handler) = this.data;
+        let mut event = tablet_tool_events::TipEvent::from_ptr(event as _);
+        let compositor = &mut *COMPOSITOR_PTR;
+        cursor_handler.on_tablet_tool_tip(compositor, cursor, &mut event);
+    };
+    tablet_tool_button_listener => tablet_tool_button_notify:
+    |this: &mut CursorWrapper, event: *mut libc::c_void,|
+    unsafe {
+        let (ref mut cursor, ref mut cursor_handler) = this.data;
+        let mut event = tablet_tool_events::ButtonEvent::from_ptr(event as _);
+        let compositor = &mut *COMPOSITOR_PTR;
+        cursor_handler.on_tablet_tool_button(compositor, cursor, &mut event);
+    };
+]);
+
+impl CursorWrapper {
+    pub(crate) unsafe fn as_ptr(&self) -> *mut wlr_cursor {
+        self.data.0.as_ptr()
+    }
+
+    pub(crate) fn cursor(&mut self) -> &mut Cursor {
+        &mut self.data.0
+    }
+}
+
+impl fmt::Debug for CursorWrapper {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "{:?}", self.data.0)
+    }
+}
+
 impl CursorBuilder {
-    pub fn new() -> Option<Self> {
+    pub fn new(cursor_handler: Box<CursorHandler>) -> Option<Self> {
         unsafe {
             let cursor = wlr_cursor_create();
             if cursor.is_null() {
                 None
             } else {
-                Some(CursorBuilder { cursor: cursor })
+                Some(CursorBuilder { cursor: cursor,
+                                     cursor_handler })
             }
         }
     }
@@ -56,9 +225,38 @@ impl CursorBuilder {
         self
     }
 
-    pub(crate) fn build(self, output_layout: OutputLayoutHandle) -> Cursor {
-        Cursor { cursor: self.cursor,
-                 output_layout }
+    pub(crate) fn build(self, output_layout: OutputLayoutHandle) -> Box<CursorWrapper> {
+        let cursor = self.cursor;
+        let mut cursor_wrapper = CursorWrapper::new((Cursor { cursor,
+                                                              output_layout },
+                                                    self.cursor_handler));
+        unsafe {
+            wl_signal_add(&mut (*cursor).events.motion as *mut _ as _,
+                          cursor_wrapper.pointer_motion_listener() as *mut _ as _);
+            wl_signal_add(&mut (*cursor).events.motion_absolute as *mut _ as _,
+                          cursor_wrapper.pointer_motion_absolute_listener() as *mut _ as _);
+            wl_signal_add(&mut (*cursor).events.button as *mut _ as _,
+                          cursor_wrapper.pointer_button_listener() as *mut _ as _);
+            wl_signal_add(&mut (*cursor).events.axis as *mut _ as _,
+                          cursor_wrapper.pointer_axis_listener() as *mut _ as _);
+            wl_signal_add(&mut (*cursor).events.touch_up as *mut _ as _,
+                          cursor_wrapper.touch_up_listener() as *mut _ as _);
+            wl_signal_add(&mut (*cursor).events.touch_down as *mut _ as _,
+                          cursor_wrapper.touch_down_listener() as *mut _ as _);
+            wl_signal_add(&mut (*cursor).events.touch_motion as *mut _ as _,
+                          cursor_wrapper.touch_motion_listener() as *mut _ as _);
+            wl_signal_add(&mut (*cursor).events.touch_cancel as *mut _ as _,
+                          cursor_wrapper.touch_cancel_listener() as *mut _ as _);
+            wl_signal_add(&mut (*cursor).events.tablet_tool_axis as *mut _ as _,
+                          cursor_wrapper.tablet_tool_axis_listener() as *mut _ as _);
+            wl_signal_add(&mut (*cursor).events.tablet_tool_proximity as *mut _ as _,
+                          cursor_wrapper.tablet_tool_proximity_listener() as *mut _ as _);
+            wl_signal_add(&mut (*cursor).events.tablet_tool_tip as *mut _ as _,
+                          cursor_wrapper.tablet_tool_tip_listener() as *mut _ as _);
+            wl_signal_add(&mut (*cursor).events.tablet_tool_button as *mut _ as _,
+                          cursor_wrapper.tablet_tool_button_listener() as *mut _ as _);
+        }
+        cursor_wrapper
     }
 }
 
@@ -272,5 +470,49 @@ impl Cursor {
 impl Drop for Cursor {
     fn drop(&mut self) {
         unsafe { wlr_cursor_destroy(self.cursor) }
+    }
+}
+
+impl Drop for CursorWrapper {
+    fn drop(&mut self) {
+        wlr_log!(L_DEBUG, "Dropped {:?}", self);
+        unsafe {
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          &mut (*self.pointer_motion_listener()).link as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          &mut (*self.pointer_motion_absolute_listener()).link as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          &mut (*self.pointer_button_listener()).link as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          &mut (*self.pointer_axis_listener()).link as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          &mut (*self.touch_up_listener()).link as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          &mut (*self.touch_down_listener()).link as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          &mut (*self.touch_motion_listener()).link as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          &mut (*self.touch_cancel_listener()).link as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          &mut (*self.tablet_tool_axis_listener()).link as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          &mut (*self.tablet_tool_proximity_listener()).link as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          &mut (*self.tablet_tool_tip_listener()).link as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          &mut (*self.tablet_tool_button_listener()).link as *mut _ as _);
+        }
     }
 }

--- a/src/types/cursor/mod.rs
+++ b/src/types/cursor/mod.rs
@@ -1,6 +1,6 @@
 pub mod cursor;
 pub mod xcursor;
 
-pub use cursor::{Cursor, CursorBuilder, CursorHandler};
+pub use cursor::{Cursor, CursorBuilder, CursorHandler, CursorId};
 pub(crate) use cursor::CursorWrapper;
 pub use xcursor::*;

--- a/src/types/cursor/mod.rs
+++ b/src/types/cursor/mod.rs
@@ -1,5 +1,6 @@
 pub mod cursor;
 pub mod xcursor;
 
-pub use cursor::*;
+pub use cursor::{Cursor, CursorBuilder, CursorHandler};
+pub(crate) use cursor::CursorWrapper;
 pub use xcursor::*;

--- a/src/types/output/output_layout.rs
+++ b/src/types/output/output_layout.rs
@@ -15,7 +15,7 @@ use wlroots_sys::{wlr_cursor_attach_output_layout, wlr_output_effective_resoluti
 
 use errors::{UpgradeHandleErr, UpgradeHandleResult};
 
-use {Area, Cursor, CursorBuilder, Origin, Output, OutputHandle};
+use {Area, Cursor, CursorBuilder, CursorWrapper, Origin, Output, OutputHandle};
 
 #[derive(Debug)]
 pub struct OutputLayout {
@@ -31,7 +31,7 @@ pub struct OutputLayout {
     liveliness: Option<Rc<AtomicBool>>,
     /// The output_layout ptr that refers to this `OutputLayout`
     layout: *mut wlr_output_layout,
-    cursors: Vec<Cursor>
+    cursors: Vec<Box<CursorWrapper>>
 }
 
 /// A handle to an `OutputLayout`.
@@ -100,8 +100,10 @@ impl OutputLayout {
         }
     }
 
-    pub fn cursors(&mut self) -> &mut [Cursor] {
-        self.cursors.as_mut_slice()
+    pub fn cursors(&mut self) -> Vec<&mut Cursor> {
+        self.cursors.iter_mut()
+            .map(|boxed| boxed.cursor())
+            .collect()
     }
 
     /// Attach a cursor to this OutputLayout.


### PR DESCRIPTION
# Events
Added Tablet Tool Events (#29) and Touch Events (#27). 

# Callbacks
* Added `CursorHandler` whose implementation should be passed to the `CursorBuilder`.
* Fixes #85

# Cursor
* Uses `CursorId` now to de-register and access `Cursor`s later.

# Examples
* Updated pointer example to use the cursor motion callback.