### PR TITLE
Seat

### DIFF
--- a/examples/rotation.rs
+++ b/examples/rotation.rs
@@ -90,7 +90,7 @@ impl OutputHandler for ExOutput {
         let ms = (seconds_delta * 1000.0) + nano_delta as f32 / 1000000.0;
         let seconds = ms / 1000.0;
         let transform_matrix = output.transform_matrix();
-        let mut renderer = renderer.render(output);
+        let mut renderer = renderer.render(output, None);
         let cat_texture = compositor_data.cat_texture.as_ref().unwrap();
         for y in StepRange(-128 + compositor_data.y_offs as i32, height, 128) {
             for x in StepRange(-128 + compositor_data.x_offs as i32, width, 128) {

--- a/examples/touch.rs
+++ b/examples/touch.rs
@@ -70,7 +70,7 @@ impl OutputHandler for ExOutput {
         // NOTE gl functions will probably always be unsafe.
         let (width, height) = output.effective_resolution();
         let transform_matrix = output.transform_matrix();
-        let mut renderer = renderer.render(output);
+        let mut renderer = renderer.render(output, None);
         renderer.clear([0.25, 0.25, 0.25, 1.0]);
         let cat_texture = state.cat_texture.as_mut().unwrap();
         let (cat_width, cat_height) = cat_texture.size();

--- a/examples/wl_shell_test.rs
+++ b/examples/wl_shell_test.rs
@@ -285,7 +285,7 @@ impl OutputHandler for ExOutput {
         let renderer = compositor.renderer
                                  .as_mut()
                                  .expect("Compositor was not loaded with a renderer");
-        render_shells(state, &mut renderer.render(output));
+        render_shells(state, &mut renderer.render(output, None));
     }
 }
 

--- a/examples/xdg_shell_v6_test.rs
+++ b/examples/xdg_shell_v6_test.rs
@@ -3,7 +3,7 @@ extern crate wlroots;
 
 use std::process::Command;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use wlroots::{project_box, Area, Capability, Compositor, CompositorBuilder, CursorBuilder,
               CursorHandler, CursorId, InputManagerHandler, Keyboard, KeyboardGrab,
@@ -256,7 +256,10 @@ fn render_shells(state: &mut State, renderer: &mut Renderer) {
                                                                          .transform_matrix());
                                         renderer.render_texture_with_matrix(&surface.texture(),
                                                                             matrix);
-                                        surface.send_frame_done(Duration::from_secs(1));
+                                        let start = SystemTime::now();
+                                        let now = start.duration_since(UNIX_EPOCH)
+                                            .expect("Time went backwards");
+                                        surface.send_frame_done(now);
                                     }
                                 })
                            .unwrap()

--- a/examples/xdg_shell_v6_test.rs
+++ b/examples/xdg_shell_v6_test.rs
@@ -62,8 +62,7 @@ impl XdgV6ShellHandler for XdgV6ShellHandlerEx {
 impl XdgV6ShellManagerHandler for XdgV6ShellManager {
     fn new_surface(&mut self,
                    compositor: &mut Compositor,
-                   shell: &mut XdgV6ShellSurface,
-                   surface: &mut Surface)
+                   shell: &mut XdgV6ShellSurface)
                    -> Option<Box<XdgV6ShellHandler>> {
         shell.ping();
         match shell.state() {
@@ -82,12 +81,6 @@ impl XdgV6ShellManagerHandler for XdgV6ShellManager {
         };
         let seat = compositor.seats.get(seat_id).expect("invalid seat id");
         let mut keyboard = seat.get_keyboard().expect("Seat did not have a keyboard set");
-        keyboard.run(|keyboard| {
-                         seat.keyboard_notify_enter(surface,
-                                                    &mut keyboard.keycodes(),
-                                                    &mut keyboard.get_modifier_masks())
-                     })
-                .unwrap();
         Some(Box::new(XdgV6ShellHandlerEx))
     }
 

--- a/examples/xdg_shell_v6_test.rs
+++ b/examples/xdg_shell_v6_test.rs
@@ -12,14 +12,12 @@ use wlroots::{project_box, Area, Compositor, CompositorBuilder, CursorBuilder, C
               Surface, XCursorTheme, XdgV6ShellHandler, XdgV6ShellManagerHandler,
               XdgV6ShellSurface, XdgV6ShellSurfaceHandle};
 use wlroots::key_events::KeyEvent;
-use wlroots::pointer_events::{AxisEvent, ButtonEvent, MotionEvent};
+use wlroots::pointer_events::{ButtonEvent, MotionEvent};
 use wlroots::utils::{init_logging, L_DEBUG};
-use wlroots::wlroots_sys::wlr_button_state::WLR_BUTTON_RELEASED;
+use wlroots::wlroots_sys::wlr_button_state::WLR_BUTTON_PRESSED;
 use wlroots::xkbcommon::xkb::keysyms::KEY_Escape;
 
 struct State {
-    color: [f32; 4],
-    default_color: [f32; 4],
     xcursor_theme: XCursorTheme,
     layout: OutputLayout,
     cursor_id: CursorId,
@@ -28,9 +26,7 @@ struct State {
 
 impl State {
     fn new(xcursor_theme: XCursorTheme, layout: OutputLayout, cursor_id: CursorId) -> Self {
-        State { color: [0.25, 0.25, 0.25, 1.0],
-                default_color: [0.25, 0.25, 0.25, 1.0],
-                xcursor_theme,
+        State { xcursor_theme,
                 layout,
                 cursor_id,
                 shells: vec![] }
@@ -137,26 +133,9 @@ impl PointerHandler for ExPointer {
 
     fn on_button(&mut self, compositor: &mut Compositor, _: &mut Pointer, event: &ButtonEvent) {
         let state: &mut State = compositor.into();
-        if event.state() == WLR_BUTTON_RELEASED {
-            state.color = state.default_color;
-        } else {
-            state.color = [0.25, 0.25, 0.25, 1.0];
-            state.color[event.button() as usize % 3] = 1.0;
+        if event.state() == WLR_BUTTON_PRESSED {
+            wlr_log!(L_DEBUG, "Clicking pointer {}", event.button())
         }
-    }
-
-    fn on_axis(&mut self, compositor: &mut Compositor, _: &mut Pointer, event: &AxisEvent) {
-        let state: &mut State = compositor.into();
-        for color_byte in &mut state.default_color[..3] {
-            *color_byte += if event.delta() > 0.0 { -0.05 } else { 0.05 };
-            if *color_byte > 1.0 {
-                *color_byte = 1.0
-            }
-            if *color_byte < 0.0 {
-                *color_byte = 0.0
-            }
-        }
-        state.color = state.default_color.clone()
     }
 }
 

--- a/examples/xdg_shell_v6_test.rs
+++ b/examples/xdg_shell_v6_test.rs
@@ -171,7 +171,7 @@ impl OutputHandler for ExOutput {
         let renderer = compositor.renderer
                                  .as_mut()
                                  .expect("Compositor was not loaded with a renderer");
-        render_shells(state, &mut renderer.render(output));
+        render_shells(state, &mut renderer.render(output, None));
     }
 }
 
@@ -251,7 +251,7 @@ fn render_shells(state: &mut State, renderer: &mut Renderer) {
                                                                             matrix);
                                         let start = SystemTime::now();
                                         let now = start.duration_since(UNIX_EPOCH)
-                                            .expect("Time went backwards");
+                                                       .expect("Time went backwards");
                                         surface.send_frame_done(now);
                                     }
                                 })

--- a/src/events/key_events.rs
+++ b/src/events/key_events.rs
@@ -22,7 +22,7 @@ impl KeyEvent {
     /// Usually you want to use `KeyEvent::input_keys` since you care about what
     /// value XKB says this is.
     pub fn keycode(&self) -> u32 {
-        unsafe { (*self.key).keycode + 8 }
+        unsafe { (*self.key).keycode }
     }
 
     /// Get how long the key has been pressed down, in milliseconds.
@@ -45,7 +45,7 @@ impl KeyEvent {
     pub fn pressed_keys(&self) -> Vec<Key> {
         unsafe {
             let mut syms = 0 as *const xkb_keysym_t;
-            let key_length = xkb_state_key_get_syms(self.xkb_state, self.keycode(), &mut syms);
+            let key_length = xkb_state_key_get_syms(self.xkb_state, self.keycode() + 8, &mut syms);
             (0..key_length).map(|index| *syms.offset(index as isize))
                            .collect()
         }

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -4,3 +4,4 @@ pub mod wl_shell_events;
 pub mod xdg_shell_v6_events;
 pub mod tablet_tool_events;
 pub mod touch_events;
+pub mod seat_events;

--- a/src/events/seat_events.rs
+++ b/src/events/seat_events.rs
@@ -1,0 +1,32 @@
+use wlroots_sys::wlr_seat_pointer_request_set_cursor_event;
+
+use {SeatClient, SurfaceHandle};
+
+#[derive(Debug)]
+pub struct SetCursorEvent {
+    event: *mut wlr_seat_pointer_request_set_cursor_event
+}
+
+impl SetCursorEvent {
+    pub(crate) unsafe fn from_ptr(event: *mut wlr_seat_pointer_request_set_cursor_event) -> Self {
+        SetCursorEvent { event }
+    }
+    /// Get the seat client associated with the seat where this
+    /// event is occurring.
+    pub fn seat_client<'seat>(&'seat self) -> SeatClient<'seat> {
+        unsafe { SeatClient::from_ptr((*self.event).seat_client) }
+    }
+
+    /// Get the surface that is providing the cursor to the seat.
+    pub fn surface(&self) -> SurfaceHandle {
+        unsafe { SurfaceHandle::from_ptr((*self.event).surface) }
+    }
+
+    pub fn serial(&self) -> u32 {
+        unsafe { (*self.event).serial }
+    }
+
+    pub fn location(&self) -> (i32, i32) {
+        unsafe { ((*self.event).hotspot_x, (*self.event).hotspot_y) }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ pub mod render;
 pub mod utils;
 
 pub use self::compositor::{terminate, Compositor, CompositorBuilder};
-pub use self::events::{key_events, pointer_events, touch_events, wl_shell_events,
+pub use self::events::{key_events, pointer_events, seat_events, touch_events, wl_shell_events,
                        xdg_shell_v6_events};
 pub use self::manager::{InputManagerHandler, KeyboardHandler, OutputBuilder, OutputBuilderResult,
                         OutputHandler, OutputManagerHandler, PointerHandler, TouchHandler,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ pub use self::types::data_device::*;
 pub use self::types::input_device::*;
 pub use self::types::keyboard::*;
 pub use self::types::output::output::*;
+pub use self::types::output::output_damage::*;
 pub use self::types::output::output_layout::*;
 pub use self::types::pointer::*;
 pub use self::types::seat::*;

--- a/src/manager/xdg_shell_v6_manager.rs
+++ b/src/manager/xdg_shell_v6_manager.rs
@@ -14,8 +14,7 @@ pub trait XdgV6ShellManagerHandler {
     /// Callback that is triggered when a new XDG shell v6 surface appears.
     fn new_surface(&mut self,
                    &mut Compositor,
-                   &mut XdgV6ShellSurface,
-                   &mut Surface)
+                   &mut XdgV6ShellSurface)
                    -> Option<Box<XdgV6ShellHandler>>;
 
     /// Callback that is triggered when an XDG shell v6 surface is destroyed.
@@ -45,10 +44,8 @@ wayland_listener!(XdgV6ShellManager, (Vec<Box<XdgV6Shell>>, Box<XdgV6ShellManage
             }
         };
         let mut shell_surface = XdgV6ShellSurface::new(data, state);
-        surface.set_lock(true);
         shell_surface.set_lock(true);
-        let new_surface_res = manager.new_surface(compositor, &mut shell_surface, &mut surface);
-        surface.set_lock(false);
+        let new_surface_res = manager.new_surface(compositor, &mut shell_surface);
         shell_surface.set_lock(false);
         if let Some(shell_surface_handler) = new_surface_res {
 

--- a/src/manager/xdg_shell_v6_manager.rs
+++ b/src/manager/xdg_shell_v6_manager.rs
@@ -107,6 +107,9 @@ wayland_listener!(XdgV6ShellManager, (Vec<Box<XdgV6Shell>>, Box<XdgV6ShellManage
             let mut removed_shell = shells.remove(index);
             ffi_dispatch!(WAYLAND_SERVER_HANDLE,
                           wl_list_remove,
+                          &mut (*removed_shell.commit_listener()).link as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
                           &mut (*removed_shell.ping_timeout_listener()).link as *mut _ as _);
             ffi_dispatch!(WAYLAND_SERVER_HANDLE,
                           wl_list_remove,

--- a/src/manager/xdg_shell_v6_manager.rs
+++ b/src/manager/xdg_shell_v6_manager.rs
@@ -60,6 +60,10 @@ wayland_listener!(XdgV6ShellManager, (Vec<Box<XdgV6Shell>>, Box<XdgV6ShellManage
             wl_signal_add(&mut (*data).events.destroy as *mut _ as _,
                           remove_listener);
 
+            // Hook the commit signal from the surface into the shell handler.
+            wl_signal_add(&mut (*(*data).surface).events.commit as *mut _ as _,
+                          shell_surface.commit_listener() as _);
+
             wl_signal_add(&mut (*data).events.ping_timeout as *mut _ as _,
                           shell_surface.ping_timeout_listener() as _);
             wl_signal_add(&mut (*data).events.new_popup as *mut _ as _,
@@ -69,18 +73,18 @@ wayland_listener!(XdgV6ShellManager, (Vec<Box<XdgV6Shell>>, Box<XdgV6ShellManage
                 Some(&mut TopLevel(ref mut toplevel)) => Some((*toplevel.as_ptr()).events)
             };
             if let Some(mut events) = events {
-                    wl_signal_add(&mut events.request_maximize as *mut _ as _,
-                                  shell_surface.maximize_listener() as _);
-                    wl_signal_add(&mut events.request_fullscreen as *mut _ as _,
-                                  shell_surface.fullscreen_listener() as _);
-                    wl_signal_add(&mut events.request_minimize as *mut _ as _,
-                                  shell_surface.minimize_listener() as _);
-                    wl_signal_add(&mut events.request_move as *mut _ as _,
-                                  shell_surface.move_listener() as _);
-                    wl_signal_add(&mut events.request_resize as *mut _ as _,
-                                  shell_surface.resize_listener() as _);
-                    wl_signal_add(&mut events.request_show_window_menu as *mut _ as _,
-                                  shell_surface.show_window_menu_listener() as _);
+                wl_signal_add(&mut events.request_maximize as *mut _ as _,
+                              shell_surface.maximize_listener() as _);
+                wl_signal_add(&mut events.request_fullscreen as *mut _ as _,
+                              shell_surface.fullscreen_listener() as _);
+                wl_signal_add(&mut events.request_minimize as *mut _ as _,
+                              shell_surface.minimize_listener() as _);
+                wl_signal_add(&mut events.request_move as *mut _ as _,
+                              shell_surface.move_listener() as _);
+                wl_signal_add(&mut events.request_resize as *mut _ as _,
+                              shell_surface.resize_listener() as _);
+                wl_signal_add(&mut events.request_show_window_menu as *mut _ as _,
+                              shell_surface.show_window_menu_listener() as _);
             }
 
             shells.push(shell_surface);

--- a/src/manager/xdg_shell_v6_manager.rs
+++ b/src/manager/xdg_shell_v6_manager.rs
@@ -29,7 +29,7 @@ wayland_listener!(XdgV6ShellManager, (Vec<Box<XdgV6Shell>>, Box<XdgV6ShellManage
         let data = data as *mut wlr_xdg_surface_v6;
         wlr_log!(L_DEBUG, "New xdg_shell_v6_surface request {:p}", data);
         let compositor = &mut *COMPOSITOR_PTR;
-        let mut surface = Surface::new((*data).surface);
+        let surface = Surface::new((*data).surface);
         let state = unsafe {
             match (*data).role {
                 WLR_XDG_SURFACE_V6_ROLE_NONE => None,

--- a/src/render/renderer.rs
+++ b/src/render/renderer.rs
@@ -1,13 +1,16 @@
 //! TODO Documentation
 
+use std::time::Duration;
+
 use libc::{c_float, c_int, c_void};
 
-use Output;
+use {Output, PixmanRegion};
 use render::Texture;
-use wlroots_sys::{wl_shm_format, wlr_backend, wlr_backend_get_egl, wlr_render_ellipse_with_matrix,
-                  wlr_render_quad_with_matrix, wlr_render_texture, wlr_render_texture_with_matrix,
-                  wlr_renderer, wlr_renderer_begin, wlr_renderer_clear, wlr_renderer_destroy,
-                  wlr_renderer_end, wlr_texture_from_pixels, wlr_gles2_renderer_create};
+use wlroots_sys::{timespec, wl_shm_format, wlr_backend, wlr_backend_get_egl,
+                  wlr_render_ellipse_with_matrix, wlr_render_quad_with_matrix, wlr_render_texture,
+                  wlr_render_texture_with_matrix, wlr_renderer, wlr_renderer_begin,
+                  wlr_renderer_clear, wlr_renderer_destroy, wlr_renderer_end,
+                  wlr_texture_from_pixels, wlr_gles2_renderer_create};
 
 /// A generic interface for rendering to the screen.
 ///
@@ -26,6 +29,7 @@ pub struct GenericRenderer {
 #[derive(Debug)]
 pub struct Renderer<'output> {
     renderer: *mut wlr_renderer,
+    pub damage: Option<(PixmanRegion, Duration)>,
     pub output: &'output mut Output
 }
 
@@ -46,12 +50,16 @@ impl GenericRenderer {
     /// Make the `Renderer` state machine type.
     ///
     /// This automatically makes the given output the current output.
-    pub fn render<'output>(&mut self, output: &'output mut Output) -> Renderer<'output> {
+    pub fn render<'output>(&mut self,
+                           output: &'output mut Output,
+                           damage: Option<(PixmanRegion, Duration)>)
+                           -> Renderer<'output> {
         unsafe {
             output.make_current();
             let (width, height) = output.dimensions();
             wlr_renderer_begin(self.renderer, width, height);
             Renderer { renderer: self.renderer,
+                       damage,
                        output }
         }
     }
@@ -145,8 +153,11 @@ impl<'output> Drop for Renderer<'output> {
     fn drop(&mut self) {
         unsafe {
             wlr_renderer_end(self.renderer);
-            // TODO What about damage tracking?
-            self.output.swap_buffers(None, None);
+            if let Some((mut damage, when)) = self.damage.take() {
+                self.output.swap_buffers(Some(when), Some(&mut damage));
+            } else {
+                self.output.swap_buffers(None, None);
+            }
         }
     }
 }

--- a/src/render/renderer.rs
+++ b/src/render/renderer.rs
@@ -6,11 +6,10 @@ use libc::{c_float, c_int, c_void};
 
 use {Output, PixmanRegion};
 use render::Texture;
-use wlroots_sys::{timespec, wl_shm_format, wlr_backend, wlr_backend_get_egl,
-                  wlr_render_ellipse_with_matrix, wlr_render_quad_with_matrix, wlr_render_texture,
-                  wlr_render_texture_with_matrix, wlr_renderer, wlr_renderer_begin,
-                  wlr_renderer_clear, wlr_renderer_destroy, wlr_renderer_end,
-                  wlr_texture_from_pixels, wlr_gles2_renderer_create};
+use wlroots_sys::{wl_shm_format, wlr_backend, wlr_backend_get_egl, wlr_render_ellipse_with_matrix,
+                  wlr_render_quad_with_matrix, wlr_render_texture, wlr_render_texture_with_matrix,
+                  wlr_renderer, wlr_renderer_begin, wlr_renderer_clear, wlr_renderer_destroy,
+                  wlr_renderer_end, wlr_texture_from_pixels, wlr_gles2_renderer_create};
 
 /// A generic interface for rendering to the screen.
 ///

--- a/src/types/output/mod.rs
+++ b/src/types/output/mod.rs
@@ -2,3 +2,4 @@ pub mod output;
 pub mod output_layout;
 pub mod output_mode;
 pub mod output_cursor;
+pub mod output_damage;

--- a/src/types/output/output.rs
+++ b/src/types/output/output.rs
@@ -440,7 +440,6 @@ impl Drop for Output {
                 if Rc::strong_count(liveliness) == 1 {
                     wlr_log!(L_DEBUG, "Dropped output {:p}", self.output);
                     unsafe {
-                        let _ = Box::from_raw((*self.output).data as *mut OutputState);
                     }
                     let weak_count = Rc::weak_count(liveliness);
                     if weak_count > 0 {
@@ -457,6 +456,7 @@ impl Drop for Output {
         // TODO Move back up in the some after NLL is a thing.
         unsafe {
             self.remove_from_output_layout();
+            let _ = Box::from_raw((*self.output).data as *mut OutputState);
         }
     }
 }

--- a/src/types/output/output.rs
+++ b/src/types/output/output.rs
@@ -406,6 +406,10 @@ impl Output {
         unsafe { wlr_output_set_scale(self.output, scale) }
     }
 
+    pub fn damage(&mut self) -> &mut OutputDamage {
+        &mut *self.damage
+    }
+
     pub(crate) unsafe fn as_ptr(&self) -> *mut wlr_output {
         self.output
     }

--- a/src/types/output/output.rs
+++ b/src/types/output/output.rs
@@ -439,6 +439,9 @@ impl Drop for Output {
             Some(ref liveliness) => {
                 if Rc::strong_count(liveliness) == 1 {
                     wlr_log!(L_DEBUG, "Dropped output {:p}", self.output);
+                    unsafe {
+                        let _ = Box::from_raw((*self.output).data as *mut OutputState);
+                    }
                     let weak_count = Rc::weak_count(liveliness);
                     if weak_count > 0 {
                         wlr_log!(L_DEBUG,

--- a/src/types/output/output.rs
+++ b/src/types/output/output.rs
@@ -2,6 +2,7 @@
 
 use std::{panic, ptr};
 use std::ffi::CStr;
+use std::mem::ManuallyDrop;
 use std::rc::{Rc, Weak};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
@@ -9,12 +10,12 @@ use std::time::Duration;
 use libc::{c_float, c_int};
 use wayland_sys::server::WAYLAND_SERVER_HANDLE;
 use wlroots_sys::{timespec, wl_list, wl_output_subpixel, wl_output_transform, wlr_output,
-                  wlr_output_effective_resolution, wlr_output_enable, wlr_output_get_gamma_size,
-                  wlr_output_make_current, wlr_output_mode, wlr_output_schedule_frame,
-                  wlr_output_set_custom_mode, wlr_output_set_fullscreen_surface,
-                  wlr_output_set_gamma, wlr_output_set_mode, wlr_output_set_position,
-                  wlr_output_set_scale, wlr_output_set_transform, wlr_output_swap_buffers,
-                  pixman_region32_t};
+                  wlr_output_damage, wlr_output_effective_resolution, wlr_output_enable,
+                  wlr_output_get_gamma_size, wlr_output_make_current, wlr_output_mode,
+                  wlr_output_schedule_frame, wlr_output_set_custom_mode,
+                  wlr_output_set_fullscreen_surface, wlr_output_set_gamma, wlr_output_set_mode,
+                  wlr_output_set_position, wlr_output_set_scale, wlr_output_set_transform,
+                  wlr_output_swap_buffers, pixman_region32_t};
 
 use super::output_layout::OutputLayoutHandle;
 use super::output_mode::OutputMode;
@@ -24,10 +25,11 @@ use utils::c_to_rust_string;
 pub type Subpixel = wl_output_subpixel;
 pub type Transform = wl_output_transform;
 
-use {Origin, Size, Surface, SurfaceHandle};
+use {Origin, OutputDamage, Size, Surface, SurfaceHandle};
 
 struct OutputState {
     handle: Weak<AtomicBool>,
+    damage: *mut wlr_output_damage,
     layout_handle: Option<OutputLayoutHandle>
 }
 
@@ -43,6 +45,8 @@ pub struct Output {
     /// This is means safe operations might fail, but only if you use the unsafe
     /// marked function `upgrade` on a `OutputHandle`.
     liveliness: Option<Rc<AtomicBool>>,
+    /// The tracker for damage on the output.
+    damage: ManuallyDrop<OutputDamage>,
     /// The output ptr that refers to this `Output`
     output: *mut wlr_output
 }
@@ -55,6 +59,8 @@ pub struct OutputHandle {
     /// When wlroots deallocates the pointer associated with this handle,
     /// this can no longer be used.
     handle: Weak<AtomicBool>,
+    /// The tracker for damage on the output.
+    damage: *mut wlr_output_damage,
     /// The output ptr that refers to this `Output`
     output: *mut wlr_output
 }
@@ -70,6 +76,7 @@ impl Output {
     /// with NLL, so if this is no longer necessary it should be removed asap.
     pub(crate) unsafe fn clone(&self) -> Output {
         Output { liveliness: self.liveliness.clone(),
+                 damage: ManuallyDrop::new(self.damage.clone()),
                  output: self.output }
     }
 
@@ -82,10 +89,13 @@ impl Output {
         (*output).data = ptr::null_mut();
         let liveliness = Rc::new(AtomicBool::new(false));
         let handle = Rc::downgrade(&liveliness);
+        let damage = ManuallyDrop::new(OutputDamage::new(output));
         let state = Box::new(OutputState { handle,
+                                           damage: damage.as_ptr(),
                                            layout_handle: None });
         (*output).data = Box::into_raw(state) as *mut _;
         Output { liveliness: Some(liveliness),
+                 damage,
                  output }
     }
 
@@ -409,11 +419,13 @@ impl Output {
         let arc = self.liveliness.as_ref()
                       .expect("Cannot downgrade a previously upgraded OutputHandle");
         OutputHandle { handle: Rc::downgrade(arc),
+                       damage: unsafe { self.damage.as_ptr() },
                        output: self.output }
     }
 
     unsafe fn from_handle(handle: &OutputHandle) -> Self {
         Output { liveliness: None,
+                 damage: ManuallyDrop::new(OutputDamage::from_ptr(handle.damage)),
                  output: handle.as_ptr() }
     }
 
@@ -440,6 +452,7 @@ impl Drop for Output {
                 if Rc::strong_count(liveliness) == 1 {
                     wlr_log!(L_DEBUG, "Dropped output {:p}", self.output);
                     unsafe {
+                        ManuallyDrop::drop(&mut self.damage);
                     }
                     let weak_count = Rc::weak_count(liveliness);
                     if weak_count > 0 {
@@ -467,8 +480,11 @@ impl OutputHandle {
     pub(crate) unsafe fn from_ptr(output: *mut wlr_output) -> Self {
         let data = Box::from_raw((*output).data as *mut OutputState);
         let handle = data.handle.clone();
+        let damage = data.damage;
         (*output).data = Box::into_raw(data) as *mut _;
-        OutputHandle { handle, output }
+        OutputHandle { handle,
+                       output,
+                       damage }
     }
 
     /// Upgrades the output handle to a reference to the backing `Output`.

--- a/src/types/output/output_damage.rs
+++ b/src/types/output/output_damage.rs
@@ -1,0 +1,110 @@
+use std::{ptr, time::Duration};
+use wlroots_sys::{timespec, wlr_output, wlr_output_damage, wlr_output_damage_add,
+                  wlr_output_damage_add_box, wlr_output_damage_add_whole,
+                  wlr_output_damage_create, wlr_output_damage_destroy,
+                  wlr_output_damage_make_current, wlr_output_damage_swap_buffers,
+                  pixman_region32_t};
+
+use Area;
+
+#[derive(Debug)]
+pub struct OutputDamage {
+    damage: *mut wlr_output_damage
+}
+
+impl OutputDamage {
+    /// Makes a new `OutputDamage` bound to the given Output.
+    ///
+    /// # Safety
+    /// This function is unsafe because the `OutputDamage` should not outlive the
+    /// past in `Output`.
+    pub(crate) unsafe fn new(output: *mut wlr_output) -> Self {
+        unsafe {
+            let damage = wlr_output_damage_create(output);
+            if damage.is_null() {
+                panic!("Damage was none")
+            }
+            OutputDamage { damage }
+        }
+    }
+
+    pub(crate) unsafe fn from_ptr(damage: *mut wlr_output_damage) -> Self {
+        OutputDamage { damage }
+    }
+
+    pub(crate) unsafe fn as_ptr(&self) -> *mut wlr_output_damage {
+        self.damage
+    }
+
+    /// Just like `std::clone::Clone` but unsafe.
+    ///
+    /// # Unsafety
+    /// You can create a reference leak using this method very easily,
+    /// and it could make it so that weak handles to an output are dangling.
+    ///
+    /// This exists due to an issue in output_manager.rs that might be fixed
+    /// with NLL, so if this is no longer necessary it should be removed asap.
+    pub(crate) unsafe fn clone(&self) -> Self {
+        OutputDamage { damage: self.damage }
+    }
+
+    /// Makes the output rendering context current.
+    /// Returns `true` if `wlr_output_damage_swap_buffers` needs to be called.
+    ///
+    ///The region of the output that needs to be repainted is added to `damage`.
+    pub fn make_current(&mut self, damage: &mut Option<*mut pixman_region32_t>) -> bool {
+        unsafe {
+            let mut res = false;
+            let damage = damage.unwrap_or_else(|| ptr::null_mut());
+            wlr_output_damage_make_current(self.damage, &mut res, damage);
+            res
+        }
+    }
+
+    /// Swaps the output buffers.
+    ///
+    /// If the time of the frame isn't known, set `when` to `None`.
+    ///
+    /// Swapping buffers schedules a `frame` event.
+    pub fn swap_buffers(&mut self,
+                        when: Option<Duration>,
+                        damage: Option<*mut pixman_region32_t>)
+                        -> bool {
+        unsafe {
+            let when = when.map(|duration| {
+                                    timespec { tv_sec: duration.as_secs() as i64,
+                                               tv_nsec: duration.subsec_nanos() as i64 }
+                                });
+            let when_ptr =
+                when.map(|mut duration| &mut duration as *mut _).unwrap_or_else(|| ptr::null_mut());
+            let damage = damage.unwrap_or_else(|| ptr::null_mut());
+            wlr_output_damage_swap_buffers(self.damage, when_ptr, damage)
+        }
+    }
+
+    /// Accumulates damage and schedules a `frame` event.
+    pub fn add(&mut self, damage: *mut pixman_region32_t) {
+        unsafe {
+            wlr_output_damage_add(self.damage, damage);
+        }
+    }
+
+    /// Damages the whole output and schedules a `frame` event.
+    pub fn add_whole(&mut self) {
+        unsafe { wlr_output_damage_add_whole(self.damage) }
+    }
+
+    /// Accumulates damage from an `Area` and schedules a `frame` event.
+    pub fn add_area(&mut self, mut area: Area) {
+        unsafe { wlr_output_damage_add_box(self.damage, &mut area.0) }
+    }
+}
+
+impl Drop for OutputDamage {
+    fn drop(&mut self) {
+        wlr_log!(L_DEBUG, "Dropped OutputDamage {:p}", self.damage);
+        unsafe {
+            wlr_output_damage_destroy(self.damage);
+        }
+    }
+}

--- a/src/types/output/output_damage.rs
+++ b/src/types/output/output_damage.rs
@@ -8,6 +8,13 @@ use wlroots_sys::{timespec, wlr_output, wlr_output_damage, wlr_output_damage_add
 use Area;
 
 #[derive(Debug)]
+/// Tracks damage for an output.
+///
+/// When a `frame` event is emitted, `make_current` should be
+/// called. If necessary, the output should be repainted and
+/// `swap_buffers` should be called.
+///
+/// No rendering should happen outside a `frame` event handler.
 pub struct OutputDamage {
     damage: *mut wlr_output_damage
 }

--- a/src/types/output/output_damage.rs
+++ b/src/types/output/output_damage.rs
@@ -1,13 +1,16 @@
+use libc::{c_int, c_uint};
 use std::{mem, ptr, time::Duration};
 use wlroots_sys::{timespec, wlr_output, wlr_output_damage, wlr_output_damage_add,
                   wlr_output_damage_add_box, wlr_output_damage_add_whole,
                   wlr_output_damage_create, wlr_output_damage_destroy,
                   wlr_output_damage_make_current, wlr_output_damage_swap_buffers,
-                  pixman_region32_fini, pixman_region32_init, pixman_region32_t};
+                  pixman_region32_fini, pixman_region32_init, pixman_region32_t,
+                  pixman_region32_union_rect};
 
 use Area;
 
 /// A pixman region, used for damage tracking.
+#[derive(Debug)]
 pub struct PixmanRegion {
     pub region: pixman_region32_t
 }
@@ -21,6 +24,13 @@ impl PixmanRegion {
             let mut region = mem::uninitialized();
             pixman_region32_init(&mut region);
             PixmanRegion { region }
+        }
+    }
+
+    pub fn rectangle(&mut self, x: c_int, y: c_int, width: c_uint, height: c_uint) {
+        unsafe {
+            let region_ptr = &mut self.region as *mut _;
+            pixman_region32_union_rect(region_ptr, region_ptr, x, y, width, height);
         }
     }
 }

--- a/src/types/seat/seat.rs
+++ b/src/types/seat/seat.rs
@@ -382,7 +382,7 @@ impl Seat {
     }
 
     /// Set this keyboard as the active keyboard for the seat.
-    pub fn set_keyboard(&self, dev: InputDevice) {
+    pub fn set_keyboard(&self, dev: &InputDevice) {
         unsafe { wlr_seat_set_keyboard(self.data.0, dev.as_ptr()) }
     }
 

--- a/src/types/surface/surface_state.rs
+++ b/src/types/surface/surface_state.rs
@@ -3,9 +3,9 @@
 use libc::c_int;
 use std::marker::PhantomData;
 
-use wlroots_sys::{wl_output_transform, wl_resource, wlr_surface_state, pixman_region32_t};
+use wlroots_sys::{wl_output_transform, wl_resource, wlr_surface_state};
 
-use Surface;
+use {PixmanRegion, Surface};
 
 #[derive(Debug)]
 #[repr(u32)]
@@ -118,19 +118,19 @@ impl<'surface> SurfaceState<'surface> {
         (*self.state).buffer
     }
 
-    pub unsafe fn surface_damage(&self) -> pixman_region32_t {
-        (*self.state).surface_damage
+    pub unsafe fn surface_damage(&self) -> PixmanRegion {
+        PixmanRegion { region: (*self.state).surface_damage }
     }
 
-    pub unsafe fn buffer_damage(&self) -> pixman_region32_t {
-        (*self.state).buffer_damage
+    pub unsafe fn buffer_damage(&self) -> PixmanRegion {
+        PixmanRegion { region: (*self.state).buffer_damage }
     }
 
-    pub unsafe fn opaque(&self) -> pixman_region32_t {
-        (*self.state).opaque
+    pub unsafe fn opaque(&self) -> PixmanRegion {
+        PixmanRegion { region: (*self.state).opaque }
     }
 
-    pub unsafe fn input(&self) -> pixman_region32_t {
-        (*self.state).input
+    pub unsafe fn input(&self) -> PixmanRegion {
+        PixmanRegion { region: (*self.state).input }
     }
 }

--- a/wlroots-sys/build.rs
+++ b/wlroots-sys/build.rs
@@ -22,6 +22,7 @@ fn main() {
         .whitelisted_type(r"^wlr_.*$")
         .whitelisted_type(r"^xkb_.*$")
         .whitelisted_type(r"^XKB_.*$")
+        .whitelisted_function(r"^_?pixman_.*$")
         .whitelisted_function(r"^_?wlr_.*$")
         .whitelisted_function(r"^xkb_.*$")
         .ctypes_prefix("libc")

--- a/wlroots-sys/src/wlroots.h
+++ b/wlroots-sys/src/wlroots.h
@@ -47,3 +47,4 @@
 #include <xcursor.h>
 #include <xwayland.h>
 #include <xkbcommon/xkbcommon.h>
+#include <pixman.h>

--- a/wlroots-sys/src/wlroots.h
+++ b/wlroots-sys/src/wlroots.h
@@ -27,6 +27,7 @@
 #include <wlr/types/wlr_keyboard.h>
 #include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_output_layout.h>
+#include <wlr/types/wlr_output_damage.h>
 #include <wlr/types/wlr_pointer.h>
 #include <wlr/types/wlr_region.h>
 #include <wlr/types/wlr_server_decoration.h>


### PR DESCRIPTION
# Examples
Made xdg shell v6 test interactive (click and you can type into the terminal)

# Events
* `keycode` on `KeyEvent` no longer auto adds 8 to the value
* Added `SeatEvents`, specifically `SetCursorEvent`, completing #37.

# OutputDamage
* added `OutputDamage`. Untested, but should fix #94.

# XDG shell
Fixed the implementation, now that I actually understand the workflow. Thanks @emersion and @acrisci for all your help!