### PR TITLE
Fixed warning about future exclusion

### DIFF
--- a/wlroots-sys/Cargo.toml
+++ b/wlroots-sys/Cargo.toml
@@ -6,7 +6,7 @@ description = "Bindgen generated low-level wlc wrapper"
 keywords = ["wayland", "compositor", "bindings"]
 categories = ["external-ffi-bindings"]
 license = "MIT"
-exclude = [".travis.yml"]
+exclude = ["wlroots/.travis.yml"]
 
 build = "build.rs"
 


### PR DESCRIPTION
The warning was starting to get annoying. We don't care about wlroots' `.travis.yml`