### PR TITLE
Update to latest wlroots...again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,10 @@ arch:
     - libcap
     - rustup
     - clang
+    - libxcb
+    - xcb-util-image
+    - xcb-util-cursor
+    - xcb-util-wm
   script:
     - rustup install stable
     - export CC=clang

--- a/examples/rotation.rs
+++ b/examples/rotation.rs
@@ -12,9 +12,8 @@ use wlroots::utils::{init_logging, L_DEBUG};
 use wlroots::wlroots_sys::wl_output_transform;
 use wlroots::xkbcommon::xkb::keysyms;
 
-const CAT_STRIDE: i32 = 128;
-const CAT_WIDTH: i32 = 128;
-const CAT_HEIGHT: i32 = 128;
+const CAT_WIDTH: u32 = 128;
+const CAT_HEIGHT: u32 = 128;
 const CAT_DATA: &'static [u8] = include_bytes!("cat.data");
 
 /// Helper step by iterator, because `step_by` on `Range` is unstable.
@@ -168,14 +167,12 @@ fn main() {
     {
         let gles2 = &mut compositor.renderer.as_mut().unwrap();
         let compositor_data: &mut CompositorState = (&mut compositor.data).downcast_mut().unwrap();
-        compositor_data.cat_texture = gles2.create_texture().map(|mut cat_texture| {
-            cat_texture.upload_pixels(TextureFormat::ABGR8888,
-                                      CAT_STRIDE,
-                                      CAT_WIDTH,
-                                      CAT_HEIGHT,
-                                      CAT_DATA);
-            cat_texture
-        })
+        compositor_data.cat_texture =
+            gles2.create_texture_from_pixels(TextureFormat::ABGR8888.into(),
+                                             CAT_WIDTH * 4,
+                                             CAT_WIDTH,
+                                             CAT_HEIGHT,
+                                             CAT_DATA);
     }
     compositor.run();
 }

--- a/src/events/tablet_tool_events.rs
+++ b/src/events/tablet_tool_events.rs
@@ -39,18 +39,11 @@ impl AxisEvent {
         unsafe { (*self.event).updated_axes }
     }
 
