### PR TITLE
Optional libcap, systemd, elogind dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,5 +35,8 @@ tempfile = "2"
 gl_generator = "0.5.0"
 
 [features]
-default = ["static"]
+default = ["static", "libcap", "systemd", "elogind"]
 static = ["wlroots-sys/static"]
+libcap = ["wlroots-sys/libcap"]
+systemd = ["wlroots-sys/systemd"]
+elogind = ["wlroots-sys/elogind"]

--- a/wlroots-sys/Cargo.toml
+++ b/wlroots-sys/Cargo.toml
@@ -17,8 +17,9 @@ meson = { version = "1.0", optional = true }
 gcc = "0.3"
 # This is for the simple example
 gl_generator = "0.5.0"
-# TODO Update once scanner fixes have been released
-wayland-scanner = "0.12.*" #{ git = "https://github.com/smithay/wayland-rs", rev = "a54e033" }
+wayland-scanner = "0.12.*"
+# For building optional dependencies
+pkg-config = "0.3.*"
 
 [dependencies]
 libc = "^0.2.*"
@@ -26,5 +27,8 @@ wayland-sys = {version = "0.12.*" }
 wayland-server = { version = "0.12.*" }
 
 [features]
-default = ["static"]
+default = ["static", "libcap", "systemd", "elogind"]
 static = ["meson"]
+libcap = []
+systemd = []
+elogind = []

--- a/wlroots-sys/build.rs
+++ b/wlroots-sys/build.rs
@@ -4,6 +4,7 @@ extern crate gl_generator;
 #[cfg(feature = "static")]
 extern crate meson;
 extern crate wayland_scanner;
+extern crate pkg_config;
 
 use gl_generator::{Api, Fallbacks, Profile, Registry, StaticGenerator};
 use std::env;
@@ -55,7 +56,6 @@ fn main() {
     println!("cargo:rustc-link-lib=dylib=xcb-shm");
     println!("cargo:rustc-link-lib=dylib=xcb-icccm");
     println!("cargo:rustc-link-lib=dylib=xcb-xkb");
-    println!("cargo:rustc-link-lib=dylib=cap");
     println!("cargo:rustc-link-lib=dylib=wayland-egl");
     println!("cargo:rustc-link-lib=dylib=wayland-client");
     println!("cargo:rustc-link-lib=dylib=wayland-server");
@@ -65,9 +65,10 @@ fn main() {
     println!("cargo:rustc-link-lib=dylib=drm");
     println!("cargo:rustc-link-lib=dylib=input");
     println!("cargo:rustc-link-lib=dylib=udev");
-    println!("cargo:rustc-link-lib=dylib=systemd");
     println!("cargo:rustc-link-lib=dylib=dbus-1");
     println!("cargo:rustc-link-lib=dylib=pixman-1");
+
+    link_optional_libs();
 
     if !cfg!(feature = "static") {
         println!("cargo:rustc-link-lib=dylib=wlroots");
@@ -141,5 +142,16 @@ fn generate_protocols() {
         wayland_scanner::generate_interfaces(protocol.0,
                                              output_dir.join(format!("{}_interfaces.rs",
                                                                      protocol.1)));
+    }
+}
+fn link_optional_libs() {
+    if cfg!(feature = "libcap") && pkg_config::probe_library("libcap").is_ok() {
+        println!("cargo:rustc-link-lib=dylib=cap");
+    }
+    if cfg!(feature = "systemd") && pkg_config::probe_library("libsystemd").is_ok() {
+        println!("cargo:rustc-link-lib=dylib=systemd");
+    }
+    if cfg!(feature = "elogind") && pkg_config::probe_library("elogind").is_ok() {
+        println!("cargo:rustc-link-lib=dylib=elogind");
     }
 }


### PR DESCRIPTION
Will by default attempt to find them and link to them. If they cannot befound, does not link to them.

Should do the right thing out of the box, but if not there's configurable feature flags.

Does this work with your setup @psychon?