### PR TITLE
Wlroots update

### DIFF
--- a/examples/rotation.rs
+++ b/examples/rotation.rs
@@ -95,8 +95,7 @@ impl OutputHandler for ExOutput {
         let cat_texture = compositor_data.cat_texture.as_ref().unwrap();
         for y in StepRange(-128 + compositor_data.y_offs as i32, height, 128) {
             for x in StepRange(-128 + compositor_data.x_offs as i32, width, 128) {
-                let matrix = cat_texture.get_matrix(&transform_matrix, x, y);
-                renderer.render_with_matrix(&cat_texture, &matrix);
+                renderer.render_texture(&cat_texture, transform_matrix, x, y, 1.0);
             }
         }
         compositor_data.x_offs += compositor_data.x_vel * seconds;

--- a/examples/touch.rs
+++ b/examples/touch.rs
@@ -76,11 +76,9 @@ impl OutputHandler for ExOutput {
         let cat_texture = state.cat_texture.as_mut().unwrap();
         let (cat_width, cat_height) = cat_texture.size();
         for touch_point in &mut state.touch_points {
-            let matrix =
-                cat_texture.get_matrix(&transform_matrix,
-                                       (touch_point.x * width as f64) as i32 - (cat_width / 2),
-                                       (touch_point.y * height as f64) as i32 - (cat_height / 2));
-            renderer.render_with_matrix(cat_texture, &matrix);
+            let x = (touch_point.x * width as f64) as i32 - (cat_width / 2);
+            let y = (touch_point.y * height as f64) as i32 - (cat_height / 2);
+            renderer.render_texture(cat_texture, transform_matrix, x, y, 1.0);
         }
     }
 }

--- a/examples/wl_shell_test.rs
+++ b/examples/wl_shell_test.rs
@@ -8,12 +8,12 @@ extern crate wlroots;
 use std::thread;
 use std::time::Duration;
 
-use wlroots::{matrix_multiply, matrix_rotate, matrix_scale, matrix_translate, project_box, Area,
-              Compositor, CompositorBuilder, CursorBuilder, CursorHandler, CursorId,
-              InputManagerHandler, Keyboard, KeyboardHandler, Origin, Output, OutputBuilder,
-              OutputBuilderResult, OutputHandler, OutputLayout, OutputManagerHandler, Pointer,
-              PointerHandler, Renderer, Seat, SeatHandler, Size, Surface, WlShellHandler,
-              WlShellManagerHandler, WlShellSurface, WlShellSurfaceHandle, XCursorTheme};
+use wlroots::{project_box, Area, Compositor, CompositorBuilder, CursorBuilder, CursorHandler,
+              CursorId, InputManagerHandler, Keyboard, KeyboardHandler, Origin, Output,
+              OutputBuilder, OutputBuilderResult, OutputHandler, OutputLayout,
+              OutputManagerHandler, Pointer, PointerHandler, Renderer, Seat, SeatHandler, Size,
+              Surface, WlShellHandler, WlShellManagerHandler, WlShellSurface,
+              WlShellSurfaceHandle, XCursorTheme};
 use wlroots::key_events::KeyEvent;
 use wlroots::pointer_events::{AxisEvent, ButtonEvent, MotionEvent};
 use wlroots::utils::{init_logging, L_DEBUG};
