### PR TITLE
Fixes #134

### DIFF
--- a/rootston/src/input.rs
+++ b/rootston/src/input.rs
@@ -118,12 +118,12 @@ impl InputManager {
                 // reset mappings
                 cursor.map_to_output(None);
                 for pointer in pointers {
-                    cursor.map_input_to_output(pointer.input_device(),
+                    cursor.map_input_to_output(pointer.input_device()?,
                                                None)
                 }
                 // TODO Also map input to region if part of config
                 for touch in touches {
-                    cursor.map_input_to_output(touch.input_device(), None)
+                    cursor.map_input_to_output(touch.input_device()?, None)
                 }
                 // TODO table tool
                 let outputs = &mut state.outputs;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -215,8 +215,8 @@ macro_rules! compositor_data {
 macro_rules! run_handles {
     ([($handle_name: ident: $unhandle_name: block)] => $body: block) => {
         $unhandle_name.run(|$handle_name| {
-            $body
-        })
+            Ok($body)
+        }).and_then(|n: $crate::HandleResult<_>| n)
     };
     ([($handle_name1: ident: $unhandle_name1: block),
       ($handle_name2: ident: $unhandle_name2: block),


### PR DESCRIPTION
Can no longer construct InputDevice from an invalid input handle.

Also makes `run_handles!` easier to use.