### PR TITLE
update to latest wlroots

### DIFF
--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -289,7 +289,8 @@ impl CompositorBuilder {
             let xwayland = self.xwayland.and_then(|manager| {
                                                       Some(XWaylandServer::new(display as _,
                                                                                compositor,
-                                                                               manager))
+                                                                               manager,
+                                                                               false))
                                                   });
 
             // Open the socket to the Wayland server.

--- a/src/types/input/input_device.rs
+++ b/src/types/input/input_device.rs
@@ -1,4 +1,4 @@
-use libc::{c_double, c_int};
+use libc::{c_double, c_uint};
 
 use wlroots_sys::{wlr_input_device, wlr_input_device_pointer, wlr_input_device_type};
 
@@ -24,11 +24,11 @@ impl InputDevice {
         InputDevice { device: self.device }
     }
 
-    pub fn vendor(&self) -> c_int {
+    pub fn vendor(&self) -> c_uint {
         unsafe { (*self.device).vendor }
     }
 
-    pub fn product(&self) -> c_int {
+    pub fn product(&self) -> c_uint {
         unsafe { (*self.device).product }
     }
 

--- a/src/types/seat/seat.rs
+++ b/src/types/seat/seat.rs
@@ -25,7 +25,8 @@ use wlroots_sys::{wlr_axis_orientation, wlr_seat, wlr_seat_create, wlr_seat_dest
                   wlr_seat_touch_notify_motion, wlr_seat_touch_notify_up,
                   wlr_seat_touch_num_points, wlr_seat_touch_point_clear_focus,
                   wlr_seat_touch_point_focus, wlr_seat_touch_send_down,
-                  wlr_seat_touch_send_motion, wlr_seat_touch_send_up, wlr_seat_touch_start_grab};
+                  wlr_seat_touch_send_motion, wlr_seat_touch_send_up, wlr_seat_touch_start_grab,
+                  wlr_axis_source};
 pub use wlroots_sys::wayland_server::protocol::wl_seat::Capability;
 use xkbcommon::xkb::Keycode;
 
@@ -398,9 +399,14 @@ impl Seat {
     ///
     /// Compositors should use `Seat::notify_axis` to
     /// send axis events to respect pointer grabs.
-    pub fn send_axis(&self, time: Duration, orientation: wlr_axis_orientation, value: f64) {
+    pub fn send_axis(&self,
+                     time: Duration,
+                     orientation: wlr_axis_orientation,
+                     value: f64,
+                     value_discrete: i32,
+                     source: wlr_axis_source) {
         unsafe {
-            wlr_seat_pointer_send_axis(self.data.0, time.to_ms(), orientation, value);
+            wlr_seat_pointer_send_axis(self.data.0, time.to_ms(), orientation, value, value_discrete, source);
         }
     }
 
@@ -449,8 +455,10 @@ impl Seat {
     pub fn pointer_notify_axis(&self,
                                time: Duration,
                                orientation: wlr_axis_orientation,
-                               value: f64) {
-        unsafe { wlr_seat_pointer_notify_axis(self.data.0, time.to_ms(), orientation, value) }
+                               value: f64,
+                               value_discrete: i32,
+                               source: wlr_axis_source) {
+        unsafe { wlr_seat_pointer_notify_axis(self.data.0, time.to_ms(), orientation, value, value_discrete, source) }
     }
 
     /// Set this keyboard as the active keyboard for the seat.

--- a/src/types/shell/xdg_shell_v6.rs
+++ b/src/types/shell/xdg_shell_v6.rs
@@ -5,12 +5,11 @@ use std::cell::Cell;
 use std::rc::{Rc, Weak};
 
 use wlroots_sys::{wlr_xdg_popup_v6, wlr_xdg_surface_v6, wlr_xdg_surface_v6_ping,
-                  wlr_xdg_surface_v6_popup_get_position, wlr_xdg_surface_v6_role,
-                  wlr_xdg_surface_v6_send_close, wlr_xdg_surface_v6_surface_at,
-                  wlr_xdg_toplevel_v6, wlr_xdg_toplevel_v6_set_activated,
-                  wlr_xdg_toplevel_v6_set_fullscreen, wlr_xdg_toplevel_v6_set_maximized,
-                  wlr_xdg_toplevel_v6_set_resizing, wlr_xdg_toplevel_v6_set_size,
-                  wlr_xdg_toplevel_v6_state};
+                  wlr_xdg_surface_v6_role, wlr_xdg_surface_v6_send_close,
+                  wlr_xdg_surface_v6_surface_at, wlr_xdg_toplevel_v6,
+                  wlr_xdg_toplevel_v6_set_activated, wlr_xdg_toplevel_v6_set_fullscreen,
+                  wlr_xdg_toplevel_v6_set_maximized, wlr_xdg_toplevel_v6_set_resizing,
+                  wlr_xdg_toplevel_v6_set_size, wlr_xdg_toplevel_v6_state};
 
 use {Area, SeatHandle, SurfaceHandle};
 use errors::{HandleErr, HandleResult};
@@ -411,17 +410,6 @@ impl XdgV6Popup {
                                     -> XdgV6Popup {
         XdgV6Popup { shell_surface,
                      popup }
-    }
-
-    /// Compute the popup position in surface-local coordinates.
-    ///
-    /// Return value is in (x, y) format.
-    pub fn position(&self) -> (f64, f64) {
-        unsafe {
-            let (mut x, mut y) = (0.0, 0.0);
-            wlr_xdg_surface_v6_popup_get_position(self.shell_surface, &mut x, &mut y);
-            (x, y)
-        }
     }
 
     /// Get a handle to the base surface of the xdg tree.

--- a/src/xwayland/server.rs
+++ b/src/xwayland/server.rs
@@ -13,9 +13,10 @@ pub struct XWaylandServer {
 impl XWaylandServer {
     pub(crate) unsafe fn new(display: *mut wl_display,
                              compositor: *mut wlr_compositor,
-                             manager: Box<XWaylandManagerHandler>)
+                             manager: Box<XWaylandManagerHandler>,
+                             lazy: bool)
                              -> Self {
-        let xwayland = wlr_xwayland_create(display, compositor);
+        let xwayland = wlr_xwayland_create(display, compositor, lazy);
         if xwayland.is_null() {
             panic!("Could not start XWayland server")
         }


### PR DESCRIPTION
Summary:

* xwayland create got the `lazy` boolean flag, which means to start xwayland only after an X client tries to connect.
* xdg_popup_v6 lost the `position()` function (which you probably don't need because you normally have the toplevel first).
* the seat axis functions gained `axis_discrete` for the discrete number of axis steps (part of the Wayland protocol) and the axis source (also part of the Wayland protocol).
