### PR TITLE
Managers are now totally in builder steps

### DIFF
--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -2,6 +2,5 @@ extern crate wlroots;
 
 fn main() {
     wlroots::utils::init_logging(wlroots::utils::L_DEBUG, None);
-    wlroots::CompositorBuilder::new().build_auto((), None, None, None)
-                                     .run()
+    wlroots::CompositorBuilder::new().build_auto(()).run()
 }

--- a/examples/pointer.rs
+++ b/examples/pointer.rs
@@ -155,9 +155,8 @@ fn main() {
 
     let cursor_id = layout.attach_cursor(cursor);
     let compositor =
-        CompositorBuilder::new().build_auto(State::new(xcursor_theme, layout, cursor_id),
-                                            Some(Box::new(InputManager)),
-                                            Some(Box::new(OutputManager)),
-                                            None);
+        CompositorBuilder::new().input_manager(Box::new(InputManager))
+                                .output_manager(Box::new(OutputManager))
+                                .build_auto(State::new(xcursor_theme, layout, cursor_id));
     compositor.run();
 }

--- a/examples/rotation.rs
+++ b/examples/rotation.rs
@@ -163,10 +163,9 @@ fn main() {
     };
     let compositor_state = CompositorState::new(rotation);
     let mut compositor = CompositorBuilder::new().gles2(true)
-                                                 .build_auto(compositor_state,
-                                                             Some(Box::new(InputManager)),
-                                                             Some(Box::new(OutputManager)),
-                                                             None);
+                                                 .input_manager(Box::new(InputManager))
+                                                 .output_manager(Box::new(OutputManager))
+                                                 .build_auto(compositor_state);
     {
         let gles2 = &mut compositor.renderer.as_mut().unwrap();
         let compositor_data: &mut CompositorState = (&mut compositor.data).downcast_mut().unwrap();

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -90,9 +90,8 @@ impl OutputHandler for ExOutput {
 
 fn main() {
     init_logging(L_DEBUG, None);
-    CompositorBuilder::new().build_auto((),
-                                        Some(Box::new(InputManager)),
-                                        Some(Box::new(OutputManager)),
-                                        None)
+    CompositorBuilder::new().input_manager(Box::new(InputManager))
+                            .output_manager(Box::new(OutputManager))
+                            .build_auto(())
                             .run()
 }

--- a/examples/touch.rs
+++ b/examples/touch.rs
@@ -2,8 +2,8 @@
 extern crate wlroots;
 
 use wlroots::{Compositor, CompositorBuilder, InputManagerHandler, Keyboard, KeyboardHandler,
-              Output, OutputBuilder, OutputBuilderResult, OutputHandler,
-              OutputManagerHandler, Texture, TextureFormat, Touch, TouchHandler};
+              Output, OutputBuilder, OutputBuilderResult, OutputHandler, OutputManagerHandler,
+              Texture, TextureFormat, Touch, TouchHandler};
 use wlroots::key_events::KeyEvent;
 use wlroots::touch_events::{DownEvent, MotionEvent, UpEvent};
 use wlroots::utils::{init_logging, L_DEBUG};
@@ -140,10 +140,9 @@ impl InputManagerHandler for InputManager {
 fn main() {
     init_logging(L_DEBUG, None);
     let mut compositor = CompositorBuilder::new().gles2(true)
-                                                 .build_auto(State::new(),
-                                                             Some(Box::new(InputManager)),
-                                                             Some(Box::new(OutputManager)),
-                                                             None);
+                                                 .input_manager(Box::new(InputManager))
+                                                 .output_manager(Box::new(OutputManager))
+                                                 .build_auto(State::new());
     {
         let gles2 = &mut compositor.renderer.as_mut().unwrap();
         let compositor_data: &mut State = (&mut compositor.data).downcast_mut().unwrap();

--- a/examples/wl_shell_test.rs
+++ b/examples/wl_shell_test.rs
@@ -314,10 +314,10 @@ fn main() {
     let cursor_id = layout.attach_cursor(cursor);
     let mut compositor =
         CompositorBuilder::new().gles2(true)
-                                .build_auto(State::new(xcursor_theme, layout, cursor_id),
-                                            Some(Box::new(InputManager)),
-                                            Some(Box::new(OutputManager)),
-                                            Some(Box::new(WlShellManager)));
+                                .input_manager(Box::new(InputManager))
+                                .output_manager(Box::new(OutputManager))
+                                .wl_shell_manager(Box::new(WlShellManager))
+                                .build_auto(State::new(xcursor_theme, layout, cursor_id));
     Seat::create(&mut compositor, "Main Seat".into(), Box::new(SeatHandlerEx))
         .expect("Could not allocate the global seat");
     compositor.run();


### PR DESCRIPTION
This makes it much more ergnomic to only select some of the managers,
and also makes it more clear what's being constructed.

The minimal example is now much, much simpler :)