### PR TITLE
Add build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,11 @@ Safe Rust bindings for [wlroots](https://github.com/SirCmpwn/wlroots).
 
 # [Documentation](https://docs.rs/wlroots/)
 
+# Building
+To build wlroots-rs you have to init the wlroots submodule first
+
+    git submodule update --init
+    cargo build
+
 # Examples
 See [the examples directory](https://github.com/swaywm/wlroots-rs/tree/master/examples) for basic examples using this library and at [rootston, our clone of the wlroots reference compositor for a more comprehensive example](https://github.com/swaywm/wlroots-rs/tree/master/rootston)


### PR DESCRIPTION
The error due to the missing submodule

    Error during basic setup:

    Neither directory contains a build file meson.build.

might not be obvious at first.