### PR TITLE
Disable default features for wlroots-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ travis-ci = { repository = "way-cooler/wlroots-rs/" }
 [dependencies]
 libc = "^0.2.*"
 rust-ini = "0.10.0"
-wlroots-sys = { path = "wlroots-sys" }
+wlroots-sys = { path = "wlroots-sys", default-features = false }
 wayland-sys = { version = "0.9.*", features = ["client", "dlopen", "server",] }
 lazy_static = "0.2"
 xkbcommon = "0.3"


### PR DESCRIPTION
Without this, the "static" feature of wlroots-sys is always enabled,
since it is the default. With this, "static" is still on by default
since wlroots-rs has default = ["static"]. However, now this can be
disabled by building wlroots-rs without default features.

Signed-off-by: Uli Schlachter <psychon@znc.in>