@@ -334,13 +334,7 @@ fn render_shells(state: &mut State, renderer: &mut Renderer) {
                                     let (render_width, render_height) =
                                         (width * renderer.output.scale() as i32,
                                         height * renderer.output.scale() as i32);
-                                    // TODO Some value from something else?
                                     let (lx, ly) = (0.0, 0.0);
-                                    let (mut ox, mut oy) = (lx, ly);
-                                    state.layout
-                                         .output_coords(renderer.output, &mut ox, &mut oy);
-                                    ox *= renderer.output.scale() as f64;
-                                    oy *= renderer.output.scale() as f64;
                                     let render_box = Area::new(Origin::new(lx as i32, ly as i32),
                                                                Size::new(render_width,
                                                                          render_height));

--- a/examples/wl_shell_test.rs
+++ b/examples/wl_shell_test.rs
@@ -345,13 +345,12 @@ fn render_shells(state: &mut State, renderer: &mut Renderer) {
                                                                Size::new(render_width,
                                                                          render_height));
                                     if state.layout.intersects(renderer.output, render_box) {
-                                        let mut matrix = [0.0; 9];
                                         let transform = renderer.output.get_transform().invert();
-                                        project_box(&mut matrix,
-                                                    render_box,
-                                                    transform,
-                                                    0.0,
-                                                    renderer.output.transform_matrix());
+                                        let matrix = project_box(render_box,
+                                                                 transform,
+                                                                 0.0,
+                                                                 renderer.output
+                                                                         .transform_matrix());
                                         renderer.render_texture_with_matrix(&surface.texture(),
                                                                             matrix);
                                         surface.send_frame_done(Duration::from_secs(1));

--- a/examples/wl_shell_test.rs
+++ b/examples/wl_shell_test.rs
@@ -8,12 +8,12 @@ extern crate wlroots;
 use std::thread;
 use std::time::Duration;
 
-use wlroots::{matrix_mul, matrix_rotate, matrix_scale, matrix_translate, Area, Compositor,
-              CompositorBuilder, CursorBuilder, CursorHandler, CursorId, InputManagerHandler,
-              Keyboard, KeyboardHandler, Origin, Output, OutputBuilder, OutputBuilderResult,
-              OutputHandler, OutputLayout, OutputManagerHandler, Pointer, PointerHandler,
-              Renderer, Seat, SeatHandler, Size, Surface, WlShellHandler, WlShellManagerHandler,
-              WlShellSurface, WlShellSurfaceHandle, XCursorTheme};
+use wlroots::{matrix_multiply, matrix_rotate, matrix_scale, matrix_translate, project_box, Area,
+              Compositor, CompositorBuilder, CursorBuilder, CursorHandler, CursorId,
+              InputManagerHandler, Keyboard, KeyboardHandler, Origin, Output, OutputBuilder,
+              OutputBuilderResult, OutputHandler, OutputLayout, OutputManagerHandler, Pointer,
+              PointerHandler, Renderer, Seat, SeatHandler, Size, Surface, WlShellHandler,
+              WlShellManagerHandler, WlShellSurface, WlShellSurfaceHandle, XCursorTheme};
 use wlroots::key_events::KeyEvent;
 use wlroots::pointer_events::{AxisEvent, ButtonEvent, MotionEvent};
 use wlroots::utils::{init_logging, L_DEBUG};
@@ -345,42 +345,15 @@ fn render_shells(state: &mut State, renderer: &mut Renderer) {
                                                                Size::new(render_width,
                                                                          render_height));
                                     if state.layout.intersects(renderer.output, render_box) {
-                                        let mut matrix = [0.0; 16];
-                                        let mut translate_center = [0.0; 16];
-                                        matrix_translate(&mut translate_center,
-                                                         (ox as i32 + render_width / 2) as f32,
-                                                         (oy as i32 + render_height / 2) as f32,
-                                                         0.0);
-                                        let mut rotate = [0.0; 16];
-                                        // TODO what is rotation
-                                        let rotation = 0.0;
-                                        matrix_rotate(&mut rotate, rotation);
-
-                                        let mut translate_origin = [0.0; 16];
-                                        matrix_translate(&mut translate_origin,
-                                                         (-render_width / 2) as f32,
-                                                         (-render_height / 2) as f32,
-                                                         0.0);
-
-                                        let mut scale = [0.0; 16];
-                                        matrix_scale(&mut scale,
-                                                     render_width as f32,
-                                                     render_height as f32,
-                                                     1.0);
-
-                                        let mut transform = [0.0; 16];
-                                        matrix_mul(&translate_center, &mut rotate, &mut transform);
-                                        matrix_mul(&transform.clone(),
-                                                   &mut translate_origin,
-                                                   &mut transform);
-                                        matrix_mul(&transform.clone(), &mut scale, &mut transform);
-
-                                        // TODO Handle non transform normal on the output
-                                        // if ... {}
-                                        matrix_mul(&renderer.output.transform_matrix(),
-                                                   &mut transform,
-                                                   &mut matrix);
-                                        renderer.render_with_matrix(&surface.texture(), &matrix);
+                                        let mut matrix = [0.0; 9];
+                                        let transform = renderer.output.get_transform().invert();
+                                        project_box(&mut matrix,
+                                                    render_box,
+                                                    transform,
+                                                    0.0,
+                                                    renderer.output.transform_matrix());
+                                        renderer.render_texture_with_matrix(&surface.texture(),
+                                                                            matrix);
                                         surface.send_frame_done(Duration::from_secs(1));
                                     }
                                 })

--- a/examples/xdg_shell_v6_test.rs
+++ b/examples/xdg_shell_v6_test.rs
@@ -5,13 +5,12 @@ use std::process::Command;
 use std::thread;
 use std::time::Duration;
 
-use wlroots::{matrix_multiply, matrix_rotate, matrix_scale, matrix_translate, project_box, Area,
-              Compositor, CompositorBuilder, CursorBuilder, CursorHandler, CursorId,
-              InputManagerHandler, Keyboard, KeyboardHandler, Origin, Output, OutputBuilder,
-              OutputBuilderResult, OutputHandler, OutputLayout, OutputManagerHandler, Pointer,
-              PointerHandler, Renderer, Seat, SeatHandler, Size, Surface, XCursorTheme,
-              XdgV6ShellHandler, XdgV6ShellManagerHandler, XdgV6ShellSurface,
-              XdgV6ShellSurfaceHandle};
+use wlroots::{project_box, Area, Compositor, CompositorBuilder, CursorBuilder, CursorHandler,
+              CursorId, InputManagerHandler, Keyboard, KeyboardHandler, Origin, Output,
+              OutputBuilder, OutputBuilderResult, OutputHandler, OutputLayout,
+              OutputManagerHandler, Pointer, PointerHandler, Renderer, Seat, SeatHandler, Size,
+              Surface, XCursorTheme, XdgV6ShellHandler, XdgV6ShellManagerHandler,
+              XdgV6ShellSurface, XdgV6ShellSurfaceHandle};
 use wlroots::key_events::KeyEvent;
 use wlroots::pointer_events::{AxisEvent, ButtonEvent, MotionEvent};
 use wlroots::utils::{init_logging, L_DEBUG};