-    /// Gets the position of the event in mm.
+    /// Gets the position of the event.
     ///
     /// Return value is in (x, y) format.
     pub fn position(&self) -> (f64, f64) {
-        unsafe { ((*self.event).x_mm, (*self.event).y_mm) }
-    }
-
-    /// Gets the size of the touch event in mm.
-    ///
-    /// Return value is in (w, h) format.
-    pub fn size(&self) -> (f64, f64) {
-        unsafe { ((*self.event).width_mm, (*self.event).height_mm) }
+        unsafe { ((*self.event).x, (*self.event).y) }
     }
 
     pub fn pressure(&self) -> f64 {
@@ -90,14 +83,7 @@ impl ProximityEvent {
     ///
     /// Return value is in (x, y) format.
     pub fn position(&self) -> (f64, f64) {
-        unsafe { ((*self.event).x_mm, (*self.event).y_mm) }
-    }
-
-    /// Gets the size of the touch event in mm.
-    ///
-    /// Return value is in (w, h) format.
-    pub fn size(&self) -> (f64, f64) {
-        unsafe { ((*self.event).width_mm, (*self.event).height_mm) }
+        unsafe { ((*self.event).x, (*self.event).y) }
     }
 
     pub fn state(&self) -> wlr_tablet_tool_proximity_state {
@@ -118,14 +104,7 @@ impl TipEvent {
     ///
     /// Return value is in (x, y) format.
     pub fn position(&self) -> (f64, f64) {
-        unsafe { ((*self.event).x_mm, (*self.event).y_mm) }
-    }
-
-    /// Gets the size of the touch event in mm.
-    ///
-    /// Return value is in (w, h) format.
-    pub fn size(&self) -> (f64, f64) {
-        unsafe { ((*self.event).width_mm, (*self.event).height_mm) }
+        unsafe { ((*self.event).x, (*self.event).y) }
     }
 
     pub fn state(&self) -> wlr_tablet_tool_tip_state {

--- a/src/events/touch_events.rs
+++ b/src/events/touch_events.rs
@@ -47,14 +47,7 @@ impl DownEvent {
     ///
     /// Return value is in (x, y) format.
     pub fn location(&self) -> (f64, f64) {
-        unsafe { ((*self.event).x_mm, (*self.event).y_mm) }
-    }
-
-    /// Gets the size of the touch event in mm.
-    ///
-    /// Return value is in (w, h) format.
-    pub fn size(&self) -> (f64, f64) {
-        unsafe { ((*self.event).width_mm, (*self.event).height_mm) }
+        unsafe { ((*self.event).x, (*self.event).y) }
     }
 }
 
@@ -94,14 +87,7 @@ impl MotionEvent {
     ///
     /// Return value is in (x, y) format.
     pub fn location(&self) -> (f64, f64) {
-        unsafe { ((*self.event).x_mm, (*self.event).y_mm) }
-    }
-
-    /// Gets the size of the touch event in mm.
-    ///
-    /// Return value is in (w, h) format.
-    pub fn size(&self) -> (f64, f64) {
-        unsafe { ((*self.event).width_mm, (*self.event).height_mm) }
+        unsafe { ((*self.event).x, (*self.event).y) }
     }
 }
 

--- a/src/manager/xdg_shell_v6_manager.rs
+++ b/src/manager/xdg_shell_v6_manager.rs
@@ -48,18 +48,24 @@ wayland_listener!(XdgV6ShellManager, (Vec<Box<XdgV6Shell>>, Box<XdgV6ShellManage
                           shell_surface.ping_timeout_listener() as _);
             wl_signal_add(&mut (*data).events.new_popup as *mut _ as _,
                           shell_surface.new_popup_listener() as _);
-            wl_signal_add(&mut (*data).events.request_maximize as *mut _ as _,
-                          shell_surface.maximize_listener() as _);
-            wl_signal_add(&mut (*data).events.request_fullscreen as *mut _ as _,
-                          shell_surface.fullscreen_listener() as _);
-            wl_signal_add(&mut (*data).events.request_minimize as *mut _ as _,
-                          shell_surface.minimize_listener() as _);
-            wl_signal_add(&mut (*data).events.request_move as *mut _ as _,
-                          shell_surface.move_listener() as _);
-            wl_signal_add(&mut (*data).events.request_resize as *mut _ as _,
-                          shell_surface.resize_listener() as _);
-            wl_signal_add(&mut (*data).events.request_show_window_menu as *mut _ as _,
-                          shell_surface.show_window_menu_listener() as _);
+            // TODO We gotta costruct a top level / popup here and store it in the
+            // XdgV6Shell so that the listeners can work properly....
+            //
+            // FIXME Consider the possiblity of borrowing the specific type during an
+            // event fire? Aliasing possible? Not sure
+
+            //wl_signal_add(&mut (*data).events.request_maximize as *mut _ as _,
+            //              shell_surface.maximize_listener() as _);
+            //wl_signal_add(&mut (*data).events.request_fullscreen as *mut _ as _,
+            //              shell_surface.fullscreen_listener() as _);
+            //wl_signal_add(&mut (*data).events.request_minimize as *mut _ as _,
+            //              shell_surface.minimize_listener() as _);
+            //wl_signal_add(&mut (*data).events.request_move as *mut _ as _,
+            //              shell_surface.move_listener() as _);
+            //wl_signal_add(&mut (*data).events.request_resize as *mut _ as _,
+            //              shell_surface.resize_listener() as _);
+            //wl_signal_add(&mut (*data).events.request_show_window_menu as *mut _ as _,
+            //              shell_surface.show_window_menu_listener() as _);
             shells.push(shell_surface);
         }
     };

--- a/src/manager/xdg_shell_v6_manager.rs
+++ b/src/manager/xdg_shell_v6_manager.rs
@@ -3,10 +3,11 @@
 use libc;
 use wayland_sys::server::WAYLAND_SERVER_HANDLE;
 use wayland_sys::server::signal::wl_signal_add;
-use wlroots_sys::wlr_xdg_surface_v6;
+use wlroots_sys::{wlr_xdg_surface_v6, wlr_xdg_surface_v6_role::*};
 
 use super::xdg_shell_v6_handler::XdgV6Shell;
-use {Surface, SurfaceHandle, XdgV6ShellHandler, XdgV6ShellSurface};
+use {Surface, SurfaceHandle, XdgV6Popup, XdgV6ShellHandler, XdgV6ShellState::*, XdgV6ShellSurface,
+     XdgV6TopLevel};
 use compositor::{Compositor, COMPOSITOR_PTR};
 
 pub trait XdgV6ShellManagerHandler {
@@ -30,16 +31,31 @@ wayland_listener!(XdgV6ShellManager, (Vec<Box<XdgV6Shell>>, Box<XdgV6ShellManage
         wlr_log!(L_DEBUG, "New xdg_shell_v6_surface request {:p}", data);
         let compositor = &mut *COMPOSITOR_PTR;
         let mut surface = Surface::new((*data).surface);
-        let mut shell_surface = XdgV6ShellSurface::new(data);
+        let state = unsafe {
+            match (*data).role {
+                WLR_XDG_SURFACE_V6_ROLE_NONE => None,
+                WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL => {
+                    let toplevel = (*data).__bindgen_anon_1.toplevel;
+                    Some(TopLevel(XdgV6TopLevel::from_shell(data, toplevel)))
+                }
+                WLR_XDG_SURFACE_V6_ROLE_POPUP => {
+                    let popup = (*data).__bindgen_anon_1.popup;
+                    Some(Popup(XdgV6Popup::from_ptr(popup)))
+                }
+            }
+        };
+        let mut shell_surface = XdgV6ShellSurface::new(data, state);
         surface.set_lock(true);
         shell_surface.set_lock(true);
         let new_surface_res = manager.new_surface(compositor, &mut shell_surface, &mut surface);
         surface.set_lock(false);
         shell_surface.set_lock(false);
         if let Some(shell_surface_handler) = new_surface_res {
+
             let mut shell_surface = XdgV6Shell::new((shell_surface,
                                                      surface,
                                                      shell_surface_handler));
+
             // Hook the destroy event into this manager.
             wl_signal_add(&mut (*data).events.destroy as *mut _ as _,
                           remove_listener);
@@ -48,24 +64,25 @@ wayland_listener!(XdgV6ShellManager, (Vec<Box<XdgV6Shell>>, Box<XdgV6ShellManage
                           shell_surface.ping_timeout_listener() as _);
             wl_signal_add(&mut (*data).events.new_popup as *mut _ as _,
                           shell_surface.new_popup_listener() as _);
-            // TODO We gotta costruct a top level / popup here and store it in the
-            // XdgV6Shell so that the listeners can work properly....
-            //
-            // FIXME Consider the possiblity of borrowing the specific type during an
-            // event fire? Aliasing possible? Not sure
+            let events = match shell_surface.surface_mut().state() {
+                None | Some(&mut Popup(_)) => None,
+                Some(&mut TopLevel(ref mut toplevel)) => Some((*toplevel.as_ptr()).events)
+            };
+            if let Some(mut events) = events {
+                    wl_signal_add(&mut events.request_maximize as *mut _ as _,
+                                  shell_surface.maximize_listener() as _);
+                    wl_signal_add(&mut events.request_fullscreen as *mut _ as _,
+                                  shell_surface.fullscreen_listener() as _);
+                    wl_signal_add(&mut events.request_minimize as *mut _ as _,
+                                  shell_surface.minimize_listener() as _);
+                    wl_signal_add(&mut events.request_move as *mut _ as _,
+                                  shell_surface.move_listener() as _);
+                    wl_signal_add(&mut events.request_resize as *mut _ as _,
+                                  shell_surface.resize_listener() as _);
+                    wl_signal_add(&mut events.request_show_window_menu as *mut _ as _,
+                                  shell_surface.show_window_menu_listener() as _);
+            }
 
-            //wl_signal_add(&mut (*data).events.request_maximize as *mut _ as _,
-            //              shell_surface.maximize_listener() as _);
-            //wl_signal_add(&mut (*data).events.request_fullscreen as *mut _ as _,
-            //              shell_surface.fullscreen_listener() as _);
-            //wl_signal_add(&mut (*data).events.request_minimize as *mut _ as _,
-            //              shell_surface.minimize_listener() as _);
-            //wl_signal_add(&mut (*data).events.request_move as *mut _ as _,
-            //              shell_surface.move_listener() as _);
-            //wl_signal_add(&mut (*data).events.request_resize as *mut _ as _,
-            //              shell_surface.resize_listener() as _);
-            //wl_signal_add(&mut (*data).events.request_show_window_menu as *mut _ as _,
-            //              shell_surface.show_window_menu_listener() as _);
             shells.push(shell_surface);
         }
     };

--- a/src/render/renderer.rs
+++ b/src/render/renderer.rs
@@ -58,7 +58,6 @@ impl GenericRenderer {
                                       stride: u32,
                                       width: u32,
                                       height: u32,
-                                      // TODO Slice of u8? It's a void*, hmm
                                       data: &[u8])
                                       -> Option<Texture> {
         unsafe {

--- a/src/render/renderer.rs
+++ b/src/render/renderer.rs
@@ -1,11 +1,12 @@
 //! TODO Documentation
 
-use libc::{c_float, c_int};
+use libc::{c_float, c_int, c_void};
 
 use Output;
 use render::Texture;
-use wlroots_sys::{wlr_backend, wlr_render_colored_ellipse, wlr_render_colored_quad,
-                  wlr_render_texture, wlr_render_texture_create, wlr_render_texture_with_matrix,
+use wlroots_sys::{wl_shm_format, wlr_backend, wlr_render_ellipse_with_matrix, wlr_render_quad_with_matrix,
+                  wlr_texture_from_pixels,
+                  wlr_render_texture, wlr_render_texture_with_matrix,
                   wlr_renderer, wlr_renderer_begin, wlr_renderer_clear, wlr_renderer_destroy,
                   wlr_renderer_end, wlr_gles2_renderer_create};
 
@@ -53,8 +54,11 @@ impl GenericRenderer {
     }
 
     /// Create a texture using this renderer.
-    pub fn create_texture(&mut self) -> Option<Texture> {
-        unsafe { create_texture(self.renderer) }
+    pub fn create_texture_from_pixels(&mut self, format: wl_shm_format,
+                                      stride: u32, width: u32, height: u32,
+                                      // TODO Slice of u8? It's a void*, hmm
+                                      data: &[u8]) -> Option<Texture> {
+        unsafe { create_texture_from_pixels(self.renderer, format, stride, width, height, data.as_ptr() as _) }
     }
 
     pub(crate) unsafe fn as_ptr(&self) -> *mut wlr_renderer {
@@ -69,11 +73,6 @@ impl Drop for GenericRenderer {
 }
 
 impl<'output> Renderer<'output> {
-    /// Create a texture using this renderer
-    pub fn create_texture(&mut self) -> Option<Texture> {
-        unsafe { create_texture(self.renderer) }
-    }
-
     pub fn clear(&mut self, float: [f32; 4]) {
         unsafe { wlr_renderer_clear(self.renderer, float.as_ptr()) }
     }
@@ -120,12 +119,12 @@ impl<'output> Renderer<'output> {
 
     /// Renders a solid quad in the specified color.
     pub fn render_colored_quad(&mut self, color: [f32; 4], matrix: [f32; 9]) {
-        unsafe { wlr_render_colored_quad(self.renderer, color.as_ptr(), matrix.as_ptr()) }
+        unsafe { wlr_render_quad_with_matrix(self.renderer, color.as_ptr(), matrix.as_ptr()) }
     }
 
     /// Renders a solid ellipse in the specified color.
     pub fn render_colored_ellipse(&mut self, color: [f32; 4], matrix: [f32; 9]) {
-        unsafe { wlr_render_colored_ellipse(self.renderer, color.as_ptr(), matrix.as_ptr()) }
+        unsafe { wlr_render_ellipse_with_matrix(self.renderer, color.as_ptr(), matrix.as_ptr()) }
     }
 }
 
@@ -139,10 +138,12 @@ impl<'output> Drop for Renderer<'output> {
     }
 }
 
-unsafe fn create_texture(renderer: *mut wlr_renderer) -> Option<Texture> {
-    let texture = wlr_render_texture_create(renderer);
+unsafe fn create_texture_from_pixels(renderer: *mut wlr_renderer, format: wl_shm_format,
+                                     stride: u32, width: u32, height: u32,
+                                     // TODO Slice of u8? It's a void*, hmm
+                                     data: *const c_void) -> Option<Texture> {
+    let texture = wlr_texture_from_pixels(renderer, format, stride, width, height, data);
     if texture.is_null() {
-        wlr_log!(L_ERROR, "Could not create texture");
         None
     } else {
         Some(Texture::from_ptr(texture))

--- a/src/render/renderer.rs
+++ b/src/render/renderer.rs
@@ -4,11 +4,10 @@ use libc::{c_float, c_int, c_void};
 
 use Output;
 use render::Texture;
-use wlroots_sys::{wl_shm_format, wlr_backend, wlr_render_ellipse_with_matrix, wlr_render_quad_with_matrix,
-                  wlr_texture_from_pixels,
-                  wlr_render_texture, wlr_render_texture_with_matrix,
+use wlroots_sys::{wl_shm_format, wlr_backend, wlr_render_ellipse_with_matrix,
+                  wlr_render_quad_with_matrix, wlr_render_texture, wlr_render_texture_with_matrix,
                   wlr_renderer, wlr_renderer_begin, wlr_renderer_clear, wlr_renderer_destroy,
-                  wlr_renderer_end, wlr_gles2_renderer_create};
+                  wlr_renderer_end, wlr_texture_from_pixels, wlr_gles2_renderer_create};
 
 /// A generic interface for rendering to the screen.
 ///
@@ -54,11 +53,22 @@ impl GenericRenderer {
     }
 
     /// Create a texture using this renderer.
-    pub fn create_texture_from_pixels(&mut self, format: wl_shm_format,
-                                      stride: u32, width: u32, height: u32,
+    pub fn create_texture_from_pixels(&mut self,
+                                      format: wl_shm_format,
+                                      stride: u32,
+                                      width: u32,
+                                      height: u32,
                                       // TODO Slice of u8? It's a void*, hmm
-                                      data: &[u8]) -> Option<Texture> {
-        unsafe { create_texture_from_pixels(self.renderer, format, stride, width, height, data.as_ptr() as _) }
+                                      data: &[u8])
+                                      -> Option<Texture> {
+        unsafe {
+            create_texture_from_pixels(self.renderer,
+                                       format,
+                                       stride,
+                                       width,
+                                       height,
+                                       data.as_ptr() as _)
+        }
     }
 
     pub(crate) unsafe fn as_ptr(&self) -> *mut wlr_renderer {
@@ -138,10 +148,14 @@ impl<'output> Drop for Renderer<'output> {
     }
 }
 
-unsafe fn create_texture_from_pixels(renderer: *mut wlr_renderer, format: wl_shm_format,
-                                     stride: u32, width: u32, height: u32,
+unsafe fn create_texture_from_pixels(renderer: *mut wlr_renderer,
+                                     format: wl_shm_format,
+                                     stride: u32,
+                                     width: u32,
+                                     height: u32,
                                      // TODO Slice of u8? It's a void*, hmm
-                                     data: *const c_void) -> Option<Texture> {
+                                     data: *const c_void)
+                                     -> Option<Texture> {
     let texture = wlr_texture_from_pixels(renderer, format, stride, width, height, data);
     if texture.is_null() {
         None

--- a/src/render/texture.rs
+++ b/src/render/texture.rs
@@ -1,5 +1,5 @@
 use libc::c_int;
-use wlroots_sys::{wl_shm_format, wlr_texture, wlr_texture_upload_pixels};
+use wlroots_sys::{wl_shm_format, wlr_texture, wlr_texture_get_size};
 
 /// Wrapper around wl_shm_format, to make it easier and nicer to type.
 #[repr(u32)]
@@ -91,23 +91,10 @@ impl Texture {
     ///
     /// Return value is in (width, height) format.
     pub fn size(&self) -> (c_int, c_int) {
-        unsafe { ((*self.texture).width, (*self.texture).height) }
-    }
-
-    pub fn upload_pixels(&mut self,
-                         texture_format: TextureFormat,
-                         stride: i32,
-                         width: i32,
-                         height: i32,
-                         bytes: &[u8])
-                         -> bool {
         unsafe {
-            wlr_texture_upload_pixels(self.texture,
-                                      texture_format.into(),
-                                      stride,
-                                      width,
-                                      height,
-                                      bytes.as_ptr())
+            let (mut width, mut height) = (0, 0);
+            wlr_texture_get_size(self.texture, &mut width, &mut height);
+            (width, height)
         }
     }
 }

--- a/src/types/cursor/cursor.rs
+++ b/src/types/cursor/cursor.rs
@@ -448,9 +448,7 @@ impl Cursor {
     pub fn absolute_to_layout_coords(&mut self,
                                      dev: &InputDevice,
                                      x_mm: f64,
-                                     y_mm: f64,
-                                     width_mm: f64,
-                                     height_mm: f64)
+                                     y_mm: f64)
                                      -> (f64, f64) {
         unsafe {
             let (mut lx, mut ly) = (0.0, 0.0);
@@ -458,8 +456,6 @@ impl Cursor {
                                                  dev.as_ptr(),
                                                  x_mm,
                                                  y_mm,
-                                                 width_mm,
-                                                 height_mm,
                                                  &mut lx,
                                                  &mut ly);
             (lx, ly)

--- a/src/types/shell/xdg_shell_v6.rs
+++ b/src/types/shell/xdg_shell_v6.rs
@@ -1,7 +1,6 @@
 //! TODO Documentation
 
 use std::{panic, ptr};
-use std::marker::PhantomData;
 use std::rc::{Rc, Weak};
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -18,48 +17,72 @@ use utils::c_to_rust_string;
 
 /// Used internally to reclaim a handle from just a *mut wlr_xdg_surface_v6.
 struct XdgV6ShellSurfaceState {
-    handle: Weak<AtomicBool>
+    handle: Weak<AtomicBool>,
+    shell_state: Option<XdgV6ShellState>
 }
 
-pub struct XdgV6TopLevel<'surface> {
+#[derive(Debug, Eq, PartialEq, Hash)]
+pub struct XdgV6TopLevel {
     shell_surface: *mut wlr_xdg_surface_v6,
-    toplevel: *mut wlr_xdg_toplevel_v6,
-    phantom: PhantomData<&'surface XdgV6ShellSurface>
+    toplevel: *mut wlr_xdg_toplevel_v6
 }
 
-pub struct XdgV6Popup<'surface> {
-    popup: *mut wlr_xdg_popup_v6,
-    phantom: PhantomData<&'surface XdgV6ShellSurface>
+#[derive(Debug, Eq, PartialEq, Hash)]
+pub struct XdgV6Popup {
+    popup: *mut wlr_xdg_popup_v6
 }
 
 /// A tagged enum of the different roles used by the xdg shell.
 ///
 /// Uses the tag to disambiguate the union in `wlr_xdg_surface_v6`.
-pub enum XdgV6ShellState<'surface> {
-    TopLevel(XdgV6TopLevel<'surface>),
-    Popup(XdgV6Popup<'surface>)
+#[derive(Debug, Eq, PartialEq, Hash)]
+pub enum XdgV6ShellState {
+    TopLevel(XdgV6TopLevel),
+    Popup(XdgV6Popup)
 }
 
 #[derive(Debug)]
 pub struct XdgV6ShellSurface {
     liveliness: Option<Rc<AtomicBool>>,
+    state: Option<XdgV6ShellState>,
     shell_surface: *mut wlr_xdg_surface_v6
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct XdgV6ShellSurfaceHandle {
+    state: Option<XdgV6ShellState>,
     handle: Weak<AtomicBool>,
     shell_surface: *mut wlr_xdg_surface_v6
 }
 
+impl Clone for XdgV6ShellSurfaceHandle {
+    fn clone(&self) -> Self {
+        let state = match self.state {
+            None => None,
+            Some(ref state) => Some(unsafe { state.clone() })
+        };
+        XdgV6ShellSurfaceHandle { state,
+                                  handle: self.handle.clone(),
+                                  shell_surface: self.shell_surface }
+    }
+}
+
 impl XdgV6ShellSurface {
-    pub(crate) unsafe fn new(shell_surface: *mut wlr_xdg_surface_v6) -> Self {
+    pub(crate) unsafe fn new(shell_surface: *mut wlr_xdg_surface_v6,
+                             state: Option<XdgV6ShellState>)
+                             -> Self {
         // TODO FIXME Free state in drop impl when Rc == 1
         (*shell_surface).data = ptr::null_mut();
         let liveliness = Rc::new(AtomicBool::new(false));
-        let state = Box::new(XdgV6ShellSurfaceState { handle: Rc::downgrade(&liveliness) });
-        (*shell_surface).data = Box::into_raw(state) as *mut _;
+        let shell_state =
+            Box::new(XdgV6ShellSurfaceState { handle: Rc::downgrade(&liveliness),
+                                              shell_state: match state {
+                                                  None => None,
+                                                  Some(ref state) => Some(state.clone())
+                                              } });
+        (*shell_surface).data = Box::into_raw(shell_state) as *mut _;
         XdgV6ShellSurface { liveliness: Some(liveliness),
+                            state,
                             shell_surface }
     }
 
@@ -69,6 +92,7 @@ impl XdgV6ShellSurface {
 
     unsafe fn from_handle(handle: &XdgV6ShellSurfaceHandle) -> Self {
         XdgV6ShellSurface { liveliness: None,
+                            state: handle.clone().state,
                             shell_surface: handle.as_ptr() }
     }
 
@@ -88,22 +112,8 @@ impl XdgV6ShellSurface {
         unsafe { (*self.shell_surface).role }
     }
 
-    pub fn state<'surface>(&'surface mut self) -> Option<XdgV6ShellState<'surface>> {
-        use self::wlr_xdg_surface_v6_role::*;
-        use XdgV6ShellState::*;
-        unsafe {
-            match (*self.shell_surface).role {
-                WLR_XDG_SURFACE_V6_ROLE_NONE => None,
-                WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL => {
-                    let toplevel = (*self.shell_surface).__bindgen_anon_1.toplevel;
-                    Some(TopLevel(XdgV6TopLevel::from_shell(self, toplevel)))
-                }
-                WLR_XDG_SURFACE_V6_ROLE_POPUP => {
-                    let popup = (*self.shell_surface).__bindgen_anon_1.popup;
-                    Some(Popup(XdgV6Popup::from_ptr(popup)))
-                }
-            }
-        }
+    pub fn state(&mut self) -> Option<&mut XdgV6ShellState> {
+        self.state.as_mut()
     }
 
     /// Determines if this XDG shell surface has been configured or not.
@@ -186,6 +196,10 @@ impl XdgV6ShellSurface {
         let arc = self.liveliness.as_ref()
                       .expect("Cannot dowgrade a previously upgraded XdgV6ShellSurfaceHandle");
         XdgV6ShellSurfaceHandle { handle: Rc::downgrade(arc),
+                                  state: match self.state {
+                                      None => None,
+                                      Some(ref state) => unsafe { Some(state.clone()) }
+                                  },
                                   shell_surface: self.shell_surface }
     }
 
@@ -210,7 +224,12 @@ impl XdgV6ShellSurfaceHandle {
             panic!("Cannot construct handle from a shell surface that has not been set up!");
         }
         let handle = (*data).handle.clone();
+        let state = match (*data).shell_state {
+            None => None,
+            Some(ref state) => Some(unsafe { state.clone() })
+        };
         XdgV6ShellSurfaceHandle { handle,
+                                  state,
                                   shell_surface }
     }
 
@@ -287,13 +306,12 @@ impl PartialEq for XdgV6ShellSurfaceHandle {
 
 impl Eq for XdgV6ShellSurfaceHandle {}
 
-impl<'surface> XdgV6TopLevel<'surface> {
-    unsafe fn from_shell(shell_surface: &'surface mut XdgV6ShellSurface,
-                         toplevel: *mut wlr_xdg_toplevel_v6)
-                         -> XdgV6TopLevel<'surface> {
-        XdgV6TopLevel { shell_surface: shell_surface.as_ptr(),
-                        toplevel,
-                        phantom: PhantomData }
+impl XdgV6TopLevel {
+    pub(crate) unsafe fn from_shell(shell_surface: *mut wlr_xdg_surface_v6,
+                                    toplevel: *mut wlr_xdg_toplevel_v6)
+                                    -> XdgV6TopLevel {
+        XdgV6TopLevel { shell_surface,
+                        toplevel }
     }
 
     /// Get the title associated with this XDG shell toplevel.
@@ -380,12 +398,15 @@ impl<'surface> XdgV6TopLevel<'surface> {
     pub fn close(&mut self) {
         unsafe { wlr_xdg_surface_v6_send_close(self.shell_surface) }
     }
+
+    pub(crate) unsafe fn as_ptr(&self) -> *mut wlr_xdg_toplevel_v6 {
+        self.toplevel
+    }
 }
 
-impl<'surface> XdgV6Popup<'surface> {
-    pub(crate) unsafe fn from_ptr(popup: *mut wlr_xdg_popup_v6) -> XdgV6Popup<'surface> {
-        XdgV6Popup { popup,
-                     phantom: PhantomData }
+impl XdgV6Popup {
+    pub(crate) unsafe fn from_ptr(popup: *mut wlr_xdg_popup_v6) -> XdgV6Popup {
+        XdgV6Popup { popup }
     }
 
     /// Get a handle to the base surface of the xdg tree.
@@ -409,5 +430,20 @@ impl<'surface> XdgV6Popup<'surface> {
 
     pub fn geometry(&self) -> Area {
         unsafe { Area((*self.popup).geometry) }
+    }
+}
+
+impl XdgV6ShellState {
+    /// Unsafe copy of the pointer
+    unsafe fn clone(&self) -> Self {
+        use XdgV6ShellState::*;
+        match *self {
+            TopLevel(XdgV6TopLevel { shell_surface,
+                                     toplevel }) => {
+                TopLevel(XdgV6TopLevel { shell_surface,
+                                         toplevel })
+            }
+            Popup(XdgV6Popup { popup }) => Popup(XdgV6Popup { popup })
+        }
     }
 }

--- a/src/types/shell/xdg_shell_v6.rs
+++ b/src/types/shell/xdg_shell_v6.rs
@@ -7,7 +7,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use wlroots_sys::{wlr_xdg_popup_v6, wlr_xdg_surface_v6, wlr_xdg_surface_v6_ping,
                   wlr_xdg_surface_v6_popup_at, wlr_xdg_surface_v6_popup_get_position,
-                  wlr_xdg_surface_v6_role, wlr_xdg_toplevel_v6, wlr_xdg_toplevel_v6_send_close,
+                  wlr_xdg_surface_v6_role, wlr_xdg_surface_v6_send_close, wlr_xdg_toplevel_v6,
                   wlr_xdg_toplevel_v6_set_activated, wlr_xdg_toplevel_v6_set_fullscreen,
                   wlr_xdg_toplevel_v6_set_maximized, wlr_xdg_toplevel_v6_set_resizing,
                   wlr_xdg_toplevel_v6_set_size, wlr_xdg_toplevel_v6_state};
@@ -380,7 +380,7 @@ impl<'surface> XdgV6TopLevel<'surface> {
 
     /// Request that this toplevel surface closes.
     pub fn close(&mut self) {
-        unsafe { wlr_xdg_toplevel_v6_send_close(self.shell_surface) }
+        unsafe { wlr_xdg_surface_v6_send_close(self.shell_surface) }
     }
 }
 

--- a/src/types/shell/xdg_shell_v6.rs
+++ b/src/types/shell/xdg_shell_v6.rs
@@ -123,20 +123,6 @@ impl XdgV6ShellSurface {
         unsafe { (*self.shell_surface).configure_next_serial }
     }
 
-    /// Get the title associated with this XDg shell.
-    pub fn title(&self) -> String {
-        unsafe {
-            c_to_rust_string((*self.shell_surface).title).expect("Could not parse class as UTF-8")
-        }
-    }
-
-    /// Get the app id associated with this XDG shell.
-    pub fn app_id(&self) -> String {
-        unsafe {
-            c_to_rust_string((*self.shell_surface).app_id).expect("Could not parse class as UTF-8")
-        }
-    }
-
     pub fn has_next_geometry(&self) -> bool {
         unsafe { (*self.shell_surface).has_next_geometry }
     }
@@ -310,6 +296,18 @@ impl<'surface> XdgV6TopLevel<'surface> {
                         phantom: PhantomData }
     }
 
+    /// Get the title associated with this XDG shell toplevel.
+    pub fn title(&self) -> String {
+        unsafe { c_to_rust_string((*self.toplevel).title).expect("Could not parse class as UTF-8") }
+    }
+
+    /// Get the app id associated with this XDG shell toplevel.
+    pub fn app_id(&self) -> String {
+        unsafe {
+            c_to_rust_string((*self.toplevel).app_id).expect("Could not parse class as UTF-8")
+        }
+    }
+
     /// Get a handle to the base surface of the xdg tree.
     pub fn base(&self) -> XdgV6ShellSurfaceHandle {
         unsafe { XdgV6ShellSurfaceHandle::from_ptr((*self.toplevel).base) }
@@ -324,14 +322,14 @@ impl<'surface> XdgV6TopLevel<'surface> {
         unsafe { (*self.toplevel).added }
     }
 
-    /// Get the client protocol request state.
-    pub fn next_state(&self) -> wlr_xdg_toplevel_v6_state {
-        unsafe { (*self.toplevel).next }
+    /// Get the pending client state.
+    pub fn client_pending_state(&self) -> wlr_xdg_toplevel_v6_state {
+        unsafe { (*self.toplevel).client_pending }
     }
 
-    /// Get the pending user configure request state.
-    pub fn pending_state(&self) -> wlr_xdg_toplevel_v6_state {
-        unsafe { (*self.toplevel).pending }
+    /// Get the pending server state.
+    pub fn server_pending_state(&self) -> wlr_xdg_toplevel_v6_state {
+        unsafe { (*self.toplevel).server_pending }
     }
 
     /// Get the current configure state.

--- a/wlroots-sys/build.rs
+++ b/wlroots-sys/build.rs
@@ -47,6 +47,13 @@ fn main() {
     println!("cargo:rustc-link-lib=dylib=X11-xcb");
     println!("cargo:rustc-link-lib=dylib=xkbcommon");
     println!("cargo:rustc-link-lib=dylib=xcb");
+    println!("cargo:rustc-link-lib=dylib=xcb-composite");
+    println!("cargo:rustc-link-lib=dylib=xcb-xfixes");
+    println!("cargo:rustc-link-lib=dylib=xcb-image");
+    println!("cargo:rustc-link-lib=dylib=xcb-render");
+    println!("cargo:rustc-link-lib=dylib=xcb-shm");
+    println!("cargo:rustc-link-lib=dylib=xcb-icccm");
+    println!("cargo:rustc-link-lib=dylib=xcb-xkb");
     println!("cargo:rustc-link-lib=dylib=cap");
     println!("cargo:rustc-link-lib=dylib=wayland-egl");
     println!("cargo:rustc-link-lib=dylib=wayland-client");

--- a/wlroots-sys/build.rs
+++ b/wlroots-sys/build.rs
@@ -31,6 +31,8 @@ fn main() {
         // pragma information on what features are available in a header file
         // titled "config.h"
         .clang_arg(format!("-I{}{}", target_dir, "/include/"))
+        // NOTE Necessary because the xdg-shell-v6 headers generate here
+        .clang_arg(format!("-I{}{}", target_dir, "/protocol/wl_protos@sta"))
         .clang_arg("-Iwlroots/include/xcursor")
         .clang_arg("-I/usr/include/pixman-1")
         // Work around bug https://github.com/rust-lang-nursery/rust-bindgen/issues/687


### PR DESCRIPTION
Latest from the hackathon before I go. This has various changes

# Render
Can't create an invalid texture, API has increased (and thus more wrapping will be necessary)

# Touch / Axis events
No longer send width/height information explicitly

# Build
links to various xcb libraries now

# TODO
- [x] Fix the xdg-v6 events so that they trigger again. The signal listeners were moved to the two various types (popup and toplevel) and so the shell struct we have needs to store them now at creation time.