### PR TITLE
Added custom terminate function

### DIFF
--- a/examples/pointer.rs
+++ b/examples/pointer.rs
@@ -82,14 +82,12 @@ impl OutputManagerHandler for OutputManager {
 }
 
 impl KeyboardHandler for ExKeyboardHandler {
-    fn on_key(&mut self, compositor: CompositorHandle, _: KeyboardHandle, key_event: &KeyEvent) {
-        with_handles!([(compositor: {compositor})] => {
-            for key in key_event.pressed_keys() {
-                if key == KEY_Escape {
-                    compositor.terminate()
-                }
+    fn on_key(&mut self, _: CompositorHandle, _: KeyboardHandle, key_event: &KeyEvent) {
+        for key in key_event.pressed_keys() {
+            if key == KEY_Escape {
+                wlroots::terminate()
             }
-        }).unwrap();
+        }
     }
 }
 

--- a/examples/rotation.rs
+++ b/examples/rotation.rs
@@ -131,7 +131,7 @@ impl KeyboardHandler for KeyboardManager {
         with_handles!([(compositor: {compositor})] => {
             for key in keys {
                 match key {
-                    keysyms::KEY_Escape => compositor.terminate(),
+                    keysyms::KEY_Escape => wlroots::terminate(),
                     keysyms::KEY_Left => update_velocities(compositor.into(), -16.0, 0.0),
                     keysyms::KEY_Right => update_velocities(compositor.into(), 16.0, 0.0),
                     keysyms::KEY_Up => update_velocities(compositor.into(), 0.0, -16.0),

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -23,20 +23,16 @@ struct InputManager;
 struct ExKeyboardHandler;
 
 impl KeyboardHandler for ExKeyboardHandler {
-    fn on_key(&mut self,
-              compositor: CompositorHandle,
-              keyboard: KeyboardHandle,
-              key_event: &KeyEvent) {
+    fn on_key(&mut self, _: CompositorHandle, keyboard: KeyboardHandle, key_event: &KeyEvent) {
         let keys = key_event.pressed_keys();
-        with_handles!([(keyboard: {keyboard}),
-                      (compositor: {compositor})] => {
+        with_handles!([(keyboard: {keyboard})] => {
             wlr_log!(L_DEBUG,
                      "Got key event. Keys: {:?}. Modifiers: {}",
                      keys,
                      keyboard.get_modifiers());
             for key in keys {
                 if key == KEY_Escape {
-                    compositor.terminate()
+                    wlroots::terminate()
                 }
             }
         }).unwrap();

--- a/examples/tablet.rs
+++ b/examples/tablet.rs
@@ -78,15 +78,10 @@ impl OutputManagerHandler for OutputManagerEx {
 }
 
 impl KeyboardHandler for KeyboardEx {
-    fn on_key(&mut self,
-              mut compositor: CompositorHandle,
-              _: KeyboardHandle,
-              key_event: &KeyEvent) {
+    fn on_key(&mut self, _: CompositorHandle, _: KeyboardHandle, key_event: &KeyEvent) {
         for key in key_event.pressed_keys() {
             if key == KEY_Escape {
-                with_handles!([(compositor: {&mut compositor})] => {
-                    compositor.terminate()
-                }).unwrap();
+                wlroots::terminate()
             }
         }
     }

--- a/examples/touch.rs
+++ b/examples/touch.rs
@@ -54,15 +54,10 @@ impl OutputManagerHandler for OutputManager {
 }
 
 impl KeyboardHandler for ExKeyboardHandler {
-    fn on_key(&mut self,
-              mut compositor: CompositorHandle,
-              _: KeyboardHandle,
-              key_event: &KeyEvent) {
+    fn on_key(&mut self, _: CompositorHandle, _: KeyboardHandle, key_event: &KeyEvent) {
         for key in key_event.pressed_keys() {
             if key == KEY_Escape {
-                with_handles!([(compositor: {&mut compositor})] => {
-                    compositor.terminate()
-                }).unwrap();
+                wlroots::terminate()
             }
         }
     }

--- a/examples/wl_shell_test.rs
+++ b/examples/wl_shell_test.rs
@@ -118,15 +118,10 @@ impl OutputManagerHandler for OutputManager {
 }
 
 impl KeyboardHandler for ExKeyboardHandler {
-    fn on_key(&mut self,
-              mut compositor: CompositorHandle,
-              _: KeyboardHandle,
-              key_event: &KeyEvent) {
+    fn on_key(&mut self, _: CompositorHandle, _: KeyboardHandle, key_event: &KeyEvent) {
         for key in key_event.pressed_keys() {
             if key == KEY_Escape {
-                with_handles!([(compositor: {&mut compositor})] => {
-                    compositor.terminate()
-                }).unwrap();
+                wlroots::terminate();
             }
             // TODO This is a dumb way to compare these values
             else if key_event.key_state() as u32 == 1 {

--- a/examples/xdg_shell_v6_test.rs
+++ b/examples/xdg_shell_v6_test.rs
@@ -13,7 +13,7 @@ use wlroots::{project_box, Area, Capability, CompositorBuilder, CompositorHandle
               XCursorManager, XdgV6ShellHandler, XdgV6ShellManagerHandler, XdgV6ShellState,
               XdgV6ShellSurfaceHandle};
 use wlroots::key_events::KeyEvent;
-use wlroots::pointer_events::{ButtonEvent, MotionEvent, AbsoluteMotionEvent};
+use wlroots::pointer_events::{AbsoluteMotionEvent, ButtonEvent, MotionEvent};
 use wlroots::utils::{init_logging, L_DEBUG};
 use wlroots::wlroots_sys::wlr_key_state::WLR_KEY_PRESSED;
 use wlroots::xkbcommon::xkb::keysyms::{KEY_Escape, KEY_F1};
@@ -28,7 +28,10 @@ struct State {
 }
 
 impl State {
-    fn new(xcursor_manager: XCursorManager, layout: OutputLayoutHandle, cursor: CursorHandle) -> Self {
+    fn new(xcursor_manager: XCursorManager,
+           layout: OutputLayoutHandle,
+           cursor: CursorHandle)
+           -> Self {
         State { xcursor_manager,
                 layout,
                 cursor,
@@ -130,7 +133,7 @@ impl KeyboardHandler for ExKeyboardHandler {
         with_handles!([(compositor: {&mut compositor})] => {
             for key in key_event.pressed_keys() {
                 if key == KEY_Escape {
-                    compositor.terminate();
+                    wlroots::terminate();
                 } else if key_event.key_state() == WLR_KEY_PRESSED {
                     if key == KEY_F1 {
                         thread::spawn(move || {
@@ -153,7 +156,10 @@ impl KeyboardHandler for ExKeyboardHandler {
 }
 
 impl PointerHandler for ExPointer {
-    fn on_motion_absolute(&mut self, compositor: CompositorHandle, _: PointerHandle, event: &AbsoluteMotionEvent) {
+    fn on_motion_absolute(&mut self,
+                          compositor: CompositorHandle,
+                          _: PointerHandle,
+                          event: &AbsoluteMotionEvent) {
         with_handles!([(compositor: {compositor})] => {
             let state: &mut State = compositor.into();
             let (x, y) = event.pos();
@@ -243,9 +249,12 @@ impl InputManagerHandler for InputManager {
 fn main() {
     init_logging(L_DEBUG, None);
     let mut cursor = Cursor::create(Box::new(CursorEx));
-    let mut xcursor_manager = XCursorManager::create("default".to_string(), 24).expect("Could not create xcursor manager");
+    let mut xcursor_manager =
+        XCursorManager::create("default".to_string(), 24).expect("Could not create xcursor \
+                                                                  manager");
     xcursor_manager.load(1.0);
-    cursor.run(|c| xcursor_manager.set_cursor_image("left_ptr".to_string(), c)).unwrap();
+    cursor.run(|c| xcursor_manager.set_cursor_image("left_ptr".to_string(), c))
+          .unwrap();
     let layout = OutputLayout::create(Box::new(OutputLayoutEx));
 
     let mut compositor =


### PR DESCRIPTION
This allows Way Cooler to properly shutdown the glib loop and fail when a panic occurs.

This makes only the global terminate function public. This simplifies the API, but it is a breaking change.