@@ -219,13 +218,7 @@ fn render_shells(state: &mut State, renderer: &mut Renderer) {
                                     let (render_width, render_height) =
                                         (width * renderer.output.scale() as i32,
                                         height * renderer.output.scale() as i32);
-                                    // TODO Some value from something else?
                                     let (lx, ly) = (0.0, 0.0);
-                                    let (mut ox, mut oy) = (lx, ly);
-                                    state.layout
-                                         .output_coords(renderer.output, &mut ox, &mut oy);
-                                    ox *= renderer.output.scale() as f64;
-                                    oy *= renderer.output.scale() as f64;
                                     let render_box = Area::new(Origin::new(lx as i32, ly as i32),
                                                                Size::new(render_width,
                                                                          render_height));

--- a/examples/xdg_shell_v6_test.rs
+++ b/examples/xdg_shell_v6_test.rs
@@ -230,13 +230,12 @@ fn render_shells(state: &mut State, renderer: &mut Renderer) {
                                                                Size::new(render_width,
                                                                          render_height));
                                     if state.layout.intersects(renderer.output, render_box) {
-                                        let mut matrix = [0.0; 9];
                                         let transform = renderer.output.get_transform().invert();
-                                        project_box(&mut matrix,
-                                                    render_box,
-                                                    transform,
-                                                    0.0,
-                                                    renderer.output.transform_matrix());
+                                        let matrix = project_box(render_box,
+                                                                 transform,
+                                                                 0.0,
+                                                                 renderer.output
+                                                                         .transform_matrix());
                                         renderer.render_texture_with_matrix(&surface.texture(),
                                                                             matrix);
                                         surface.send_frame_done(Duration::from_secs(1));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,8 +52,8 @@ pub use self::types::touch::*;
 pub use key_events::Key;
 pub use pointer_events::ButtonState;
 
-pub use self::render::{matrix_identity, matrix_mul, matrix_rotate, matrix_scale, matrix_texture,
-                       matrix_transform, matrix_translate, GenericRenderer, Renderer, Texture,
-                       TextureFormat};
+pub use self::render::{matrix_identity, matrix_multiply, matrix_rotate, matrix_scale,
+                       matrix_texture, matrix_transform, matrix_translate, project_box,
+                       GenericRenderer, Renderer, Texture, TextureFormat};
 
 pub use self::errors::*;

--- a/src/render/matrix.rs
+++ b/src/render/matrix.rs
@@ -1,7 +1,7 @@
 //! TODO Documentation
 
-use wlroots_sys::{wl_output_transform, wlr_matrix_identity, wlr_matrix_mul, wlr_matrix_rotate,
-                  wlr_matrix_scale, wlr_matrix_texture, wlr_matrix_transform, wlr_matrix_translate};
+use wlroots_sys::{wl_output_transform, wlr_matrix_identity, wlr_matrix_multiply, wlr_matrix_projection,
+                  wlr_matrix_rotate, wlr_matrix_scale, wlr_matrix_transform, wlr_matrix_translate};
 
 /// Modifies the matrix to become the identity matrix.
 pub fn matrix_identity(output: &mut [f32; 16]) {
@@ -24,8 +24,8 @@ pub fn matrix_rotate(output: &mut [f32; 16], radians: f32) {
 }
 
 /// TODO Document
-pub fn matrix_mul(x: &[f32; 16], y: &[f32; 16], product: &mut [f32; 16]) {
-    unsafe { wlr_matrix_mul(x, y, product) }
+pub fn matrix_mul(mat: &mut [f32; 16], x: [f32; 16], y: [f32; 16]) {
+    unsafe { wlr_matrix_multiply(mat.as_mut_ptr(), x.as_ptr(), y.as_ptr()) }
 }
 
 /// Transform the matrix based on the given Wayland output transform mode.
@@ -39,5 +39,5 @@ pub fn matrix_texture(mat: &mut [f32; 16],
                       width: i32,
                       height: i32,
                       transform: wl_output_transform) {
-    unsafe { wlr_matrix_texture(mat.as_mut_ptr(), width, height, transform) }
+    unsafe { wlr_matrix_projection(mat.as_mut_ptr(), width, height, transform) }
 }

--- a/src/render/matrix.rs
+++ b/src/render/matrix.rs
@@ -1,8 +1,9 @@
 //! TODO Documentation
 
+use Area;
 use wlroots_sys::{wl_output_transform, wlr_matrix_identity, wlr_matrix_multiply,
-                  wlr_matrix_projection, wlr_matrix_rotate, wlr_matrix_scale,
-                  wlr_matrix_transform, wlr_matrix_translate};
+                  wlr_matrix_project_box, wlr_matrix_projection, wlr_matrix_rotate,
+                  wlr_matrix_scale, wlr_matrix_transform, wlr_matrix_translate};
 
 /// Modifies the matrix to become the identity matrix.
 pub fn matrix_identity(output: &mut [f32; 9]) {
@@ -24,8 +25,8 @@ pub fn matrix_rotate(output: &mut [f32; 9], radians: f32) {
     unsafe { wlr_matrix_rotate(output.as_mut_ptr(), radians) }
 }
 
-/// TODO Document
-pub fn matrix_mul(mat: &mut [f32; 9], x: [f32; 9], y: [f32; 9]) {
+/// Multiply two matrices together, storing the result in `mat`.
+pub fn matrix_multiply(x: [f32; 9], y: [f32; 9], mat: &mut [f32; 9]) {
     unsafe { wlr_matrix_multiply(mat.as_mut_ptr(), x.as_ptr(), y.as_ptr()) }
 }
 
@@ -38,4 +39,18 @@ pub fn matrix_transform(mat: &mut [f32; 9], transform: wl_output_transform) {
 /// the width and height of a texture.
 pub fn matrix_texture(mat: &mut [f32; 9], width: i32, height: i32, transform: wl_output_transform) {
     unsafe { wlr_matrix_projection(mat.as_mut_ptr(), width, height, transform) }
+}
+
+pub fn project_box(mat: &mut [f32; 9],
+                   area: Area,
+                   transform: wl_output_transform,
+                   rotation: f32,
+                   projection: [f32; 9]) {
+    unsafe {
+        wlr_matrix_project_box(mat.as_mut_ptr(),
+                               &*area,
+                               transform,
+                               rotation,
+                               projection.as_ptr())
+    }
 }

--- a/src/render/matrix.rs
+++ b/src/render/matrix.rs
@@ -1,43 +1,41 @@
 //! TODO Documentation
 
-use wlroots_sys::{wl_output_transform, wlr_matrix_identity, wlr_matrix_multiply, wlr_matrix_projection,
-                  wlr_matrix_rotate, wlr_matrix_scale, wlr_matrix_transform, wlr_matrix_translate};
+use wlroots_sys::{wl_output_transform, wlr_matrix_identity, wlr_matrix_multiply,
+                  wlr_matrix_projection, wlr_matrix_rotate, wlr_matrix_scale,
+                  wlr_matrix_transform, wlr_matrix_translate};
 
 /// Modifies the matrix to become the identity matrix.
-pub fn matrix_identity(output: &mut [f32; 16]) {
+pub fn matrix_identity(output: &mut [f32; 9]) {
     unsafe { wlr_matrix_identity(output.as_mut_ptr()) }
 }
 
 /// Translate the matrix in the x, and y.
-pub fn matrix_translate(output: &mut [f32; 16], x: f32, y: f32) {
+pub fn matrix_translate(output: &mut [f32; 9], x: f32, y: f32) {
     unsafe { wlr_matrix_translate(output.as_mut_ptr(), x, y) }
 }
 
 /// Scale the output in the x, and y.
-pub fn matrix_scale(output: &mut [f32; 16], x: f32, y: f32) {
+pub fn matrix_scale(output: &mut [f32; 9], x: f32, y: f32) {
     unsafe { wlr_matrix_scale(output.as_mut_ptr(), x, y) }
 }
 
 /// Rotate the matrix by some amount of radians.
-pub fn matrix_rotate(output: &mut [f32; 16], radians: f32) {
+pub fn matrix_rotate(output: &mut [f32; 9], radians: f32) {
     unsafe { wlr_matrix_rotate(output.as_mut_ptr(), radians) }
 }
 
 /// TODO Document
-pub fn matrix_mul(mat: &mut [f32; 16], x: [f32; 16], y: [f32; 16]) {
+pub fn matrix_mul(mat: &mut [f32; 9], x: [f32; 9], y: [f32; 9]) {
     unsafe { wlr_matrix_multiply(mat.as_mut_ptr(), x.as_ptr(), y.as_ptr()) }
 }
 
 /// Transform the matrix based on the given Wayland output transform mode.
-pub fn matrix_transform(mat: &mut [f32; 16], transform: wl_output_transform) {
+pub fn matrix_transform(mat: &mut [f32; 9], transform: wl_output_transform) {
     unsafe { wlr_matrix_transform(mat.as_mut_ptr(), transform) }
 }
 
 /// Transform the matrix based on the given Wayland output transform mode and
 /// the width and height of a texture.
-pub fn matrix_texture(mat: &mut [f32; 16],
-                      width: i32,
-                      height: i32,
-                      transform: wl_output_transform) {
+pub fn matrix_texture(mat: &mut [f32; 9], width: i32, height: i32, transform: wl_output_transform) {
     unsafe { wlr_matrix_projection(mat.as_mut_ptr(), width, height, transform) }
 }

--- a/src/render/matrix.rs
+++ b/src/render/matrix.rs
@@ -5,22 +5,22 @@ use wlroots_sys::{wl_output_transform, wlr_matrix_identity, wlr_matrix_mul, wlr_
 
 /// Modifies the matrix to become the identity matrix.
 pub fn matrix_identity(output: &mut [f32; 16]) {
-    unsafe { wlr_matrix_identity(output) }
+    unsafe { wlr_matrix_identity(output.as_mut_ptr()) }
 }
 
-/// Translate the matrix in the x, y, and z directions.
-pub fn matrix_translate(output: &mut [f32; 16], x: f32, y: f32, z: f32) {
-    unsafe { wlr_matrix_translate(output, x, y, z) }
+/// Translate the matrix in the x, and y.
+pub fn matrix_translate(output: &mut [f32; 16], x: f32, y: f32) {
+    unsafe { wlr_matrix_translate(output.as_mut_ptr(), x, y) }
 }
 
-/// Scale the output in the x, y, and z directions some amount.
-pub fn matrix_scale(output: &mut [f32; 16], x: f32, y: f32, z: f32) {
-    unsafe { wlr_matrix_scale(output, x, y, z) }
+/// Scale the output in the x, and y.
+pub fn matrix_scale(output: &mut [f32; 16], x: f32, y: f32) {
+    unsafe { wlr_matrix_scale(output.as_mut_ptr(), x, y) }
 }
 
 /// Rotate the matrix by some amount of radians.
 pub fn matrix_rotate(output: &mut [f32; 16], radians: f32) {
-    unsafe { wlr_matrix_rotate(output, radians) }
+    unsafe { wlr_matrix_rotate(output.as_mut_ptr(), radians) }
 }
 
 /// TODO Document

--- a/src/render/matrix.rs
+++ b/src/render/matrix.rs
@@ -10,47 +10,74 @@ pub fn matrix_identity(output: &mut [f32; 9]) {
     unsafe { wlr_matrix_identity(output.as_mut_ptr()) }
 }
 
-/// Translate the matrix in the x, and y.
-pub fn matrix_translate(output: &mut [f32; 9], x: f32, y: f32) {
-    unsafe { wlr_matrix_translate(output.as_mut_ptr(), x, y) }
+/// Translate the matrix in x, and y.
+pub fn matrix_translate(x: f32, y: f32) -> [f32; 9] {
+    let mut output = [0.0; 9];
+    unsafe {
+        wlr_matrix_translate(output.as_mut_ptr(), x, y);
+    }
+    output
 }
 
 /// Scale the output in the x, and y.
-pub fn matrix_scale(output: &mut [f32; 9], x: f32, y: f32) {
-    unsafe { wlr_matrix_scale(output.as_mut_ptr(), x, y) }
+pub fn matrix_scale(x: f32, y: f32) -> [f32; 9] {
+    let mut output = [0.0; 9];
+    unsafe {
+        wlr_matrix_scale(output.as_mut_ptr(), x, y);
+    }
+    output
 }
 
 /// Rotate the matrix by some amount of radians.
-pub fn matrix_rotate(output: &mut [f32; 9], radians: f32) {
-    unsafe { wlr_matrix_rotate(output.as_mut_ptr(), radians) }
+pub fn matrix_rotate(mut matrix: [f32; 9], radians: f32) -> [f32; 9] {
+    unsafe {
+        wlr_matrix_rotate(matrix.as_mut_ptr(), radians);
+    }
+    matrix
 }
 
-/// Multiply two matrices together, storing the result in `mat`.
-pub fn matrix_multiply(x: [f32; 9], y: [f32; 9], mat: &mut [f32; 9]) {
-    unsafe { wlr_matrix_multiply(mat.as_mut_ptr(), x.as_ptr(), y.as_ptr()) }
+/// Multiply two matrices together.
+pub fn matrix_multiply(x: [f32; 9], y: [f32; 9]) -> [f32; 9] {
+    let mut output = [0.0; 9];
+    unsafe {
+        wlr_matrix_multiply(output.as_mut_ptr(), x.as_ptr(), y.as_ptr());
+    }
+    output
 }
 
 /// Transform the matrix based on the given Wayland output transform mode.
-pub fn matrix_transform(mat: &mut [f32; 9], transform: wl_output_transform) {
-    unsafe { wlr_matrix_transform(mat.as_mut_ptr(), transform) }
+pub fn matrix_transform(mut matrix: [f32; 9], transform: wl_output_transform) -> [f32; 9] {
+    unsafe {
+        wlr_matrix_transform(matrix.as_mut_ptr(), transform);
+    }
+    matrix
 }
 
 /// Transform the matrix based on the given Wayland output transform mode and
 /// the width and height of a texture.
-pub fn matrix_texture(mat: &mut [f32; 9], width: i32, height: i32, transform: wl_output_transform) {
-    unsafe { wlr_matrix_projection(mat.as_mut_ptr(), width, height, transform) }
+pub fn matrix_texture(mut matrix: [f32; 9],
+                      width: i32,
+                      height: i32,
+                      transform: wl_output_transform)
+                      -> [f32; 9] {
+    unsafe {
+        wlr_matrix_projection(matrix.as_mut_ptr(), width, height, transform);
+    }
+    matrix
 }
 
-pub fn project_box(mat: &mut [f32; 9],
-                   area: Area,
+pub fn project_box(area: Area,
                    transform: wl_output_transform,
                    rotation: f32,
-                   projection: [f32; 9]) {
+                   projection: [f32; 9])
+                   -> [f32; 9] {
     unsafe {
-        wlr_matrix_project_box(mat.as_mut_ptr(),
+        let mut output = [0.0; 9];
+        wlr_matrix_project_box(output.as_mut_ptr(),
                                &*area,
                                transform,
                                rotation,
-                               projection.as_ptr())
+                               projection.as_ptr());
+        output
     }
 }

--- a/src/render/renderer.rs
+++ b/src/render/renderer.rs
@@ -43,7 +43,8 @@ impl GenericRenderer {
     pub fn render<'output>(&mut self, output: &'output mut Output) -> Renderer<'output> {
         unsafe {
             output.make_current();
-            wlr_renderer_begin(self.renderer, output.as_ptr());
+            let (width, height) = output.dimensions();
+            wlr_renderer_begin(self.renderer, width, height);
             Renderer { renderer: self.renderer,
                        output }
         }
@@ -72,7 +73,7 @@ impl<'output> Renderer<'output> {
     }
 
     pub fn clear(&mut self, float: [f32; 4]) {
-        unsafe { wlr_renderer_clear(self.renderer, &float) }
+        unsafe { wlr_renderer_clear(self.renderer, float.as_ptr()) }
     }
 
     /// Renders the requested texture using the provided matrix. A typical texture
@@ -92,17 +93,17 @@ impl<'output> Renderer<'output> {
     /// This will render the texture at <123, 321>.
     pub fn render_with_matrix(&mut self, texture: &Texture, matrix: &[f32; 16]) -> bool {
         // TODO FIXME Add alpha as param
-        unsafe { wlr_render_with_matrix(self.renderer, texture.as_ptr(), matrix, 1.0) }
+        unsafe { wlr_render_with_matrix(self.renderer, texture.as_ptr(), matrix.as_ptr(), 1.0) }
     }
 
     /// Renders a solid quad in the specified color.
     pub fn render_colored_quad(&mut self, color: &[f32; 4], matrix: &[f32; 16]) {
-        unsafe { wlr_render_colored_quad(self.renderer, color, matrix) }
+        unsafe { wlr_render_colored_quad(self.renderer, color.as_ptr(), matrix.as_ptr()) }
     }
 
     /// Renders a solid ellipse in the specified color.
     pub fn render_colored_ellipse(&mut self, color: &[f32; 4], matrix: &[f32; 16]) {
-        unsafe { wlr_render_colored_ellipse(self.renderer, color, matrix) }
+        unsafe { wlr_render_colored_ellipse(self.renderer, color.as_ptr(), matrix.as_ptr()) }
     }
 }
 

--- a/src/render/renderer.rs
+++ b/src/render/renderer.rs
@@ -91,18 +91,20 @@ impl<'output> Renderer<'output> {
     /// ```
     ///
     /// This will render the texture at <123, 321>.
-    pub fn render_with_matrix(&mut self, texture: &Texture, matrix: &[f32; 16]) -> bool {
+    pub fn render_with_matrix(&mut self, texture: &Texture, matrix: &[f32; 9]) -> bool {
         // TODO FIXME Add alpha as param
-        unsafe { wlr_render_texture_with_matrix(self.renderer, texture.as_ptr(), matrix.as_ptr(), 1.0) }
+        unsafe {
+            wlr_render_texture_with_matrix(self.renderer, texture.as_ptr(), matrix.as_ptr(), 1.0)
+        }
     }
 
     /// Renders a solid quad in the specified color.
-    pub fn render_colored_quad(&mut self, color: &[f32; 4], matrix: &[f32; 16]) {
+    pub fn render_colored_quad(&mut self, color: &[f32; 4], matrix: &[f32; 9]) {
         unsafe { wlr_render_colored_quad(self.renderer, color.as_ptr(), matrix.as_ptr()) }
     }
 
     /// Renders a solid ellipse in the specified color.
-    pub fn render_colored_ellipse(&mut self, color: &[f32; 4], matrix: &[f32; 16]) {
+    pub fn render_colored_ellipse(&mut self, color: &[f32; 4], matrix: &[f32; 9]) {
         unsafe { wlr_render_colored_ellipse(self.renderer, color.as_ptr(), matrix.as_ptr()) }
     }
 }

--- a/src/render/renderer.rs
+++ b/src/render/renderer.rs
@@ -1,11 +1,13 @@
 //! TODO Documentation
 
+use libc::{c_float, c_int};
+
 use Output;
 use render::Texture;
 use wlroots_sys::{wlr_backend, wlr_render_colored_ellipse, wlr_render_colored_quad,
-                  wlr_render_texture_create, wlr_render_texture_with_matrix, wlr_renderer,
-                  wlr_renderer_begin, wlr_renderer_clear, wlr_renderer_destroy, wlr_renderer_end,
-                  wlr_gles2_renderer_create};
+                  wlr_render_texture, wlr_render_texture_create, wlr_render_texture_with_matrix,
+                  wlr_renderer, wlr_renderer_begin, wlr_renderer_clear, wlr_renderer_destroy,
+                  wlr_renderer_end, wlr_gles2_renderer_create};
 
 /// A generic interface for rendering to the screen.
 ///
@@ -76,6 +78,24 @@ impl<'output> Renderer<'output> {
         unsafe { wlr_renderer_clear(self.renderer, float.as_ptr()) }
     }
 
+    /// Renders the requseted texture.
+    pub fn render_texture(&mut self,
+                          texture: &Texture,
+                          projection: [f32; 9],
+                          x: c_int,
+                          y: c_int,
+                          alpha: c_float)
+                          -> bool {
+        unsafe {
+            wlr_render_texture(self.renderer,
+                               texture.as_ptr(),
+                               projection.as_ptr(),
+                               x,
+                               y,
+                               alpha)
+        }
+    }
+
     /// Renders the requested texture using the provided matrix. A typical texture
     /// rendering goes like so:
     ///
@@ -91,7 +111,7 @@ impl<'output> Renderer<'output> {
     /// ```
     ///
     /// This will render the texture at <123, 321>.
-    pub fn render_with_matrix(&mut self, texture: &Texture, matrix: &[f32; 9]) -> bool {
+    pub fn render_texture_with_matrix(&mut self, texture: &Texture, matrix: [f32; 9]) -> bool {
         // TODO FIXME Add alpha as param
         unsafe {
             wlr_render_texture_with_matrix(self.renderer, texture.as_ptr(), matrix.as_ptr(), 1.0)
@@ -99,12 +119,12 @@ impl<'output> Renderer<'output> {
     }
 
     /// Renders a solid quad in the specified color.
-    pub fn render_colored_quad(&mut self, color: &[f32; 4], matrix: &[f32; 9]) {
+    pub fn render_colored_quad(&mut self, color: [f32; 4], matrix: [f32; 9]) {
         unsafe { wlr_render_colored_quad(self.renderer, color.as_ptr(), matrix.as_ptr()) }
     }
 
     /// Renders a solid ellipse in the specified color.
-    pub fn render_colored_ellipse(&mut self, color: &[f32; 4], matrix: &[f32; 9]) {
+    pub fn render_colored_ellipse(&mut self, color: [f32; 4], matrix: [f32; 9]) {
         unsafe { wlr_render_colored_ellipse(self.renderer, color.as_ptr(), matrix.as_ptr()) }
     }
 }

--- a/src/render/renderer.rs
+++ b/src/render/renderer.rs
@@ -3,7 +3,7 @@
 use Output;
 use render::Texture;
 use wlroots_sys::{wlr_backend, wlr_render_colored_ellipse, wlr_render_colored_quad,
-                  wlr_render_texture_create, wlr_render_with_matrix, wlr_renderer,
+                  wlr_render_texture_create, wlr_render_texture_with_matrix, wlr_renderer,
                   wlr_renderer_begin, wlr_renderer_clear, wlr_renderer_destroy, wlr_renderer_end,
                   wlr_gles2_renderer_create};
 
@@ -87,13 +87,13 @@ impl<'output> Renderer<'output> {
     /// float projection[16];
     /// float matrix[16];
     /// wlr_texture_get_matrix(texture, &matrix, &projection, 123, 321);
-    /// wlr_render_with_matrix(renderer, texture, &matrix);
+    /// wlr_render_texture_with_matrix(renderer, texture, &matrix);
     /// ```
     ///
     /// This will render the texture at <123, 321>.
     pub fn render_with_matrix(&mut self, texture: &Texture, matrix: &[f32; 16]) -> bool {
         // TODO FIXME Add alpha as param
-        unsafe { wlr_render_with_matrix(self.renderer, texture.as_ptr(), matrix.as_ptr(), 1.0) }
+        unsafe { wlr_render_texture_with_matrix(self.renderer, texture.as_ptr(), matrix.as_ptr(), 1.0) }
     }
 
     /// Renders a solid quad in the specified color.

--- a/src/render/texture.rs
+++ b/src/render/texture.rs
@@ -1,5 +1,5 @@
 use libc::c_int;
-use wlroots_sys::{wl_shm_format, wlr_texture, wlr_texture_get_matrix, wlr_texture_upload_pixels};
+use wlroots_sys::{wl_shm_format, wlr_texture, wlr_texture_upload_pixels};
 
 /// Wrapper around wl_shm_format, to make it easier and nicer to type.
 #[repr(u32)]
@@ -108,14 +108,6 @@ impl Texture {
                                       width,
                                       height,
                                       bytes.as_ptr())
-        }
-    }
-
-    pub fn get_matrix(&self, projection: &[f32; 16], x: i32, y: i32) -> [f32; 16] {
-        unsafe {
-            let mut matrix: [f32; 16] = [0.0; 16];
-            wlr_texture_get_matrix(self.texture, &mut matrix, projection, x, y);
-            matrix
         }
     }
 }

--- a/src/types/output/output.rs
+++ b/src/types/output/output.rs
@@ -343,7 +343,7 @@ impl Output {
         }
     }
 
-    pub fn transform_matrix(&self) -> [c_float; 16] {
+    pub fn transform_matrix(&self) -> [c_float; 9] {
         unsafe { (*self.output).transform_matrix }
     }
 

--- a/src/types/shell/xdg_shell_v6.rs
+++ b/src/types/shell/xdg_shell_v6.rs
@@ -95,11 +95,11 @@ impl XdgV6ShellSurface {
             match (*self.shell_surface).role {
                 WLR_XDG_SURFACE_V6_ROLE_NONE => None,
                 WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL => {
-                    let toplevel = (*self.shell_surface).__bindgen_anon_1.toplevel_state;
+                    let toplevel = (*self.shell_surface).__bindgen_anon_1.toplevel;
                     Some(TopLevel(XdgV6TopLevel::from_shell(self, toplevel)))
                 }
                 WLR_XDG_SURFACE_V6_ROLE_POPUP => {
-                    let popup = (*self.shell_surface).__bindgen_anon_1.popup_state;
+                    let popup = (*self.shell_surface).__bindgen_anon_1.popup;
                     Some(Popup(XdgV6Popup::from_ptr(popup)))
                 }
             }
@@ -141,26 +141,12 @@ impl XdgV6ShellSurface {
         unsafe { (*self.shell_surface).has_next_geometry }
     }
 
-    pub fn next_geometry(&self) -> Option<Area> {
-        unsafe {
-            let next_geometry = (*self.shell_surface).next_geometry;
-            if next_geometry.is_null() {
-                None
-            } else {
-                Some(Area(*next_geometry))
-            }
-        }
+    pub fn next_geometry(&self) -> Area {
+        unsafe { Area((*self.shell_surface).next_geometry) }
     }
 
-    pub fn geometry(&self) -> Option<Area> {
-        unsafe {
-            let geometry = (*self.shell_surface).geometry;
-            if geometry.is_null() {
-                None
-            } else {
-                Some(Area(*geometry))
-            }
-        }
+    pub fn geometry(&self) -> Area {
+        unsafe { Area((*self.shell_surface).geometry) }
     }
 
     /// Send a ping to the surface.

--- a/src/types/surface/surface.rs
+++ b/src/types/surface/surface.rs
@@ -8,9 +8,8 @@ use std::time::Duration;
 use wayland_sys::server::WAYLAND_SERVER_HANDLE;
 use wayland_sys::server::signal::wl_signal_add;
 use wlroots_sys::{timespec, wlr_subsurface, wlr_surface, wlr_surface_get_main_surface,
-                  wlr_surface_has_buffer, wlr_surface_make_subsurface,
-                  wlr_surface_send_enter, wlr_surface_send_frame_done, wlr_surface_send_leave,
-                  wlr_surface_subsurface_at};
+                  wlr_surface_has_buffer, wlr_surface_make_subsurface, wlr_surface_send_enter,
+                  wlr_surface_send_frame_done, wlr_surface_send_leave, wlr_surface_subsurface_at};
 
 use super::{Subsurface, SubsurfaceHandle, SubsurfaceManager, SurfaceState};
 use Output;

--- a/src/types/surface/surface.rs
+++ b/src/types/surface/surface.rs
@@ -1,6 +1,6 @@
 //! TODO Documentation
 
-use std::{panic, ptr};
+use std::panic;
 use std::rc::{Rc, Weak};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
@@ -8,7 +8,7 @@ use std::time::Duration;
 use wayland_sys::server::WAYLAND_SERVER_HANDLE;
 use wayland_sys::server::signal::wl_signal_add;
 use wlroots_sys::{timespec, wlr_subsurface, wlr_surface, wlr_surface_get_main_surface,
-                  wlr_surface_get_matrix, wlr_surface_has_buffer, wlr_surface_make_subsurface,
+                  wlr_surface_has_buffer, wlr_surface_make_subsurface,
                   wlr_surface_send_enter, wlr_surface_send_frame_done, wlr_surface_send_leave,
                   wlr_surface_subsurface_at};
 
@@ -146,27 +146,6 @@ impl Surface {
         unsafe { c_to_rust_string((*self.surface).role) }
     }
 
-    /// Gets a matrix you can pass into wlr_render_with_matrix to display this
-    /// surface.
-    ///
-    /// `matrix` is the output matrix, `projection` is the wlr_output
-    /// projection matrix, and `transform` is any additional transformations you want
-    /// to perform on the surface (or None/the identity matrix if you don't).
-    ///
-    /// `transform` is used before the surface is scaled, so its geometry extends
-    /// from 0 to 1 in both dimensions.
-    pub fn get_matrix<'a, T>(&mut self,
-                             matrix: &mut [f32; 16],
-                             projection: &[f32; 16],
-                             transform: T)
-        where T: Into<Option<&'a [f32; 16]>>
-    {
-        let transform = transform.into()
-                                 .map(|transform| transform as *const _)
-                                 .unwrap_or_else(|| ptr::null());
-        unsafe { wlr_surface_get_matrix(self.surface, matrix, projection, transform) }
-    }
-
     /// Whether or not this surface currently has an attached buffer.
     ///
     /// A surface has an attached buffer when it commits with a non-null buffer in its pending
@@ -241,13 +220,13 @@ impl Surface {
 
     /// Get the matrix used to convert the internal byte buffer to use in the
     /// surface.
-    pub fn buffer_to_surface_matrix(&self) -> [f32; 16] {
+    pub fn buffer_to_surface_matrix(&self) -> [f32; 9] {
         unsafe { (*self.surface).buffer_to_surface_matrix }
     }
 
     /// Get the matrix used to convert the surface back to the internal byte
     /// buffer.
-    pub fn surface_to_buffer_matrix(&self) -> [f32; 16] {
+    pub fn surface_to_buffer_matrix(&self) -> [f32; 9] {
         unsafe { (*self.surface).surface_to_buffer_matrix }
     }
 

--- a/wlroots-sys/src/lib.rs
+++ b/wlroots-sys/src/lib.rs
@@ -38,3 +38,12 @@ pub use self::generated::*;
 
 pub type wlr_output_events = self::generated::wlr_output__bindgen_ty_1;
 pub type wlr_input_device_pointer = self::generated::wlr_input_device__bindgen_ty_1;
+
+impl wl_output_transform {
+    /// Invert the transform.
+    pub fn invert(self) -> Self {
+        unsafe {
+            wlr_output_transform_invert(self)
+        }
+    }
+}

--- a/wlroots-sys/src/lib.rs
+++ b/wlroots-sys/src/lib.rs
@@ -42,8 +42,6 @@ pub type wlr_input_device_pointer = self::generated::wlr_input_device__bindgen_t
 impl wl_output_transform {
     /// Invert the transform.
     pub fn invert(self) -> Self {
-        unsafe {
-            wlr_output_transform_invert(self)
-        }
+        unsafe { wlr_output_transform_invert(self) }
     }
 }

--- a/wlroots-sys/src/wlroots.h
+++ b/wlroots-sys/src/wlroots.h
@@ -10,13 +10,15 @@
 #include <wlr/backend/session/interface.h>
 
 /// Render includes
-#include <wlr/render.h>
+#include <wlr/render/wlr_renderer.h>
+#include <wlr/render/egl.h>
 #include <wlr/render/gles2.h>
 #include <wlr/render/interface.h>
-#include <wlr/render/matrix.h>
+#include <wlr/render/wlr_texture.h>
 
 /// Type includes
 #include <wlr/types/wlr_box.h>
+#include <wlr/types/wlr_matrix.h>
 #include <wlr/types/wlr_compositor.h>
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_data_device.h>


### PR DESCRIPTION
Updated wlroots to the latest master, which has changes to rendering and matrix operations (amongst other things).

Matrix functions now return their result, instead of modifying their inputs / needing a mutable reference as the output. This should make this less confusing.

Added `invert` for `wl_output_transform`

