### PR TITLE
Lenient handle upgrades

### DIFF
--- a/examples/pointer.rs
+++ b/examples/pointer.rs
@@ -180,7 +180,7 @@ impl InputManagerHandler for InputManager {
 
 fn main() {
     init_logging(L_DEBUG, None);
-    let mut cursor = Cursor::create(Box::new(ExCursor));
+    let cursor = Cursor::create(Box::new(ExCursor));
     let mut xcursor_manager =
         XCursorManager::create("default".to_string(), 24).expect("Could not create xcursor \
                                                                   manager");

--- a/examples/xdg_shell_v6_test.rs
+++ b/examples/xdg_shell_v6_test.rs
@@ -144,7 +144,7 @@ impl KeyboardHandler for ExKeyboardHandler {
                 }
             }
             let state: &mut State = compositor.into();
-            let mut seat_handle = state.seat_handle.clone().unwrap();
+            let seat_handle = state.seat_handle.clone().unwrap();
             seat_handle.run(|seat| {
                 seat.keyboard_notify_key(key_event.time_msec(),
                                          key_event.keycode(),
@@ -248,7 +248,7 @@ impl InputManagerHandler for InputManager {
 
 fn main() {
     init_logging(L_DEBUG, None);
-    let mut cursor = Cursor::create(Box::new(CursorEx));
+    let cursor = Cursor::create(Box::new(CursorEx));
     let mut xcursor_manager =
         XCursorManager::create("default".to_string(), 24).expect("Could not create xcursor \
                                                                   manager");
@@ -265,7 +265,7 @@ fn main() {
                                 .build_auto(State::new(xcursor_manager, layout, cursor));
 
     {
-        let mut seat_handle =
+        let seat_handle =
             Seat::create(&mut compositor, "seat0".into(), Box::new(SeatHandlerEx));
         seat_handle.run(|seat| {
                             seat.set_capabilities(Capability::all());

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -488,7 +488,7 @@ impl CompositorHandle {
     /// or if you run this function within the another run to the same `Output`.
     ///
     /// So don't nest `run` calls and everything will be ok :).
-    pub fn run<F, R>(&mut self, runner: F) -> HandleResult<R>
+    pub fn run<F, R>(&self, runner: F) -> HandleResult<R>
         where F: FnOnce(&mut Compositor) -> R
     {
         let compositor = unsafe { self.upgrade()? };

--- a/src/types/cursor/cursor.rs
+++ b/src/types/cursor/cursor.rs
@@ -573,7 +573,7 @@ impl Cursor {
 
     /// Determines if we are within a valid layout.
     fn assert_layout(&self) {
-        match self.data.2.clone().map(|mut layout| layout.run(|_| ())) {
+        match self.data.2.clone().map(|layout| layout.run(|_| ())) {
             Some(Ok(())) | Some(Err(HandleErr::AlreadyBorrowed)) => {}
             None | Some(Err(_)) => panic!("Cursor was not attached to an output layout!")
         }

--- a/src/types/cursor/cursor.rs
+++ b/src/types/cursor/cursor.rs
@@ -701,7 +701,7 @@ impl CursorHandle {
     ///
     /// So don't nest `run` calls or call this in a Cursor callback
     /// and everything will be ok :).
-    pub fn run<F, R>(&mut self, runner: F) -> HandleResult<R>
+    pub fn run<F, R>(&self, runner: F) -> HandleResult<R>
         where F: FnOnce(&mut Cursor) -> R
     {
         let mut cursor = unsafe { self.upgrade()? };

--- a/src/types/input/keyboard.rs
+++ b/src/types/input/keyboard.rs
@@ -289,7 +289,7 @@ impl KeyboardHandle {
     /// or if you run this function within the another run to the same `Output`.
     ///
     /// So don't nest `run` calls and everything will be ok :).
-    pub fn run<F, R>(&mut self, runner: F) -> HandleResult<R>
+    pub fn run<F, R>(&self, runner: F) -> HandleResult<R>
         where F: FnOnce(&mut Keyboard) -> R
     {
         let mut keyboard = unsafe { self.upgrade()? };

--- a/src/types/input/pointer.rs
+++ b/src/types/input/pointer.rs
@@ -166,7 +166,7 @@ impl PointerHandle {
     /// or if you run this function within the another run to the same `Output`.
     ///
     /// So don't nest `run` calls and everything will be ok :).
-    pub fn run<F, R>(&mut self, runner: F) -> HandleResult<R>
+    pub fn run<F, R>(&self, runner: F) -> HandleResult<R>
         where F: FnOnce(&Pointer) -> R
     {
         let mut pointer = unsafe { self.upgrade()? };

--- a/src/types/input/tablet_pad.rs
+++ b/src/types/input/tablet_pad.rs
@@ -159,7 +159,7 @@ impl TabletPadHandle {
     /// or if you run this function within the another run to the same `TabletPad`.
     ///
     /// So don't nest `run` calls and everything will be ok :).
-    pub fn run<F, R>(&mut self, runner: F) -> HandleResult<R>
+    pub fn run<F, R>(&self, runner: F) -> HandleResult<R>
         where F: FnOnce(&mut TabletPad) -> R
     {
         let mut pad = unsafe { self.upgrade()? };

--- a/src/types/input/tablet_tool.rs
+++ b/src/types/input/tablet_tool.rs
@@ -159,7 +159,7 @@ impl TabletToolHandle {
     /// or if you run this function within the another run to the same `TabletPad`.
     ///
     /// So don't nest `run` calls and everything will be ok :).
-    pub fn run<F, R>(&mut self, runner: F) -> HandleResult<R>
+    pub fn run<F, R>(&self, runner: F) -> HandleResult<R>
         where F: FnOnce(&mut TabletTool) -> R
     {
         let mut tool = unsafe { self.upgrade()? };

--- a/src/types/input/touch.rs
+++ b/src/types/input/touch.rs
@@ -165,7 +165,7 @@ impl TouchHandle {
     /// or if you run this function within the another run to the same `Output`.
     ///
     /// So don't nest `run` calls and everything will be ok :).
-    pub fn run<F, R>(&mut self, runner: F) -> HandleResult<R>
+    pub fn run<F, R>(&self, runner: F) -> HandleResult<R>
         where F: FnOnce(&Touch) -> R
     {
         let mut touch = unsafe { self.upgrade()? };

--- a/src/types/output/output.rs
+++ b/src/types/output/output.rs
@@ -549,7 +549,7 @@ impl OutputHandle {
     /// or if you run this function within the another run to the same `Output`.
     ///
     /// So don't nest `run` calls and everything will be ok :).
-    pub fn run<F, R>(&mut self, runner: F) -> HandleResult<R>
+    pub fn run<F, R>(&self, runner: F) -> HandleResult<R>
         where F: FnOnce(&mut Output) -> R
     {
         let mut output = unsafe { self.upgrade()? };

--- a/src/types/output/output.rs
+++ b/src/types/output/output.rs
@@ -135,7 +135,7 @@ impl Output {
             return
         }
         // Remove output from previous output layout.
-        if let Some(mut layout_handle) = (*output_data).layout_handle.take() {
+        if let Some(layout_handle) = (*output_data).layout_handle.take() {
             match layout_handle.run(|layout| layout.remove(self)) {
                 Ok(_) | Err(HandleErr::AlreadyDropped) => self.clear_output_layout_data(),
                 Err(HandleErr::AlreadyBorrowed) => {

--- a/src/types/output/output_layout.rs
+++ b/src/types/output/output_layout.rs
@@ -411,7 +411,7 @@ impl OutputLayoutHandle {
     /// to a short lived scope of an anonymous function,
     /// this function ensures the OutputLayout does not live longer
     /// than it exists (because the lifetime is controlled by the user).
-    pub fn run<F, R>(&mut self, runner: F) -> HandleResult<R>
+    pub fn run<F, R>(&self, runner: F) -> HandleResult<R>
         where F: FnOnce(&mut OutputLayout) -> R
     {
         let mut output_layout = unsafe { self.upgrade()? };

--- a/src/types/seat/seat.rs
+++ b/src/types/seat/seat.rs
@@ -841,7 +841,7 @@ impl SeatHandle {
     ///
     /// So don't nest `run` calls or call this in a Seat callback
     /// and everything will be ok :).
-    pub fn run<F, R>(&mut self, runner: F) -> HandleResult<R>
+    pub fn run<F, R>(&self, runner: F) -> HandleResult<R>
         where F: FnOnce(&mut Seat) -> R
     {
         let mut seat = unsafe { self.upgrade()? };

--- a/src/types/shell/wl_shell.rs
+++ b/src/types/shell/wl_shell.rs
@@ -195,7 +195,7 @@ impl WlShellSurfaceHandle {
     /// or if you run this function within the another run to the same `Output`.
     ///
     /// So don't nest `run` calls and everything will be ok :).
-    pub fn run<F, R>(&mut self, runner: F) -> HandleResult<R>
+    pub fn run<F, R>(&self, runner: F) -> HandleResult<R>
         where F: FnOnce(&mut WlShellSurface) -> R
     {
         let mut wl_shell_surface = unsafe { self.upgrade()? };

--- a/src/types/shell/xdg_shell_v6.rs
+++ b/src/types/shell/xdg_shell_v6.rs
@@ -279,7 +279,7 @@ impl XdgV6ShellSurfaceHandle {
     /// or if you run this function within the another run to the same `Output`.
     ///
     /// So don't nest `run` calls and everything will be ok :).
-    pub fn run<F, R>(&mut self, runner: F) -> HandleResult<R>
+    pub fn run<F, R>(&self, runner: F) -> HandleResult<R>
         where F: FnOnce(&mut XdgV6ShellSurface) -> R
     {
         let mut xdg_surface = unsafe { self.upgrade()? };

--- a/src/types/surface/sub_surface.rs
+++ b/src/types/surface/sub_surface.rs
@@ -151,7 +151,7 @@ impl SubsurfaceHandle {
     /// or if you run this function within the another run to the same `Surface`.
     ///
     /// So don't nest `run` calls and everything will be ok :).
-    pub fn run<F, R>(&mut self, runner: F) -> HandleResult<R>
+    pub fn run<F, R>(&self, runner: F) -> HandleResult<R>
         where F: FnOnce(&mut Subsurface) -> R
     {
         let mut subsurface = unsafe { self.upgrade()? };

--- a/src/types/surface/surface.rs
+++ b/src/types/surface/surface.rs
@@ -310,7 +310,7 @@ impl SurfaceHandle {
     /// or if you run this function within the another run to the same `Surface`.
     ///
     /// So don't nest `run` calls and everything will be ok :).
-    pub fn run<F, R>(&mut self, runner: F) -> HandleResult<R>
+    pub fn run<F, R>(&self, runner: F) -> HandleResult<R>
         where F: FnOnce(&mut Surface) -> R
     {
         let mut surface = unsafe { self.upgrade()? };

--- a/src/xwayland/surface.rs
+++ b/src/xwayland/surface.rs
@@ -508,7 +508,7 @@ impl XWaylandSurfaceHandle {
     /// or if you run this function within the another run to the same `XWaylandSurface`.
     ///
     /// So don't nest `run` calls and everything will be ok :).
-    pub fn run<F, R>(&mut self, runner: F) -> HandleResult<R>
+    pub fn run<F, R>(&self, runner: F) -> HandleResult<R>
         where F: FnOnce(&mut XWaylandSurface) -> R
     {
         let mut wl_shell_surface = unsafe { self.upgrade()? };


### PR DESCRIPTION
Changed the `run` methods on `*Handle` types to only require an immutable reference to the handle instead of a mutable reference.

The mutable requirement doesn't add anything at all. It's not UB because we aren't modifying the Handle at all when we do that unsafely, it only makes it _slightly_ more clear there's mutation going on. But it's a red herring. The mutation is done on the backing structure which _is_ `&mut` so there's nothing bad there.

This is an issue because in Way Cooler we want to refer to the same handle across data structures (e.g the focus shell in both the global list of shells and in the abstraction over the seat to keep track of the focused one) and it's not possible without resorting shoe-horning it into one data structure or by keeping an ugly `Rc<RefCell<T>>` everywhere. With this change, you just need the `Rc<T>` which is much easier to deal with.

CC @acrisci this might fix the problems you have with https://github.com/way-cooler/way-cooler/pull/546