### PR TITLE
Allow global compositor access outside of the wayland event loop

### DIFF
--- a/rootston/src/input.rs
+++ b/rootston/src/input.rs
@@ -149,12 +149,8 @@ impl InputManager {
                         }
                     }
                 }
-            })?;
-            //                                         Some(cursor)
-            //                                     })
-            //                                .ok()?;
-            //                          Some(seat)
-            //                      })?;
+                Ok(())
+            })??;
         }
 
         // configure device to output mappings

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -427,7 +427,9 @@ pub fn with_compositor<F, R>(func: F) -> HandleResult<R>
             return Err(HandleErr::AlreadyBorrowed)
         } else {
             compositor.lock.set(true);
-            Ok(func(compositor))
+            let res = Ok(func(compositor));
+            compositor.lock.set(false);
+            res
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,8 @@ pub mod render;
 pub mod utils;
 mod xwayland;
 
-pub use self::compositor::{terminate, Compositor, CompositorBuilder, CompositorHandler};
+pub use self::compositor::{terminate, with_compositor, Compositor, CompositorBuilder,
+                           CompositorHandler};
 pub use self::events::{key_events, seat_events, tablet_pad_events, tablet_tool_events,
                        touch_events, wl_shell_events,
                        pointer_events::{self, BTN_BACK, BTN_EXTRA, BTN_FORWARD, BTN_LEFT,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -215,8 +215,8 @@ macro_rules! compositor_data {
 macro_rules! run_handles {
     ([($handle_name: ident: $unhandle_name: block)] => $body: block) => {
         $unhandle_name.run(|$handle_name| {
-            Ok($body)
-        }).and_then(|n: $crate::HandleResult<_>| n)
+            $body
+        })
     };
     ([($handle_name1: ident: $unhandle_name1: block),
       ($handle_name2: ident: $unhandle_name2: block),

--- a/src/manager/keyboard_handler.rs
+++ b/src/manager/keyboard_handler.rs
@@ -29,36 +29,44 @@ wayland_listener!(KeyboardWrapper, (Keyboard, Box<KeyboardHandler>), [
         let xkb_state = (*keyboard.as_ptr()).xkb_state;
         let mut key = KeyEvent::new(data as *mut wlr_event_keyboard_key, xkb_state);
 
+        compositor.lock.set(true);
         keyboard.set_lock(true);
         keyboard_handler.on_key(compositor, keyboard, &mut key);
         keyboard.set_lock(false);
+        compositor.lock.set(false);
     };
     modifiers_listener => modifiers_notify: |this: &mut KeyboardWrapper, _data: *mut libc::c_void,|
     unsafe {
         let (ref mut keyboard, ref mut keyboard_handler) = this.data;
         let compositor = &mut *COMPOSITOR_PTR;
 
+        compositor.lock.set(true);
         keyboard.set_lock(true);
         keyboard_handler.modifiers(compositor, keyboard);
         keyboard.set_lock(false);
+        compositor.lock.set(false);
     };
     keymap_listener => keymap_notify: |this: &mut KeyboardWrapper, _data: *mut libc::c_void,|
     unsafe {
         let (ref mut keyboard, ref mut keyboard_handler) = this.data;
         let compositor = &mut *COMPOSITOR_PTR;
 
+        compositor.lock.set(true);
         keyboard.set_lock(true);
         keyboard_handler.keymap(compositor, keyboard);
         keyboard.set_lock(false);
+        compositor.lock.set(false);
     };
    repeat_listener => repeat_notify: |this: &mut KeyboardWrapper, _data: *mut libc::c_void,|
     unsafe {
         let (ref mut keyboard, ref mut keyboard_handler) = this.data;
         let compositor = &mut *COMPOSITOR_PTR;
 
+        compositor.lock.set(true);
         keyboard.set_lock(true);
         keyboard_handler.repeat_info(compositor, keyboard);
         keyboard.set_lock(false);
+        compositor.lock.set(false);
     };
 ]);
 

--- a/src/manager/output_handler.rs
+++ b/src/manager/output_handler.rs
@@ -32,55 +32,78 @@ wayland_listener!(UserOutput, (Output, Box<OutputHandler>), [
     frame_listener => frame_notify: |this: &mut UserOutput, _output: *mut libc::c_void,| unsafe {
         let (ref mut output, ref mut manager) = this.data;
         let compositor = &mut *COMPOSITOR_PTR;
+
+        compositor.lock.set(true);
         output.set_lock(true);
         manager.on_frame(compositor, output);
         output.set_lock(false);
+        compositor.lock.set(false);
     };
     mode_listener => mode_notify: |this: &mut UserOutput, _output: *mut libc::c_void,|
     unsafe {
         let (ref mut output, ref mut manager) = this.data;
         let compositor = &mut *COMPOSITOR_PTR;
+
+        compositor.lock.set(true);
         output.set_lock(true);
         manager.on_mode_change(compositor, output);
         output.set_lock(false);
+        compositor.lock.set(false);
     };
     enable_listener => enable_notify: |this: &mut UserOutput, _output: *mut libc::c_void,| unsafe {
         let (ref mut output, ref mut manager) = this.data;
         let compositor = &mut *COMPOSITOR_PTR;
+
+        compositor.lock.set(true);
         output.set_lock(true);
         manager.on_enable(compositor, output);
         output.set_lock(false);
+        compositor.lock.set(false);
     };
     scale_listener => scale_notify: |this: &mut UserOutput, _output: *mut libc::c_void,| unsafe {
         let (ref mut output, ref mut manager) = this.data;
         let compositor = &mut *COMPOSITOR_PTR;
+
+        compositor.lock.set(true);
         output.set_lock(true);
         manager.on_scale_change(compositor, output);
         output.set_lock(false);
+        compositor.lock.set(false);
     };
     transform_listener => transform_notify: |this: &mut UserOutput, _output: *mut libc::c_void,|
     unsafe {
         let (ref mut output, ref mut manager) = this.data;
         let compositor = &mut *COMPOSITOR_PTR;
+
+        compositor.lock.set(true);
         output.set_lock(true);
         manager.on_transform(compositor, output);
         output.set_lock(false);
+        compositor.lock.set(false);
     };
     swap_buffers_listener => swap_buffers_notify: |this: &mut UserOutput,
-                                                   _output: *mut libc::c_void,| unsafe {
+                                                   _output: *mut libc::c_void,|
+    unsafe {
+
         let (ref mut output, ref mut manager) = this.data;
         let compositor = &mut *COMPOSITOR_PTR;
+
+        compositor.lock.set(true);
         output.set_lock(true);
         manager.on_buffers_swapped(compositor, output);
         output.set_lock(false);
+        compositor.lock.set(false);
     };
     need_swap_listener => need_swap_notify: |this: &mut UserOutput, _output: *mut libc::c_void,|
     unsafe {
         let (ref mut output, ref mut manager) = this.data;
         let compositor = &mut *COMPOSITOR_PTR;
+
+        compositor.lock.set(true);
         output.set_lock(true);
         manager.needs_swap(compositor, output);
         output.set_lock(false);
+        compositor.lock.set(false);
     };
 ]);
 

--- a/src/manager/pointer_handler.rs
+++ b/src/manager/pointer_handler.rs
@@ -26,35 +26,47 @@ wayland_listener!(PointerWrapper, (Pointer, Box<PointerHandler>), [
         let pointer = &mut this.data.0;
         let event = ButtonEvent::from_ptr(data as *mut wlr_event_pointer_button);
         let compositor = &mut *COMPOSITOR_PTR;
+
+        compositor.lock.set(true);
         pointer.set_lock(true);
         this.data.1.on_button(compositor, pointer, &event);
         pointer.set_lock(false);
+        compositor.lock.set(false);
     };
     motion_listener => motion_notify:  |this: &mut PointerWrapper, data: *mut libc::c_void,|
     unsafe {
         let pointer = &mut this.data.0;
         let event = MotionEvent::from_ptr(data as *mut wlr_event_pointer_motion);
         let compositor = &mut *COMPOSITOR_PTR;
+
+        compositor.lock.set(true);
         pointer.set_lock(true);
         this.data.1.on_motion(compositor, pointer, &event);
         pointer.set_lock(false);
+        compositor.lock.set(false);
     };
     motion_absolute_listener => motion_absolute_notify:
     |this: &mut PointerWrapper, data: *mut libc::c_void,| unsafe {
         let pointer = &mut this.data.0;
         let event = AbsoluteMotionEvent::from_ptr(data as *mut _);
         let compositor = &mut *COMPOSITOR_PTR;
+
+        compositor.lock.set(true);
         pointer.set_lock(true);
         this.data.1.on_motion_absolute(compositor, pointer, &event);
         pointer.set_lock(false);
+        compositor.lock.set(false);
     };
     axis_listener => axis_notify:  |this: &mut PointerWrapper, data: *mut libc::c_void,| unsafe {
         let pointer = &mut this.data.0;
         let event = AxisEvent::from_ptr(data as *mut wlr_event_pointer_axis);
         let compositor = &mut *COMPOSITOR_PTR;
+
+        compositor.lock.set(true);
         pointer.set_lock(true);
         this.data.1.on_axis(compositor, pointer, &event);
         pointer.set_lock(false);
+        compositor.lock.set(false);
     };
 ]);
 

--- a/src/manager/tablet_pad_handler.rs
+++ b/src/manager/tablet_pad_handler.rs
@@ -21,27 +21,36 @@ wayland_listener!(TabletPadWrapper, (TabletPad, Box<TabletPadHandler>), [
         let (ref mut pad, ref mut handler) = this.data;
         let event = ButtonEvent::from_ptr(data as *mut _);
         let compositor = &mut *COMPOSITOR_PTR;
+
+        compositor.lock.set(true);
         pad.set_lock(true);
         handler.on_button(compositor, pad, &event);
         pad.set_lock(false);
+        compositor.lock.set(false);
     };
     strip_listener => strip_notify: |this: &mut TabletPadWrapper, data: *mut libc::c_void,|
     unsafe {
         let (ref mut pad, ref mut handler) = this.data;
         let event = StripEvent::from_ptr(data as *mut _);
         let compositor = &mut *COMPOSITOR_PTR;
+
+        compositor.lock.set(true);
         pad.set_lock(true);
         handler.on_strip(compositor, pad, &event);
         pad.set_lock(false);
+        compositor.lock.set(false);
     };
     ring_listener => ring_notify: |this: &mut TabletPadWrapper, data: *mut libc::c_void,|
     unsafe {
         let (ref mut pad, ref mut handler) = this.data;
         let event = RingEvent::from_ptr(data as *mut _);
         let compositor = &mut *COMPOSITOR_PTR;
+
+        compositor.lock.set(true);
         pad.set_lock(true);
         handler.on_ring(compositor, pad, &event);
         pad.set_lock(false);
+        compositor.lock.set(false);
     };
 ]);
 

--- a/src/manager/tablet_tool_handler.rs
+++ b/src/manager/tablet_tool_handler.rs
@@ -25,9 +25,12 @@ wayland_listener!(TabletToolWrapper, (TabletTool, Box<TabletToolHandler>), [
         let (ref mut tool, ref mut handler) = this.data;
         let event = AxisEvent::from_ptr(data as *mut _);
         let compositor = &mut *COMPOSITOR_PTR;
+
+        compositor.lock.set(true);
         tool.set_lock(true);
         handler.on_axis(compositor, tool, &event);
         tool.set_lock(false);
+        compositor.lock.set(false);
     };
     proximity_listener => proximity_notify: |this: &mut TabletToolWrapper,
     data: *mut libc::c_void,|
@@ -35,26 +38,35 @@ wayland_listener!(TabletToolWrapper, (TabletTool, Box<TabletToolHandler>), [
         let (ref mut tool, ref mut handler) = this.data;
         let event = ProximityEvent::from_ptr(data as *mut _);
         let compositor = &mut *COMPOSITOR_PTR;
+
+        compositor.lock.set(true);
         tool.set_lock(true);
         handler.on_proximity(compositor, tool, &event);
         tool.set_lock(false);
+        compositor.lock.set(false);
     };
     tip_listener => tip_notify: |this: &mut TabletToolWrapper, data: *mut libc::c_void,| unsafe {
         let (ref mut tool, ref mut handler) = this.data;
         let event = TipEvent::from_ptr(data as *mut _);
         let compositor = &mut *COMPOSITOR_PTR;
+
+        compositor.lock.set(true);
         tool.set_lock(true);
         handler.on_tip(compositor, tool, &event);
         tool.set_lock(false);
+        compositor.lock.set(false);
     };
     button_listener => button_notify: |this: &mut TabletToolWrapper, data: *mut libc::c_void,|
     unsafe {
         let (ref mut tool, ref mut handler) = this.data;
         let event = ButtonEvent::from_ptr(data as *mut _);
         let compositor = &mut *COMPOSITOR_PTR;
+
+        compositor.lock.set(true);
         tool.set_lock(true);
         handler.on_button(compositor, tool, &event);
         tool.set_lock(false);
+        compositor.lock.set(false);
     };
 ]);
 

--- a/src/manager/touch_handler.rs
+++ b/src/manager/touch_handler.rs
@@ -28,33 +28,45 @@ wayland_listener!(TouchWrapper, (Touch, Box<TouchHandler>), [
         let (ref mut touch, ref mut handler) = this.data;
         let event = DownEvent::from_ptr(data as *mut _);
         let compositor = &mut *COMPOSITOR_PTR;
+
+        compositor.lock.set(true);
         touch.set_lock(true);
         handler.on_down(compositor, touch, &event);
         touch.set_lock(false);
+        compositor.lock.set(false);
     };
     up_listener => up_notify: |this: &mut TouchWrapper, data: *mut libc::c_void,| unsafe {
         let (ref mut touch, ref mut handler) = this.data;
         let event = UpEvent::from_ptr(data as *mut _);
         let compositor = &mut *COMPOSITOR_PTR;
+
+        compositor.lock.set(true);
         touch.set_lock(true);
         handler.on_up(compositor, touch, &event);
         touch.set_lock(false);
+        compositor.lock.set(false);
     };
     motion_listener => motion_notify: |this: &mut TouchWrapper, data: *mut libc::c_void,| unsafe {
         let (ref mut touch, ref mut handler) = this.data;
         let event = MotionEvent::from_ptr(data as *mut _);
         let compositor = &mut *COMPOSITOR_PTR;
+
+        compositor.lock.set(true);
         touch.set_lock(true);
         handler.on_motion(compositor, touch, &event);
         touch.set_lock(false);
+        compositor.lock.set(false);
     };
     cancel_listener => cancel_notify: |this: &mut TouchWrapper, data: *mut libc::c_void,| unsafe {
         let (ref mut touch, ref mut handler) = this.data;
         let event = CancelEvent::from_ptr(data as *mut _);
         let compositor = &mut *COMPOSITOR_PTR;
+
+        compositor.lock.set(true);
         touch.set_lock(true);
         handler.on_cancel(compositor, touch, &event);
         touch.set_lock(false);
+        compositor.lock.set(false);
     };
 ]);
 

--- a/src/manager/wl_shell_handler.rs
+++ b/src/manager/wl_shell_handler.rs
@@ -66,11 +66,14 @@ wayland_listener!(WlShell, (WlShellSurface, Surface, Box<WlShellHandler>), [
                 return;
             }
             let compositor = &mut *COMPOSITOR_PTR;
+
+            compositor.lock.set(true);
             shell_surface.set_lock(true);
             surface.set_lock(true);
             manager.destroy(compositor, surface, shell_surface);
             shell_surface.set_lock(false);
             surface.set_lock(false);
+            compositor.lock.set(false);
         }
         ffi_dispatch!(WAYLAND_SERVER_HANDLE,
                       wl_list_remove,
@@ -110,22 +113,28 @@ wayland_listener!(WlShell, (WlShellSurface, Surface, Box<WlShellHandler>), [
     unsafe {
         let (ref mut shell_surface, ref mut surface, ref mut manager) = this.data;
         let compositor = &mut *COMPOSITOR_PTR;
+
+        compositor.lock.set(true);
         shell_surface.set_lock(true);
         surface.set_lock(true);
         manager.ping_timeout(compositor, surface, shell_surface);
         shell_surface.set_lock(false);
         surface.set_lock(false);
+        compositor.lock.set(false);
     };
     request_move_listener => request_move_notify: |this: &mut WlShell, data: *mut libc::c_void,|
     unsafe {
         let (ref mut shell_surface, ref mut surface, ref mut manager) = this.data;
         let compositor = &mut *COMPOSITOR_PTR;
         let mut event = MoveEvent::from_ptr(data as _);
+
+        compositor.lock.set(true);
         shell_surface.set_lock(true);
         surface.set_lock(true);
         manager.move_request(compositor, surface, shell_surface, &mut event);
         shell_surface.set_lock(false);
         surface.set_lock(false);
+        compositor.lock.set(false);
     };
     request_resize_listener => request_resize_notify: |this: &mut WlShell,
                                                        data: *mut libc::c_void,|
@@ -133,11 +142,14 @@ wayland_listener!(WlShell, (WlShellSurface, Surface, Box<WlShellHandler>), [
         let (ref mut shell_surface, ref mut surface, ref mut manager) = this.data;
         let compositor = &mut *COMPOSITOR_PTR;
         let mut event = ResizeEvent::from_ptr(data as _);
+
+        compositor.lock.set(true);
         shell_surface.set_lock(true);
         surface.set_lock(true);
         manager.resize_request(compositor, surface, shell_surface, &mut event);
         shell_surface.set_lock(false);
         surface.set_lock(false);
+        compositor.lock.set(false);
     };
     request_fullscreen_listener => request_fullscreen_notify: |this: &mut WlShell,
                                                                data: *mut libc::c_void,|
@@ -145,11 +157,14 @@ wayland_listener!(WlShell, (WlShellSurface, Surface, Box<WlShellHandler>), [
         let (ref mut shell_surface, ref mut surface, ref mut manager) = this.data;
         let compositor = &mut *COMPOSITOR_PTR;
         let mut event = FullscreenEvent::from_ptr(data as _);
+
+        compositor.lock.set(true);
         shell_surface.set_lock(true);
         surface.set_lock(true);
         manager.fullscreen_request(compositor, surface, shell_surface, &mut event);
         shell_surface.set_lock(false);
         surface.set_lock(false);
+        compositor.lock.set(false);
     };
     request_maximize_listener => request_maximize_notify: |this: &mut WlShell,
                                                            data: *mut libc::c_void,|
@@ -157,40 +172,52 @@ wayland_listener!(WlShell, (WlShellSurface, Surface, Box<WlShellHandler>), [
         let (ref mut shell_surface, ref mut surface, ref mut manager) = this.data;
         let compositor = &mut *COMPOSITOR_PTR;
         let mut event = MaximizeEvent::from_ptr(data as _);
+
+        compositor.lock.set(true);
         shell_surface.set_lock(true);
         surface.set_lock(true);
         manager.maximize_request(compositor, surface, shell_surface, &mut event);
         shell_surface.set_lock(false);
         surface.set_lock(false);
+        compositor.lock.set(false);
     };
     set_state_listener => set_state_notify: |this: &mut WlShell, _data: *mut libc::c_void,|
     unsafe {
         let (ref mut shell_surface, ref mut surface, ref mut manager) = this.data;
         let compositor = &mut *COMPOSITOR_PTR;
+
+        compositor.lock.set(true);
         shell_surface.set_lock(true);
         surface.set_lock(true);
         manager.state_change(compositor, surface, shell_surface);
         shell_surface.set_lock(false);
         surface.set_lock(false);
+        compositor.lock.set(false);
     };
     set_title_listener => set_title_notify: |this: &mut WlShell, _data: *mut libc::c_void,|
     unsafe {
         let (ref mut shell_surface, ref mut surface, ref mut manager) = this.data;
         let compositor = &mut *COMPOSITOR_PTR;
+
+        compositor.lock.set(true);
         shell_surface.set_lock(true);
         surface.set_lock(true);
         manager.title_change(compositor, surface, shell_surface);
         shell_surface.set_lock(false);
         surface.set_lock(false);
+        compositor.lock.set(false);
     };
     set_class_listener => set_class_notify: |this: &mut WlShell, _data: *mut libc::c_void,|
     unsafe {
         let (ref mut shell_surface, ref mut surface, ref mut manager) = this.data;
         let compositor = &mut *COMPOSITOR_PTR;
+
+        compositor.lock.set(true);
         shell_surface.set_lock(true);
         surface.set_lock(true);
         manager.class_change(compositor, surface, shell_surface);
         shell_surface.set_lock(false);
         surface.set_lock(false);
+        compositor.lock.set(false);
     };
 ]);

--- a/src/manager/wl_shell_manager.rs
+++ b/src/manager/wl_shell_manager.rs
@@ -26,11 +26,15 @@ wayland_listener!(WlShellManager, Box<WlShellManagerHandler>, [
         let compositor = &mut *COMPOSITOR_PTR;
         let mut surface = Surface::new((*data).surface);
         let mut shell_surface = WlShellSurface::new(data);
+
+        compositor.lock.set(true);
         surface.set_lock(true);
         shell_surface.set_lock(true);
         let new_surface_res = manager.new_surface(compositor, &mut shell_surface, &mut surface);
+        compositor.lock.set(false);
         surface.set_lock(false);
         shell_surface.set_lock(false);
+
         if let Some(shell_surface_handler) = new_surface_res {
             let mut shell_surface = WlShell::new((shell_surface, surface, shell_surface_handler));
             // Add the destroy event to this handler.

--- a/src/manager/xdg_shell_v6_handler.rs
+++ b/src/manager/xdg_shell_v6_handler.rs
@@ -68,94 +68,121 @@ wayland_listener!(XdgV6Shell, (XdgV6ShellSurface, Surface, Box<XdgV6ShellHandler
     commit_listener => commit_notify: |this: &mut XdgV6Shell, _data: *mut libc::c_void,| unsafe {
         let (ref mut shell_surface, ref mut surface, ref mut manager) = this.data;
         let compositor = &mut *COMPOSITOR_PTR;
+
+        compositor.lock.set(true);
         shell_surface.set_lock(true);
         surface.set_lock(true);
         manager.on_commit(compositor, surface, shell_surface);
         shell_surface.set_lock(false);
         surface.set_lock(false);
+        compositor.lock.set(false);
     };
     ping_timeout_listener => ping_timeout_notify: |this: &mut XdgV6Shell,
                                                    _data: *mut libc::c_void,|
     unsafe {
         let (ref mut shell_surface, ref mut surface, ref mut manager) = this.data;
         let compositor = &mut *COMPOSITOR_PTR;
+
+        compositor.lock.set(true);
         shell_surface.set_lock(true);
         surface.set_lock(true);
         manager.ping_timeout(compositor, surface, shell_surface);
         shell_surface.set_lock(false);
         surface.set_lock(false);
+        compositor.lock.set(false);
     };
     new_popup_listener => new_popup_notify: |this: &mut XdgV6Shell, _data: *mut libc::c_void,|
     unsafe {
         let (ref mut shell_surface, ref mut surface, ref mut manager) = this.data;
         let compositor = &mut *COMPOSITOR_PTR;
+
+        compositor.lock.set(true);
         shell_surface.set_lock(true);
         surface.set_lock(true);
         manager.new_popup(compositor, surface, shell_surface);
         shell_surface.set_lock(false);
         surface.set_lock(false);
+        compositor.lock.set(false);
     };
     maximize_listener => maximize_notify: |this: &mut XdgV6Shell, _event: *mut libc::c_void,|
     unsafe {
         let (ref mut shell_surface, ref mut surface, ref mut manager) = this.data;
         let compositor = &mut *COMPOSITOR_PTR;
+
+        compositor.lock.set(true);
         shell_surface.set_lock(true);
         surface.set_lock(true);
         manager.maximize_request(compositor, surface, shell_surface);
         shell_surface.set_lock(false);
         surface.set_lock(false);
+        compositor.lock.set(false);
     };
     fullscreen_listener => fullscreen_notify: |this: &mut XdgV6Shell, event: *mut libc::c_void,|
     unsafe {
         let (ref mut shell_surface, ref mut surface, ref mut manager) = this.data;
         let compositor = &mut *COMPOSITOR_PTR;
         let mut event = SetFullscreenEvent::from_ptr(event as _);
+
+        compositor.lock.set(true);
         shell_surface.set_lock(true);
         surface.set_lock(true);
         manager.fullscreen_request(compositor, surface, shell_surface, &mut event);
         shell_surface.set_lock(false);
         surface.set_lock(false);
+        compositor.lock.set(false);
     };
     minimize_listener => minimize_notify: |this: &mut XdgV6Shell, _event: *mut libc::c_void,|
     unsafe {
         let (ref mut shell_surface, ref mut surface, ref mut manager) = this.data;
         let compositor = &mut *COMPOSITOR_PTR;
+
+        compositor.lock.set(true);
         shell_surface.set_lock(true);
         surface.set_lock(true);
         manager.minimize_request(compositor, surface, shell_surface);
         shell_surface.set_lock(false);
         surface.set_lock(false);
+        compositor.lock.set(false);
     };
     move_listener => move_notify: |this: &mut XdgV6Shell, event: *mut libc::c_void,| unsafe {
         let (ref mut shell_surface, ref mut surface, ref mut manager) = this.data;
         let compositor = &mut *COMPOSITOR_PTR;
         let mut event = MoveEvent::from_ptr(event as _);
+
+        compositor.lock.set(true);
         shell_surface.set_lock(true);
         surface.set_lock(true);
         manager.move_request(compositor, surface, shell_surface, &mut event);
         shell_surface.set_lock(false);
         surface.set_lock(false);
+        compositor.lock.set(false);
     };
     resize_listener => resize_notify: |this: &mut XdgV6Shell, event: *mut libc::c_void,| unsafe {
         let (ref mut shell_surface, ref mut surface, ref mut manager) = this.data;
         let compositor = &mut *COMPOSITOR_PTR;
         let mut event = ResizeEvent::from_ptr(event as _);
+
+        compositor.lock.set(true);
         shell_surface.set_lock(true);
         surface.set_lock(true);
         manager.resize_request(compositor, surface, shell_surface, &mut event);
         shell_surface.set_lock(false);
         surface.set_lock(false);
+        compositor.lock.set(false);
     };
     show_window_menu_listener => show_window_menu_notify: |this: &mut XdgV6Shell,
                                                            event: *mut libc::c_void,| unsafe {
         let (ref mut shell_surface, ref mut surface, ref mut manager) = this.data;
         let compositor = &mut *COMPOSITOR_PTR;
         let mut event = ShowWindowMenuEvent::from_ptr(event as _);
+
+        compositor.lock.set(true);
         shell_surface.set_lock(true);
         surface.set_lock(true);
         manager.show_window_menu_request(compositor, surface, shell_surface, &mut event);
         shell_surface.set_lock(false);
         surface.set_lock(false);
+        compositor.lock.set(false);
     };
 ]);
 

--- a/src/manager/xdg_shell_v6_manager.rs
+++ b/src/manager/xdg_shell_v6_manager.rs
@@ -43,9 +43,13 @@ wayland_listener!(XdgV6ShellManager, (Vec<Box<XdgV6Shell>>, Box<XdgV6ShellManage
             }
         };
         let mut shell_surface = XdgV6ShellSurface::new(data, state);
+
+        compositor.lock.set(true);
         shell_surface.set_lock(true);
         let new_surface_res = manager.new_surface(compositor, &mut shell_surface);
         shell_surface.set_lock(false);
+        compositor.lock.set(false);
+
         if let Some(shell_surface_handler) = new_surface_res {
 
             let mut shell_surface = XdgV6Shell::new((shell_surface,

--- a/src/render/renderer.rs
+++ b/src/render/renderer.rs
@@ -92,6 +92,24 @@ impl Drop for GenericRenderer {
 }
 
 impl<'output> Renderer<'output> {
+    /// Create a texture using this renderer.
+    pub fn create_texture_from_pixels(&mut self,
+                                      format: wl_shm_format,
+                                      stride: u32,
+                                      width: u32,
+                                      height: u32,
+                                      data: &[u8])
+                                      -> Option<Texture> {
+        unsafe {
+            create_texture_from_pixels(self.renderer,
+                                       format,
+                                       stride,
+                                       width,
+                                       height,
+                                       data.as_ptr() as _)
+        }
+    }
+
     pub fn clear(&mut self, float: [f32; 4]) {
         unsafe { wlr_renderer_clear(self.renderer, float.as_ptr()) }
     }

--- a/src/types/cursor/cursor.rs
+++ b/src/types/cursor/cursor.rs
@@ -367,12 +367,11 @@ impl Cursor {
     /// Panics when trying to set the lock on an upgraded handle.
     unsafe fn set_lock(&self, val: bool) {
         let counter = &(*((*self.data.0).data as *mut CursorState)).counter;
-        counter.as_ref().store(val, Ordering::Release);
+        counter.as_ref().set(val);
     }
 
     unsafe fn get_lock(&self) -> bool {
-        (*((*self.data.0).data as *mut CursorState)).counter
-                                                    .load(Ordering::Relaxed)
+        (*((*self.data.0).data as *mut CursorState)).counter.get()
     }
 
     /// Attach this cursor to an output layout.

--- a/src/types/cursor/cursor.rs
+++ b/src/types/cursor/cursor.rs
@@ -101,7 +101,13 @@ wayland_listener!(Cursor, (*mut wlr_cursor, Box<CursorHandler>, Option<OutputLay
         let mut cursor = Cursor::from_ptr(cursor_ptr);
         let mut event = pointer_events::MotionEvent::from_ptr(event as _);
         let compositor = &mut *COMPOSITOR_PTR;
+
+        compositor.lock.set(true);
+        cursor.set_lock(true);
         cursor_handler.on_pointer_motion(compositor, &mut cursor, &mut event);
+        cursor.set_lock(false);
+        compositor.lock.set(false);
+
         Box::into_raw(cursor);
     };
     pointer_motion_absolute_listener => pointer_motion_absolute_notify:
@@ -111,9 +117,13 @@ wayland_listener!(Cursor, (*mut wlr_cursor, Box<CursorHandler>, Option<OutputLay
         let mut event = pointer_events::AbsoluteMotionEvent::from_ptr(event as _);
         let mut cursor = Cursor::from_ptr(cursor_ptr);
         let compositor = &mut *COMPOSITOR_PTR;
-        cursor_handler.on_pointer_motion_absolute(compositor,
-                                                                        &mut cursor,
-                                                                        &mut event);
+
+        compositor.lock.set(true);
+        cursor.set_lock(true);
+        cursor_handler.on_pointer_motion_absolute(compositor, &mut cursor, &mut event);
+        cursor.set_lock(false);
+        compositor.lock.set(false);
+
         Box::into_raw(cursor);
     };
     pointer_button_listener => pointer_button_notify:
@@ -123,7 +133,13 @@ wayland_listener!(Cursor, (*mut wlr_cursor, Box<CursorHandler>, Option<OutputLay
         let mut cursor = Cursor::from_ptr(cursor_ptr);
         let mut event = pointer_events::ButtonEvent::from_ptr(event as _);
         let compositor = &mut *COMPOSITOR_PTR;
+
+        compositor.lock.set(true);
+        cursor.set_lock(true);
         cursor_handler.on_pointer_button(compositor, &mut cursor, &mut event);
+        cursor.set_lock(false);
+        compositor.lock.set(false);
+
         Box::into_raw(cursor);
     };
     pointer_axis_listener => pointer_axis_notify:
@@ -133,7 +149,13 @@ wayland_listener!(Cursor, (*mut wlr_cursor, Box<CursorHandler>, Option<OutputLay
         let mut cursor = Cursor::from_ptr(cursor_ptr);
         let mut event = pointer_events::AxisEvent::from_ptr(event as _);
         let compositor = &mut *COMPOSITOR_PTR;
+
+        compositor.lock.set(true);
+        cursor.set_lock(true);
         cursor_handler.on_pointer_axis(compositor, &mut cursor, &mut event);
+        cursor.set_lock(false);
+        compositor.lock.set(false);
+
         Box::into_raw(cursor);
     };
     touch_up_listener => touch_up_notify: |this: &mut Cursor, event: *mut libc::c_void,|
@@ -142,7 +164,13 @@ wayland_listener!(Cursor, (*mut wlr_cursor, Box<CursorHandler>, Option<OutputLay
         let mut cursor = Cursor::from_ptr(cursor_ptr);
         let mut event = touch_events::UpEvent::from_ptr(event as _);
         let compositor = &mut *COMPOSITOR_PTR;
+
+        compositor.lock.set(true);
+        cursor.set_lock(true);
         cursor_handler.on_touch_up(compositor, &mut cursor, &mut event);
+        cursor.set_lock(false);
+        compositor.lock.set(false);
+
         Box::into_raw(cursor);
     };
     touch_down_listener => touch_down_notify: |this: &mut Cursor, event: *mut libc::c_void,|
@@ -151,7 +179,13 @@ wayland_listener!(Cursor, (*mut wlr_cursor, Box<CursorHandler>, Option<OutputLay
         let mut cursor = Cursor::from_ptr(cursor_ptr);
         let mut event = touch_events::DownEvent::from_ptr(event as _);
         let compositor = &mut *COMPOSITOR_PTR;
+
+        compositor.lock.set(true);
+        cursor.set_lock(true);
         cursor_handler.on_touch_down(compositor, &mut cursor, &mut event);
+        cursor.set_lock(false);
+        compositor.lock.set(false);
+
         Box::into_raw(cursor);
     };
     touch_motion_listener => touch_motion_notify:
@@ -161,7 +195,13 @@ wayland_listener!(Cursor, (*mut wlr_cursor, Box<CursorHandler>, Option<OutputLay
         let mut cursor = Cursor::from_ptr(cursor_ptr);
         let mut event = touch_events::MotionEvent::from_ptr(event as _);
         let compositor = &mut *COMPOSITOR_PTR;
+
+        compositor.lock.set(true);
+        cursor.set_lock(true);
         cursor_handler.on_touch_motion(compositor, &mut cursor, &mut event);
+        cursor.set_lock(false);
+        compositor.lock.set(false);
+
         Box::into_raw(cursor);
     };
     touch_cancel_listener => touch_cancel_notify:
@@ -171,7 +211,13 @@ wayland_listener!(Cursor, (*mut wlr_cursor, Box<CursorHandler>, Option<OutputLay
         let mut cursor = Cursor::from_ptr(cursor_ptr);
         let mut event = touch_events::CancelEvent::from_ptr(event as _);
         let compositor = &mut *COMPOSITOR_PTR;
+
+        compositor.lock.set(true);
+        cursor.set_lock(true);
         cursor_handler.on_touch_cancel(compositor, &mut cursor, &mut event);
+        cursor.set_lock(false);
+        compositor.lock.set(false);
+
         Box::into_raw(cursor);
     };
     tablet_tool_axis_listener => tablet_tool_axis_notify:
@@ -181,7 +227,13 @@ wayland_listener!(Cursor, (*mut wlr_cursor, Box<CursorHandler>, Option<OutputLay
         let mut cursor = Cursor::from_ptr(cursor_ptr);
         let mut event = tablet_tool_events::AxisEvent::from_ptr(event as _);
         let compositor = &mut *COMPOSITOR_PTR;
+
+        compositor.lock.set(true);
+        cursor.set_lock(true);
         cursor_handler.on_tablet_tool_axis(compositor, &mut cursor, &mut event);
+        cursor.set_lock(false);
+        compositor.lock.set(false);
+
         Box::into_raw(cursor);
     };
     tablet_tool_proximity_listener => tablet_tool_proximity_notify:
@@ -191,9 +243,13 @@ wayland_listener!(Cursor, (*mut wlr_cursor, Box<CursorHandler>, Option<OutputLay
         let mut cursor = Cursor::from_ptr(cursor_ptr);
         let mut event = tablet_tool_events::ProximityEvent::from_ptr(event as _);
         let compositor = &mut *COMPOSITOR_PTR;
-        cursor_handler.on_tablet_tool_proximity(compositor,
-                                                                      &mut cursor,
-                                                                      &mut event);
+
+        compositor.lock.set(true);
+        cursor.set_lock(true);
+        cursor_handler.on_tablet_tool_proximity(compositor, &mut cursor, &mut event);
+        cursor.set_lock(false);
+        compositor.lock.set(false);
+
         Box::into_raw(cursor);
     };
     tablet_tool_tip_listener => tablet_tool_tip_notify:
@@ -203,7 +259,13 @@ wayland_listener!(Cursor, (*mut wlr_cursor, Box<CursorHandler>, Option<OutputLay
         let mut cursor = Cursor::from_ptr(cursor_ptr);
         let mut event = tablet_tool_events::TipEvent::from_ptr(event as _);
         let compositor = &mut *COMPOSITOR_PTR;
+
+        compositor.lock.set(true);
+        cursor.set_lock(true);
         cursor_handler.on_tablet_tool_tip(compositor, &mut cursor, &mut event);
+        cursor.set_lock(false);
+        compositor.lock.set(false);
+
         Box::into_raw(cursor);
     };
     tablet_tool_button_listener => tablet_tool_button_notify:
@@ -213,7 +275,13 @@ wayland_listener!(Cursor, (*mut wlr_cursor, Box<CursorHandler>, Option<OutputLay
         let mut cursor = Cursor::from_ptr(cursor_ptr);
         let mut event = tablet_tool_events::ButtonEvent::from_ptr(event as _);
         let compositor = &mut *COMPOSITOR_PTR;
+
+        compositor.lock.set(true);
+        cursor.set_lock(true);
         cursor_handler.on_tablet_tool_button(compositor, &mut cursor, &mut event);
+        cursor.set_lock(false);
+        compositor.lock.set(false);
+
         Box::into_raw(cursor);
     };
 ]);
@@ -282,6 +350,16 @@ impl Cursor {
             CursorHandle { cursor: self.data.0,
                            handle }
         }
+    }
+
+    /// Manually set the lock used to determine if a double-borrow is
+    /// occuring on this structure.
+    ///
+    /// # Panics
+    /// Panics when trying to set the lock on an upgraded handle.
+    unsafe fn set_lock(&self, val: bool) {
+        let counter = &(*((*self.data.0).data as *mut CursorState)).counter;
+        counter.as_ref().store(val, Ordering::Release);
     }
 
     /// Attach this cursor to an output layout.

--- a/src/types/cursor/cursor.rs
+++ b/src/types/cursor/cursor.rs
@@ -102,10 +102,11 @@ wayland_listener!(Cursor, (*mut wlr_cursor, Box<CursorHandler>, Option<OutputLay
         let mut event = pointer_events::MotionEvent::from_ptr(event as _);
         let compositor = &mut *COMPOSITOR_PTR;
 
+        let prev_cursor_lock = cursor.get_lock();
         compositor.lock.set(true);
         cursor.set_lock(true);
         cursor_handler.on_pointer_motion(compositor, &mut cursor, &mut event);
-        cursor.set_lock(false);
+        cursor.set_lock(prev_cursor_lock);
         compositor.lock.set(false);
 
         Box::into_raw(cursor);
@@ -118,42 +119,43 @@ wayland_listener!(Cursor, (*mut wlr_cursor, Box<CursorHandler>, Option<OutputLay
         let mut cursor = Cursor::from_ptr(cursor_ptr);
         let compositor = &mut *COMPOSITOR_PTR;
 
+        let prev_cursor_lock = cursor.get_lock();
         compositor.lock.set(true);
         cursor.set_lock(true);
         cursor_handler.on_pointer_motion_absolute(compositor, &mut cursor, &mut event);
-        cursor.set_lock(false);
+        cursor.set_lock(prev_cursor_lock);
         compositor.lock.set(false);
 
         Box::into_raw(cursor);
     };
-    pointer_button_listener => pointer_button_notify:
-    |this: &mut Cursor, event: *mut libc::c_void,|
+    pointer_button_listener => pointer_button_notify: |this: &mut Cursor, event: *mut libc::c_void,|
     unsafe {
         let (cursor_ptr, ref mut cursor_handler, _) = this.data;
         let mut cursor = Cursor::from_ptr(cursor_ptr);
         let mut event = pointer_events::ButtonEvent::from_ptr(event as _);
         let compositor = &mut *COMPOSITOR_PTR;
 
+        let prev_cursor_lock = cursor.get_lock();
         compositor.lock.set(true);
         cursor.set_lock(true);
         cursor_handler.on_pointer_button(compositor, &mut cursor, &mut event);
-        cursor.set_lock(false);
+        cursor.set_lock(prev_cursor_lock);
         compositor.lock.set(false);
 
         Box::into_raw(cursor);
     };
-    pointer_axis_listener => pointer_axis_notify:
-    |this: &mut Cursor, event: *mut libc::c_void,|
+    pointer_axis_listener => pointer_axis_notify: |this: &mut Cursor, event: *mut libc::c_void,|
     unsafe {
         let (cursor_ptr, ref mut cursor_handler, _) = this.data;
         let mut cursor = Cursor::from_ptr(cursor_ptr);
         let mut event = pointer_events::AxisEvent::from_ptr(event as _);
         let compositor = &mut *COMPOSITOR_PTR;
 
+        let prev_cursor_lock = cursor.get_lock();
         compositor.lock.set(true);
         cursor.set_lock(true);
         cursor_handler.on_pointer_axis(compositor, &mut cursor, &mut event);
-        cursor.set_lock(false);
+        cursor.set_lock(prev_cursor_lock);
         compositor.lock.set(false);
 
         Box::into_raw(cursor);
@@ -165,10 +167,11 @@ wayland_listener!(Cursor, (*mut wlr_cursor, Box<CursorHandler>, Option<OutputLay
         let mut event = touch_events::UpEvent::from_ptr(event as _);
         let compositor = &mut *COMPOSITOR_PTR;
 
+        let prev_cursor_lock = cursor.get_lock();
         compositor.lock.set(true);
         cursor.set_lock(true);
         cursor_handler.on_touch_up(compositor, &mut cursor, &mut event);
-        cursor.set_lock(false);
+        cursor.set_lock(prev_cursor_lock);
         compositor.lock.set(false);
 
         Box::into_raw(cursor);
@@ -180,106 +183,111 @@ wayland_listener!(Cursor, (*mut wlr_cursor, Box<CursorHandler>, Option<OutputLay
         let mut event = touch_events::DownEvent::from_ptr(event as _);
         let compositor = &mut *COMPOSITOR_PTR;
 
+        let prev_cursor_lock = cursor.get_lock();
         compositor.lock.set(true);
         cursor.set_lock(true);
         cursor_handler.on_touch_down(compositor, &mut cursor, &mut event);
-        cursor.set_lock(false);
+        cursor.set_lock(prev_cursor_lock);
         compositor.lock.set(false);
 
         Box::into_raw(cursor);
     };
-    touch_motion_listener => touch_motion_notify:
-    |this: &mut Cursor, event: *mut libc::c_void,|
+    touch_motion_listener => touch_motion_notify: |this: &mut Cursor, event: *mut libc::c_void,|
     unsafe {
         let (cursor_ptr, ref mut cursor_handler, _) = this.data;
         let mut cursor = Cursor::from_ptr(cursor_ptr);
         let mut event = touch_events::MotionEvent::from_ptr(event as _);
         let compositor = &mut *COMPOSITOR_PTR;
 
+        let prev_cursor_lock = cursor.get_lock();
         compositor.lock.set(true);
         cursor.set_lock(true);
         cursor_handler.on_touch_motion(compositor, &mut cursor, &mut event);
-        cursor.set_lock(false);
+        cursor.set_lock(prev_cursor_lock);
         compositor.lock.set(false);
 
         Box::into_raw(cursor);
     };
-    touch_cancel_listener => touch_cancel_notify:
-    |this: &mut Cursor, event: *mut libc::c_void,|
+    touch_cancel_listener => touch_cancel_notify: |this: &mut Cursor, event: *mut libc::c_void,|
     unsafe {
         let (cursor_ptr, ref mut cursor_handler, _) = this.data;
         let mut cursor = Cursor::from_ptr(cursor_ptr);
         let mut event = touch_events::CancelEvent::from_ptr(event as _);
         let compositor = &mut *COMPOSITOR_PTR;
 
+        let prev_cursor_lock = cursor.get_lock();
         compositor.lock.set(true);
         cursor.set_lock(true);
         cursor_handler.on_touch_cancel(compositor, &mut cursor, &mut event);
-        cursor.set_lock(false);
+        cursor.set_lock(prev_cursor_lock);
         compositor.lock.set(false);
 
         Box::into_raw(cursor);
     };
-    tablet_tool_axis_listener => tablet_tool_axis_notify:
-    |this: &mut Cursor, event: *mut libc::c_void,|
+    tablet_tool_axis_listener => tablet_tool_axis_notify: |this: &mut Cursor,
+                                                           event: *mut libc::c_void,|
     unsafe {
         let (cursor_ptr, ref mut cursor_handler, _) = this.data;
         let mut cursor = Cursor::from_ptr(cursor_ptr);
         let mut event = tablet_tool_events::AxisEvent::from_ptr(event as _);
         let compositor = &mut *COMPOSITOR_PTR;
 
+        let prev_cursor_lock = cursor.get_lock();
         compositor.lock.set(true);
         cursor.set_lock(true);
         cursor_handler.on_tablet_tool_axis(compositor, &mut cursor, &mut event);
-        cursor.set_lock(false);
+        cursor.set_lock(prev_cursor_lock);
         compositor.lock.set(false);
 
         Box::into_raw(cursor);
     };
-    tablet_tool_proximity_listener => tablet_tool_proximity_notify:
-    |this: &mut Cursor, event: *mut libc::c_void,|
+    tablet_tool_proximity_listener => tablet_tool_proximity_notify: |this: &mut Cursor,
+                                                                     event: *mut libc::c_void,|
     unsafe {
         let (cursor_ptr, ref mut cursor_handler, _) = this.data;
         let mut cursor = Cursor::from_ptr(cursor_ptr);
         let mut event = tablet_tool_events::ProximityEvent::from_ptr(event as _);
         let compositor = &mut *COMPOSITOR_PTR;
 
+        let prev_cursor_lock = cursor.get_lock();
         compositor.lock.set(true);
         cursor.set_lock(true);
         cursor_handler.on_tablet_tool_proximity(compositor, &mut cursor, &mut event);
-        cursor.set_lock(false);
+        cursor.set_lock(prev_cursor_lock);
         compositor.lock.set(false);
 
         Box::into_raw(cursor);
     };
-    tablet_tool_tip_listener => tablet_tool_tip_notify:
-    |this: &mut Cursor, event: *mut libc::c_void,|
+    tablet_tool_tip_listener => tablet_tool_tip_notify: |this: &mut Cursor,
+                                                         event: *mut libc::c_void,|
     unsafe {
         let (cursor_ptr, ref mut cursor_handler, _) = this.data;
         let mut cursor = Cursor::from_ptr(cursor_ptr);
         let mut event = tablet_tool_events::TipEvent::from_ptr(event as _);
         let compositor = &mut *COMPOSITOR_PTR;
 
+        let prev_cursor_lock = cursor.get_lock();
         compositor.lock.set(true);
         cursor.set_lock(true);
         cursor_handler.on_tablet_tool_tip(compositor, &mut cursor, &mut event);
-        cursor.set_lock(false);
+        cursor.set_lock(prev_cursor_lock);
         compositor.lock.set(false);
 
         Box::into_raw(cursor);
     };
-    tablet_tool_button_listener => tablet_tool_button_notify:
-    |this: &mut Cursor, event: *mut libc::c_void,|
+    tablet_tool_button_listener => tablet_tool_button_notify: |this: &mut Cursor,
+                                                               event: *mut libc::c_void,|
     unsafe {
         let (cursor_ptr, ref mut cursor_handler, _) = this.data;
         let mut cursor = Cursor::from_ptr(cursor_ptr);
         let mut event = tablet_tool_events::ButtonEvent::from_ptr(event as _);
         let compositor = &mut *COMPOSITOR_PTR;
 
+        let prev_cursor_lock = cursor.get_lock();
         compositor.lock.set(true);
         cursor.set_lock(true);
         cursor_handler.on_tablet_tool_button(compositor, &mut cursor, &mut event);
-        cursor.set_lock(false);
+        cursor.set_lock(prev_cursor_lock);
         compositor.lock.set(false);
 
         Box::into_raw(cursor);
@@ -360,6 +368,11 @@ impl Cursor {
     unsafe fn set_lock(&self, val: bool) {
         let counter = &(*((*self.data.0).data as *mut CursorState)).counter;
         counter.as_ref().store(val, Ordering::Release);
+    }
+
+    unsafe fn get_lock(&self) -> bool {
+        (*((*self.data.0).data as *mut CursorState)).counter
+                                                    .load(Ordering::Relaxed)
     }
 
     /// Attach this cursor to an output layout.

--- a/src/types/output/output_layout.rs
+++ b/src/types/output/output_layout.rs
@@ -344,13 +344,13 @@ impl OutputLayout {
     /// Panics when trying to set the lock on an upgraded handle.
     unsafe fn set_lock(&self, val: bool) {
         let counter = &(*((*self.data.0).data as *mut OutputLayoutState)).counter;
-        counter.as_ref().store(val, Ordering::Release);
+        counter.as_ref().set(val);
     }
 
     unsafe fn get_lock(&self) -> bool {
         (*((*self.data.0).data as *mut OutputLayoutState)).counter
                                                           .as_ref()
-                                                          .load(Ordering::Relaxed)
+                                                          .get()
     }
 }
 

--- a/src/types/output/output_layout.rs
+++ b/src/types/output/output_layout.rs
@@ -54,7 +54,11 @@ wayland_listener!(OutputLayout, (*mut wlr_output_layout, Box<OutputLayoutHandler
         let layout_output = OutputLayoutOutput{layout_output, phantom: PhantomData};
         let compositor = &mut *COMPOSITOR_PTR;
         let mut output_layout = OutputLayout::from_ptr(output_ptr);
+
+        output_layout.set_lock(true);
         manager.output_added(compositor, &mut output_layout, layout_output);
+        output_layout.set_lock(false);
+
         Box::into_raw(output_layout);
     };
     output_remove_listener => output_remove_notify: |this: &mut OutputLayout,
@@ -65,7 +69,11 @@ wayland_listener!(OutputLayout, (*mut wlr_output_layout, Box<OutputLayoutHandler
         let layout_output = OutputLayoutOutput { layout_output, phantom: PhantomData};
         let compositor = &mut *COMPOSITOR_PTR;
         let mut output_layout = OutputLayout::from_ptr(output_ptr);
+
+        output_layout.set_lock(true);
         manager.output_removed(compositor, &mut output_layout, layout_output);
+        output_layout.set_lock(false);
+
         Box::into_raw(output_layout);
     };
     change_listener => change_notify: |this: &mut OutputLayout, data: *mut libc::c_void,|
@@ -75,7 +83,11 @@ wayland_listener!(OutputLayout, (*mut wlr_output_layout, Box<OutputLayoutHandler
         let layout_output = OutputLayoutOutput { layout_output, phantom: PhantomData};
         let compositor = &mut *COMPOSITOR_PTR;
         let mut output_layout = OutputLayout::from_ptr(output_ptr);
+
+        output_layout.set_lock(true);
         manager.on_change(compositor, &mut output_layout, layout_output);
+        output_layout.set_lock(false);
+
         Box::into_raw(output_layout);
     };
 ]);
@@ -314,6 +326,11 @@ impl OutputLayout {
             OutputLayoutHandle { layout: self.data.0,
                                  handle }
         }
+    }
+
+    unsafe fn set_lock(&self, val: bool) {
+        let counter = &(*((*self.data.0).data as *mut OutputLayoutState)).counter;
+        counter.as_ref().store(val, Ordering::Release);
     }
 }
 

--- a/src/types/seat/seat.rs
+++ b/src/types/seat/seat.rs
@@ -334,8 +334,7 @@ impl Seat {
     }
 
     unsafe fn get_lock(&self) -> bool {
-        (*((*self.data.0).data as *mut SeatState)).counter
-                                                  .get()
+        (*((*self.data.0).data as *mut SeatState)).counter.get()
     }
 
     /// Get the name of the seat.

--- a/src/types/seat/seat.rs
+++ b/src/types/seat/seat.rs
@@ -330,12 +330,12 @@ impl Seat {
     /// Panics when trying to set the lock on an upgraded handle.
     unsafe fn set_lock(&self, val: bool) {
         let counter = &(*((*self.data.0).data as *mut SeatState)).counter;
-        counter.as_ref().store(val, Ordering::Release);
+        counter.as_ref().set(val);
     }
 
     unsafe fn get_lock(&self) -> bool {
         (*((*self.data.0).data as *mut SeatState)).counter
-                                                  .load(Ordering::Relaxed)
+                                                  .get()
     }
 
     /// Get the name of the seat.

--- a/src/types/seat/seat.rs
+++ b/src/types/seat/seat.rs
@@ -96,9 +96,12 @@ wayland_listener!(Seat, (*mut wlr_seat, Box<SeatHandler>), [
         let pointer_grab = &mut *(event as *mut PointerGrab);
         let mut seat = Seat::from_ptr(seat_ptr);
 
+        let prev_seat_lock = seat.get_lock();
+        compositor.lock.set(true);
         seat.set_lock(true);
         handler.pointer_grabbed(compositor, &mut seat, pointer_grab);
-        seat.set_lock(false);
+        seat.set_lock(prev_seat_lock);
+        compositor.lock.set(false);
 
         Box::into_raw(seat);
     };
@@ -111,9 +114,12 @@ wayland_listener!(Seat, (*mut wlr_seat, Box<SeatHandler>), [
         let pointer_grab = &mut *(event as *mut PointerGrab);
         let mut seat = Seat::from_ptr(seat_ptr);
 
+        let prev_seat_lock = seat.get_lock();
+        compositor.lock.set(true);
         seat.set_lock(true);
         handler.pointer_released(compositor, &mut seat, pointer_grab);
-        seat.set_lock(false);
+        seat.set_lock(prev_seat_lock);
+        compositor.lock.set(false);
 
         Box::into_raw(seat);
     };
@@ -125,9 +131,12 @@ wayland_listener!(Seat, (*mut wlr_seat, Box<SeatHandler>), [
         let keyboard_grab = &mut *(event as *mut KeyboardGrab);
         let mut seat = Seat::from_ptr(seat_ptr);
 
+        let prev_seat_lock = seat.get_lock();
+        compositor.lock.set(true);
         seat.set_lock(true);
         handler.keyboard_grabbed(compositor, &mut seat, keyboard_grab);
-        seat.set_lock(false);
+        seat.set_lock(prev_seat_lock);
+        compositor.lock.set(false);
 
         Box::into_raw(seat);
     };
@@ -139,9 +148,12 @@ wayland_listener!(Seat, (*mut wlr_seat, Box<SeatHandler>), [
         let keyboard_grab = &mut *(event as *mut KeyboardGrab);
         let mut seat = Seat::from_ptr(seat_ptr);
 
+        let prev_seat_lock = seat.get_lock();
+        compositor.lock.set(true);
         seat.set_lock(true);
         handler.keyboard_released(compositor, &mut seat, keyboard_grab);
-        seat.set_lock(false);
+        seat.set_lock(prev_seat_lock);
+        compositor.lock.set(false);
 
         Box::into_raw(seat);
     };
@@ -153,9 +165,12 @@ wayland_listener!(Seat, (*mut wlr_seat, Box<SeatHandler>), [
         let touch_grab = &mut *(event as *mut TouchGrab);
         let mut seat = Seat::from_ptr(seat_ptr);
 
+        let prev_seat_lock = seat.get_lock();
+        compositor.lock.set(true);
         seat.set_lock(true);
         handler.touch_grabbed(compositor, &mut seat, touch_grab);
-        seat.set_lock(false);
+        seat.set_lock(prev_seat_lock);
+        compositor.lock.set(false);
 
         Box::into_raw(seat);
     };
@@ -167,9 +182,12 @@ wayland_listener!(Seat, (*mut wlr_seat, Box<SeatHandler>), [
         let touch_grab = &mut *(event as *mut TouchGrab);
         let mut seat = Seat::from_ptr(seat_ptr);
 
+        let prev_seat_lock = seat.get_lock();
+        compositor.lock.set(true);
         seat.set_lock(true);
         handler.touch_released(compositor, &mut seat, touch_grab);
-        seat.set_lock(false);
+        seat.set_lock(prev_seat_lock);
+        compositor.lock.set(false);
 
         Box::into_raw(seat);
     };
@@ -181,9 +199,13 @@ wayland_listener!(Seat, (*mut wlr_seat, Box<SeatHandler>), [
         let event_ptr = event_ptr as *mut wlr_seat_pointer_request_set_cursor_event;
         let mut event = SetCursorEvent::from_ptr(event_ptr);
         let mut seat = Seat::from_ptr(seat_ptr);
+
+        let prev_seat_lock = seat.get_lock();
+        compositor.lock.set(true);
         seat.set_lock(true);
         handler.cursor_set(compositor, &mut seat, &mut event);
-        seat.set_lock(false);
+        seat.set_lock(prev_seat_lock);
+        compositor.lock.set(false);
 
         Box::into_raw(seat);
     };
@@ -193,9 +215,12 @@ wayland_listener!(Seat, (*mut wlr_seat, Box<SeatHandler>), [
         let compositor = &mut *COMPOSITOR_PTR;
         let mut seat = Seat::from_ptr(seat_ptr);
 
+        let prev_seat_lock = seat.get_lock();
+        compositor.lock.set(true);
         seat.set_lock(true);
         handler.received_selection(compositor, &mut seat);
-        seat.set_lock(false);
+        seat.set_lock(prev_seat_lock);
+        compositor.lock.set(false);
 
         Box::into_raw(seat);
     };
@@ -206,9 +231,12 @@ wayland_listener!(Seat, (*mut wlr_seat, Box<SeatHandler>), [
         let compositor = &mut *COMPOSITOR_PTR;
         let mut seat = Seat::from_ptr(seat_ptr);
 
+        let prev_seat_lock = seat.get_lock();
+        compositor.lock.set(true);
         seat.set_lock(true);
         handler.primary_selection(compositor, &mut seat);
-        seat.set_lock(false);
+        seat.set_lock(prev_seat_lock);
+        compositor.lock.set(false);
 
         Box::into_raw(seat);
     };
@@ -222,9 +250,12 @@ wayland_listener!(Seat, (*mut wlr_seat, Box<SeatHandler>), [
         let compositor = &mut *COMPOSITOR_PTR;
         let mut seat = Seat::from_ptr(seat_ptr);
 
+        let prev_seat_lock = seat.get_lock();
+        compositor.lock.set(true);
         seat.set_lock(true);
         handler.destroy(compositor, &mut seat);
-        seat.set_lock(false);
+        seat.set_lock(prev_seat_lock);
+        compositor.lock.set(false);
 
         // NOTE Destructor is already being run,
         // otherwise this would be a double free.
@@ -300,6 +331,11 @@ impl Seat {
     unsafe fn set_lock(&self, val: bool) {
         let counter = &(*((*self.data.0).data as *mut SeatState)).counter;
         counter.as_ref().store(val, Ordering::Release);
+    }
+
+    unsafe fn get_lock(&self) -> bool {
+        (*((*self.data.0).data as *mut SeatState)).counter
+                                                  .load(Ordering::Relaxed)
     }
 
     /// Get the name of the seat.

--- a/src/xwayland/manager.rs
+++ b/src/xwayland/manager.rs
@@ -21,7 +21,10 @@ wayland_listener!(XWaylandManager, Box<XWaylandManagerHandler>, [
     unsafe {
         let manager = &mut this.data;
         let compositor = &mut *COMPOSITOR_PTR;
-        manager.on_ready(compositor)
+
+        compositor.lock.set(true);
+        manager.on_ready(compositor);
+        compositor.lock.set(false);
     };
     new_surface_listener => new_surface_notify: |this: &mut XWaylandManager,
                                                  data: *mut libc::c_void,|
@@ -29,7 +32,10 @@ wayland_listener!(XWaylandManager, Box<XWaylandManagerHandler>, [
         let manager = &mut this.data;
         let surface = data as *mut wlr_xwayland_surface;
         let compositor = &mut *COMPOSITOR_PTR;
+
+        compositor.lock.set(true);
         // TODO Pass in the new surface from the data
         manager.new_surface(compositor);
+        compositor.lock.set(false);
     };
 ]);


### PR DESCRIPTION
In Way Cooler we need access to the compositor state during Lua calls when we are not in the wayland event loop (because Way Cooler is single threaded).

To that end, I have added a function allowing the user to execute some code in the context of the compositor called `with_compositor`.

These series of patches also fixes a critical error made in `CursorHandle`, `SeatHandle`, and `OutputHandle`. You could upgrade these even when you were currently borrowing the concrete type in a callback. That has now been fixed.

# run_handles
Also fixed base case in `run_handles!`

# Renderer
Added `create_texture_from_pixels` onto the `Renderer` (exactly the same as `GenericRenderer`).