### PR TITLE
Xdg shell

### DIFF
--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -2,6 +2,7 @@ pub mod key_events;
 pub mod pointer_events;
 pub mod wl_shell_events;
 pub mod xdg_shell_v6_events;
+pub mod xdg_shell_events;
 pub mod tablet_tool_events;
 pub mod touch_events;
 pub mod seat_events;

--- a/src/events/xdg_shell_events.rs
+++ b/src/events/xdg_shell_events.rs
@@ -1,0 +1,116 @@
+//! Events for stable XDG shell
+
+use wlroots_sys::{wlr_xdg_toplevel_move_event, wlr_xdg_toplevel_resize_event,
+                  wlr_xdg_toplevel_set_fullscreen_event,
+                  wlr_xdg_toplevel_show_window_menu_event};
+
+use {OutputHandle, XdgShellSurfaceHandle};
+
+/// Event that triggers when the surface has been moved in coordinate space.
+#[derive(Debug, PartialEq, Eq)]
+pub struct MoveEvent {
+    event: *mut wlr_xdg_toplevel_move_event
+}
+
+/// Event that triggers when the suface has been resized.
+#[derive(Debug, PartialEq, Eq)]
+pub struct ResizeEvent {
+    event: *mut wlr_xdg_toplevel_resize_event
+}
+
+/// Event that is triggered when the surface toggles between being fullscreen
+/// or not.
+#[derive(Debug, PartialEq, Eq)]
+pub struct SetFullscreenEvent {
+    event: *mut wlr_xdg_toplevel_set_fullscreen_event
+}
+
+/// Event that is triggered when the surface shows the window menu.
+#[derive(Debug, PartialEq, Eq)]
+pub struct ShowWindowMenuEvent {
+    event: *mut wlr_xdg_toplevel_show_window_menu_event
+}
+
+impl MoveEvent {
+    pub(crate) unsafe fn from_ptr(event: *mut wlr_xdg_toplevel_move_event) -> Self {
+        MoveEvent { event }
+    }
+
+    /// Get a handle to the surface associated with this event.
+    pub fn surface(&self) -> XdgShellSurfaceHandle {
+        unsafe { XdgShellSurfaceHandle::from_ptr((*self.event).surface) }
+    }
+
+    // TODO Get seat client
+
+    pub fn serial(&self) -> u32 {
+        unsafe { (*self.event).serial }
+    }
+}
+
+impl ResizeEvent {
+    pub(crate) unsafe fn from_ptr(event: *mut wlr_xdg_toplevel_resize_event) -> Self {
+        ResizeEvent { event }
+    }
+
+    /// Get a handle to the surface associated with this event.
+    pub fn surface(&self) -> XdgShellSurfaceHandle {
+        unsafe { XdgShellSurfaceHandle::from_ptr((*self.event).surface) }
+    }
+
+    // TODO Get seat client
+
+    pub fn serial(&self) -> u32 {
+        unsafe { (*self.event).serial }
+    }
+
+    pub fn edges(&self) -> u32 {
+        unsafe { (*self.event).edges }
+    }
+}
+
+impl SetFullscreenEvent {
+    pub(crate) unsafe fn from_ptr(event: *mut wlr_xdg_toplevel_set_fullscreen_event) -> Self {
+        SetFullscreenEvent { event }
+    }
+
+    /// Get a handle to the surface associated with this event.
+    pub fn surface(&self) -> XdgShellSurfaceHandle {
+        unsafe { XdgShellSurfaceHandle::from_ptr((*self.event).surface) }
+    }
+
+    /// Determine if the event is to trigger fullscreen or to stop being
+    /// fullscreen.
+    pub fn fullscreen(&self) -> bool {
+        unsafe { (*self.event).fullscreen }
+    }
+
+    /// Get a handle to the output that this fullscreen event refers to.
+    pub fn output(&self) -> OutputHandle {
+        unsafe { OutputHandle::from_ptr((*self.event).output) }
+    }
+}
+
+impl ShowWindowMenuEvent {
+    pub(crate) unsafe fn from_ptr(event: *mut wlr_xdg_toplevel_show_window_menu_event) -> Self {
+        ShowWindowMenuEvent { event }
+    }
+
+    /// Get a handle to the surface associated with this event.
+    pub fn surface(&self) -> XdgShellSurfaceHandle {
+        unsafe { XdgShellSurfaceHandle::from_ptr((*self.event).surface) }
+    }
+
+    // TODO seat client
+
+    pub fn serial(&self) -> u32 {
+        unsafe { (*self.event).serial }
+    }
+
+    /// Get the coordinates for where this show menu event takes place.
+    ///
+    /// Return value is in (x, y) format.
+    pub fn coords(&self) -> (u32, u32) {
+        unsafe { ((*self.event).x, (*self.event).y) }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,11 +33,12 @@ pub use self::events::{key_events, seat_events, tablet_pad_events, tablet_tool_e
                        touch_events, wl_shell_events, xwayland_events,
                        pointer_events::{self, BTN_BACK, BTN_EXTRA, BTN_FORWARD, BTN_LEFT,
                                         BTN_MIDDLE, BTN_MOUSE, BTN_RIGHT, BTN_SIDE, BTN_TASK},
-                       xdg_shell_v6_events};
+                       xdg_shell_v6_events, xdg_shell_events};
 pub use self::manager::{InputManagerHandler, KeyboardHandler, OutputBuilder, OutputBuilderResult,
                         OutputHandler, OutputManagerHandler, PointerHandler, TabletPadHandler,
                         TabletToolHandler, TouchHandler, WlShellHandler, WlShellManagerHandler,
-                        XdgV6ShellHandler, XdgV6ShellManagerHandler};
+                        XdgV6ShellHandler, XdgV6ShellManagerHandler,
+                        XdgShellHandler, XdgShellManagerHandler};
 pub use self::types::area::*;
 pub use self::types::cursor::*;
 pub use self::types::data_device::*;

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -8,6 +8,8 @@ mod wl_shell_manager;
 mod wl_shell_handler;
 mod xdg_shell_v6_manager;
 mod xdg_shell_v6_handler;
+mod xdg_shell_manager;
+mod xdg_shell_handler;
 mod tablet_pad_handler;
 mod tablet_tool_handler;
 
@@ -24,3 +26,5 @@ pub use self::wl_shell_handler::*;
 pub use self::wl_shell_manager::*;
 pub use self::xdg_shell_v6_handler::*;
 pub use self::xdg_shell_v6_manager::*;
+pub use self::xdg_shell_handler::*;
+pub use self::xdg_shell_manager::*;

--- a/src/manager/xdg_shell_handler.rs
+++ b/src/manager/xdg_shell_handler.rs
@@ -1,0 +1,193 @@
+//! Handler for stable XDG shell clients.
+
+use libc;
+
+use wlroots_sys::wlr_xdg_surface;
+
+use {Surface, SurfaceHandle, XdgShellSurface, XdgShellSurfaceHandle};
+use compositor::{compositor_handle, CompositorHandle};
+use xdg_shell_events::{MoveEvent, ResizeEvent, SetFullscreenEvent, ShowWindowMenuEvent};
+
+/// Handles events from the client stable XDG shells.
+pub trait XdgShellHandler {
+    /// Called when the surface recieve a request event.
+    fn on_commit(&mut self, CompositorHandle, SurfaceHandle, XdgShellSurfaceHandle) {}
+
+    /// Called when the wayland shell is destroyed (e.g by the user)
+
+    fn destroy(&mut self, CompositorHandle, SurfaceHandle, XdgShellSurfaceHandle) {}
+
+    /// Called when the ping request timed out.
+    ///
+    /// This usually indicates something is wrong with the client.
+    fn ping_timeout(&mut self, CompositorHandle, SurfaceHandle, XdgShellSurfaceHandle) {}
+
+    /// Called when a new popup appears in the xdg tree.
+    fn new_popup(&mut self, CompositorHandle, SurfaceHandle, XdgShellSurfaceHandle) {}
+
+    /// Called when there is a request to maximize the XDG surface.
+    fn maximize_request(&mut self, CompositorHandle, SurfaceHandle, XdgShellSurfaceHandle) {}
+
+    /// Called when there is a request to minimize the XDG surface.
+    fn minimize_request(&mut self, CompositorHandle, SurfaceHandle, XdgShellSurfaceHandle) {}
+
+    /// Called when there is a request to move the shell surface somewhere else.
+    fn move_request(&mut self,
+                    CompositorHandle,
+                    SurfaceHandle,
+                    XdgShellSurfaceHandle,
+                    &MoveEvent) {
+    }
+
+    /// Called when there is a request to resize the shell surface.
+    fn resize_request(&mut self,
+                      CompositorHandle,
+                      SurfaceHandle,
+                      XdgShellSurfaceHandle,
+                      &ResizeEvent) {
+    }
+
+    /// Called when there is a request to make the shell surface fullscreen.
+    fn fullscreen_request(&mut self,
+                          CompositorHandle,
+                          SurfaceHandle,
+                          XdgShellSurfaceHandle,
+                          &SetFullscreenEvent) {
+    }
+
+    /// Called when there is a request to show the window menu.
+    fn show_window_menu_request(&mut self,
+                                CompositorHandle,
+                                SurfaceHandle,
+                                XdgShellSurfaceHandle,
+                                &ShowWindowMenuEvent) {
+    }
+}
+
+wayland_listener!(XdgShell, (XdgShellSurface, Surface, Box<XdgShellHandler>), [
+    commit_listener => commit_notify: |this: &mut XdgShell, _data: *mut libc::c_void,| unsafe {
+        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let compositor = match compositor_handle() {
+            Some(handle) => handle,
+            None => return
+        };
+
+        manager.on_commit(compositor,
+                          surface.weak_reference(),
+                          shell_surface.weak_reference());
+    };
+    ping_timeout_listener => ping_timeout_notify: |this: &mut XdgShell,
+                                                   _data: *mut libc::c_void,|
+    unsafe {
+        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let compositor = match compositor_handle() {
+            Some(handle) => handle,
+            None => return
+        };
+
+        manager.ping_timeout(compositor,
+                             surface.weak_reference(),
+                             shell_surface.weak_reference());
+    };
+    new_popup_listener => new_popup_notify: |this: &mut XdgShell, _data: *mut libc::c_void,|
+    unsafe {
+        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let compositor = match compositor_handle() {
+            Some(handle) => handle,
+            None => return
+        };
+
+        manager.new_popup(compositor,
+                          surface.weak_reference(),
+                          shell_surface.weak_reference());
+    };
+    maximize_listener => maximize_notify: |this: &mut XdgShell, _event: *mut libc::c_void,|
+    unsafe {
+        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let compositor = match compositor_handle() {
+            Some(handle) => handle,
+            None => return
+        };
+
+        manager.maximize_request(compositor,
+                                 surface.weak_reference(),
+                                 shell_surface.weak_reference());
+    };
+    fullscreen_listener => fullscreen_notify: |this: &mut XdgShell, event: *mut libc::c_void,|
+    unsafe {
+        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let compositor = match compositor_handle() {
+            Some(handle) => handle,
+            None => return
+        };
+        let event = SetFullscreenEvent::from_ptr(event as _);
+
+        manager.fullscreen_request(compositor,
+                                   surface.weak_reference(),
+                                   shell_surface.weak_reference(),
+                                   &event);
+    };
+    minimize_listener => minimize_notify: |this: &mut XdgShell, _event: *mut libc::c_void,|
+    unsafe {
+        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let compositor = match compositor_handle() {
+            Some(handle) => handle,
+            None => return
+        };
+
+        manager.minimize_request(compositor,
+                                 surface.weak_reference(),
+                                 shell_surface.weak_reference());
+    };
+    move_listener => move_notify: |this: &mut XdgShell, event: *mut libc::c_void,| unsafe {
+        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let compositor = match compositor_handle() {
+            Some(handle) => handle,
+            None => return
+        };
+        let event = MoveEvent::from_ptr(event as _);
+
+        manager.move_request(compositor,
+                             surface.weak_reference(),
+                             shell_surface.weak_reference(),
+                             &event);
+    };
+    resize_listener => resize_notify: |this: &mut XdgShell, event: *mut libc::c_void,| unsafe {
+        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let compositor = match compositor_handle() {
+            Some(handle) => handle,
+            None => return
+        };
+        let event = ResizeEvent::from_ptr(event as _);
+
+        manager.resize_request(compositor,
+                               surface.weak_reference(),
+                               shell_surface.weak_reference(),
+                               &event);
+    };
+    show_window_menu_listener => show_window_menu_notify: |this: &mut XdgShell,
+                                                           event: *mut libc::c_void,|
+    unsafe {
+        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let compositor = match compositor_handle() {
+            Some(handle) => handle,
+            None => return
+        };
+        let event = ShowWindowMenuEvent::from_ptr(event as _);
+
+        manager.show_window_menu_request(compositor,
+                                         surface.weak_reference(),
+                                         shell_surface.weak_reference(),
+                                         &event);
+    };
+]);
+
+impl XdgShell {
+    pub(crate) unsafe fn surface_ptr(&self) -> *mut wlr_xdg_surface {
+        self.data.0.as_ptr()
+    }
+
+    pub(crate) fn surface_mut(&mut self) -> XdgShellSurfaceHandle {
+        self.data.0.weak_reference()
+    }
+}

--- a/src/manager/xdg_shell_manager.rs
+++ b/src/manager/xdg_shell_manager.rs
@@ -135,6 +135,5 @@ wayland_listener!(XdgShellManager, (Vec<Box<XdgShell>>, Box<XdgShellManagerHandl
                           wl_list_remove,
                           &mut (*removed_shell.show_window_menu_listener()).link as *mut _ as _);
         }
-        // TODO Remove from list using iter().position
     };
 ]);

--- a/src/manager/xdg_shell_manager.rs
+++ b/src/manager/xdg_shell_manager.rs
@@ -1,0 +1,140 @@
+//! Manager for stable XDG shell client.
+
+use libc;
+use wayland_sys::server::WAYLAND_SERVER_HANDLE;
+use wayland_sys::server::signal::wl_signal_add;
+use wlroots_sys::{wlr_xdg_surface, wlr_xdg_surface_role::*};
+
+use super::xdg_shell_handler::XdgShell;
+use {Surface, XdgPopup, XdgShellHandler, XdgShellState::*, XdgShellSurface,
+     XdgShellSurfaceHandle, XdgTopLevel};
+use compositor::{compositor_handle, CompositorHandle};
+
+pub trait XdgShellManagerHandler {
+    /// Callback that is triggered when a new stable XDG shell surface appears.
+    fn new_surface(&mut self,
+                   CompositorHandle,
+                   XdgShellSurfaceHandle)
+                   -> Option<Box<XdgShellHandler>>;
+
+    /// Callback that is triggered when an stable XDG shell surface is destroyed.
+    fn surface_destroyed(&mut self, CompositorHandle, XdgShellSurfaceHandle);
+}
+
+wayland_listener!(XdgShellManager, (Vec<Box<XdgShell>>, Box<XdgShellManagerHandler>), [
+    add_listener => add_notify: |this: &mut XdgShellManager, data: *mut libc::c_void,|
+    unsafe {
+        let remove_listener = this.remove_listener() as *mut _ as _;
+        let (ref mut shells, ref mut manager) = this.data;
+        let data = data as *mut wlr_xdg_surface;
+        let compositor = match compositor_handle() {
+            Some(handle) => handle,
+            None => return
+        };
+        wlr_log!(L_DEBUG, "New xdg_shell_surface request {:p}", data);
+        let surface = Surface::new((*data).surface);
+        let state = unsafe {
+            match (*data).role {
+                WLR_XDG_SURFACE_ROLE_NONE => None,
+                WLR_XDG_SURFACE_ROLE_TOPLEVEL => {
+                    let toplevel = (*data).__bindgen_anon_1.toplevel;
+                    Some(TopLevel(XdgTopLevel::from_shell(data, toplevel)))
+                }
+                WLR_XDG_SURFACE_ROLE_POPUP => {
+                    let popup = (*data).__bindgen_anon_1.popup;
+                    Some(Popup(XdgPopup::from_shell(data, popup)))
+                }
+            }
+        };
+        let shell_surface = XdgShellSurface::new(data, state);
+
+        let new_surface_res = manager.new_surface(compositor,
+                                                  shell_surface.weak_reference());
+
+        if let Some(shell_surface_handler) = new_surface_res {
+
+            let mut shell_surface = XdgShell::new((shell_surface,
+                                                     surface,
+                                                     shell_surface_handler));
+
+            // Hook the destroy event into this manager.
+            wl_signal_add(&mut (*data).events.destroy as *mut _ as _,
+                          remove_listener);
+
+            // Hook the commit signal from the surface into the shell handler.
+            wl_signal_add(&mut (*(*data).surface).events.commit as *mut _ as _,
+                          shell_surface.commit_listener() as _);
+
+            wl_signal_add(&mut (*data).events.ping_timeout as *mut _ as _,
+                          shell_surface.ping_timeout_listener() as _);
+            wl_signal_add(&mut (*data).events.new_popup as *mut _ as _,
+                          shell_surface.new_popup_listener() as _);
+            let events = with_handles!([(shell_surface: {shell_surface.surface_mut()})] => {
+                match shell_surface.state() {
+                    None | Some(&mut Popup(_)) => None,
+                    Some(&mut TopLevel(ref mut toplevel)) => Some((*toplevel.as_ptr()).events)
+                }
+            }).expect("Cannot borrow xdg shell surface");
+            if let Some(mut events) = events {
+                wl_signal_add(&mut events.request_maximize as *mut _ as _,
+                              shell_surface.maximize_listener() as _);
+                wl_signal_add(&mut events.request_fullscreen as *mut _ as _,
+                              shell_surface.fullscreen_listener() as _);
+                wl_signal_add(&mut events.request_minimize as *mut _ as _,
+                              shell_surface.minimize_listener() as _);
+                wl_signal_add(&mut events.request_move as *mut _ as _,
+                              shell_surface.move_listener() as _);
+                wl_signal_add(&mut events.request_resize as *mut _ as _,
+                              shell_surface.resize_listener() as _);
+                wl_signal_add(&mut events.request_show_window_menu as *mut _ as _,
+                              shell_surface.show_window_menu_listener() as _);
+            }
+
+            shells.push(shell_surface);
+        }
+    };
+    remove_listener => remove_notify: |this: &mut XdgShellManager, data: *mut libc::c_void,|
+    unsafe {
+        let (ref mut shells, ref mut manager) = this.data;
+        let data = data as *mut wlr_xdg_surface;
+        let compositor = match compositor_handle() {
+            Some(handle) => handle,
+            None => return
+        };
+        if let Some(shell) = shells.iter_mut().find(|shell| shell.surface_ptr() == data) {
+            let mut shell_surface = shell.surface_mut();
+            manager.surface_destroyed(compositor, shell_surface);
+        }
+        if let Some(index) = shells.iter().position(|shell| shell.surface_ptr() == data) {
+            let mut removed_shell = shells.remove(index);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          &mut (*removed_shell.commit_listener()).link as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          &mut (*removed_shell.ping_timeout_listener()).link as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          &mut (*removed_shell.new_popup_listener()).link as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          &mut (*removed_shell.maximize_listener()).link as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          &mut (*removed_shell.fullscreen_listener()).link as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          &mut (*removed_shell.minimize_listener()).link as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          &mut (*removed_shell.move_listener()).link as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          &mut (*removed_shell.resize_listener()).link as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          &mut (*removed_shell.show_window_menu_listener()).link as *mut _ as _);
+        }
+        // TODO Remove from list using iter().position
+    };
+]);

--- a/src/manager/xdg_shell_v6_manager.rs
+++ b/src/manager/xdg_shell_v6_manager.rs
@@ -135,6 +135,5 @@ wayland_listener!(XdgV6ShellManager, (Vec<Box<XdgV6Shell>>, Box<XdgV6ShellManage
                           wl_list_remove,
                           &mut (*removed_shell.show_window_menu_listener()).link as *mut _ as _);
         }
-        // TODO Remove from list using iter().position
     };
 ]);

--- a/src/types/shell/mod.rs
+++ b/src/types/shell/mod.rs
@@ -1,5 +1,7 @@
 mod wl_shell;
 mod xdg_shell_v6;
+mod xdg_shell;
 
 pub use self::wl_shell::*;
 pub use self::xdg_shell_v6::*;
+pub use self::xdg_shell::*;

--- a/src/types/shell/xdg_shell.rs
+++ b/src/types/shell/xdg_shell.rs
@@ -1,0 +1,479 @@
+//! TODO Documentation
+
+use std::{panic, ptr};
+use std::cell::Cell;
+use std::rc::{Rc, Weak};
+
+use wlroots_sys::{wlr_xdg_popup, wlr_xdg_surface, wlr_xdg_surface_ping,
+                  wlr_xdg_surface_role, wlr_xdg_surface_send_close,
+                  wlr_xdg_surface_surface_at, wlr_xdg_toplevel,
+                  wlr_xdg_toplevel_set_activated, wlr_xdg_toplevel_set_fullscreen,
+                  wlr_xdg_toplevel_set_maximized, wlr_xdg_toplevel_set_resizing,
+                  wlr_xdg_toplevel_set_size, wlr_xdg_toplevel_state,
+                  wlr_xdg_surface_for_each_surface, wlr_surface, wlr_xdg_surface_from_wlr_surface};
+
+use {Area, SeatHandle, SurfaceHandle};
+use errors::{HandleErr, HandleResult};
+use utils::c_to_rust_string;
+use libc::c_void;
+
+/// Used internally to reclaim a handle from just a *mut wlr_xdg_surface.
+struct XdgShellSurfaceState {
+    handle: Weak<Cell<bool>>,
+    shell_state: Option<XdgShellState>
+}
+
+#[derive(Debug, Eq, PartialEq, Hash)]
+pub struct XdgTopLevel {
+    shell_surface: *mut wlr_xdg_surface,
+    toplevel: *mut wlr_xdg_toplevel
+}
+
+#[derive(Debug, Eq, PartialEq, Hash)]
+pub struct XdgPopup {
+    shell_surface: *mut wlr_xdg_surface,
+    popup: *mut wlr_xdg_popup
+}
+
+/// A tagged enum of the different roles used by the xdg shell.
+///
+/// Uses the tag to disambiguate the union in `wlr_xdg_surface`.
+#[derive(Debug, Eq, PartialEq, Hash)]
+pub enum XdgShellState {
+    TopLevel(XdgTopLevel),
+    Popup(XdgPopup)
+}
+
+#[derive(Debug)]
+pub struct XdgShellSurface {
+    liveliness: Rc<Cell<bool>>,
+    state: Option<XdgShellState>,
+    shell_surface: *mut wlr_xdg_surface
+}
+
+#[derive(Debug)]
+pub struct XdgShellSurfaceHandle {
+    state: Option<XdgShellState>,
+    handle: Weak<Cell<bool>>,
+    shell_surface: *mut wlr_xdg_surface
+}
+
+impl Clone for XdgShellSurfaceHandle {
+    fn clone(&self) -> Self {
+        let state = match self.state {
+            None => None,
+            Some(ref state) => Some(unsafe { state.clone() })
+        };
+        XdgShellSurfaceHandle { state,
+                                  handle: self.handle.clone(),
+                                  shell_surface: self.shell_surface }
+    }
+}
+
+impl XdgShellSurface {
+    pub(crate) unsafe fn new<T>(shell_surface: *mut wlr_xdg_surface, state: T) -> Self
+        where T: Into<Option<XdgShellState>>
+    {
+        let state = state.into();
+        // TODO FIXME Free state in drop impl when Rc == 1
+        (*shell_surface).data = ptr::null_mut();
+        let liveliness = Rc::new(Cell::new(false));
+        let shell_state =
+            Box::new(XdgShellSurfaceState { handle: Rc::downgrade(&liveliness),
+                                              shell_state: match state {
+                                                  None => None,
+                                                  Some(ref state) => Some(state.clone())
+                                              } });
+        (*shell_surface).data = Box::into_raw(shell_state) as *mut _;
+        XdgShellSurface { liveliness,
+                            state: state,
+                            shell_surface }
+    }
+
+    pub(crate) unsafe fn as_ptr(&self) -> *mut wlr_xdg_surface {
+        self.shell_surface
+    }
+
+    unsafe fn from_handle(handle: &XdgShellSurfaceHandle) -> HandleResult<Self> {
+        let liveliness = handle.handle
+                               .upgrade()
+                               .ok_or_else(|| HandleErr::AlreadyDropped)?;
+        Ok(XdgShellSurface { liveliness,
+                               state: handle.clone().state,
+                               shell_surface: handle.as_ptr() })
+    }
+
+    /// Gets the surface used by this XDG shell.
+    pub fn surface(&mut self) -> SurfaceHandle {
+        unsafe {
+            let surface = (*self.shell_surface).surface;
+            if surface.is_null() {
+                panic!("xdg shell had a null surface!")
+            }
+            SurfaceHandle::from_ptr(surface)
+        }
+    }
+
+    /// Get the role of this XDG surface.
+    pub fn role(&self) -> wlr_xdg_surface_role {
+        unsafe { (*self.shell_surface).role }
+    }
+
+    pub fn state(&mut self) -> Option<&mut XdgShellState> {
+        self.state.as_mut()
+    }
+
+    /// Determines if this XDG shell surface has been configured or not.
+    pub fn configured(&self) -> bool {
+        unsafe { (*self.shell_surface).configured }
+    }
+
+    pub fn added(&self) -> bool {
+        unsafe { (*self.shell_surface).added }
+    }
+
+    pub fn configure_serial(&self) -> u32 {
+        unsafe { (*self.shell_surface).configure_serial }
+    }
+
+    pub fn configure_next_serial(&self) -> u32 {
+        unsafe { (*self.shell_surface).configure_next_serial }
+    }
+
+    pub fn has_next_geometry(&self) -> bool {
+        unsafe { (*self.shell_surface).has_next_geometry }
+    }
+
+    pub fn next_geometry(&self) -> Area {
+        unsafe { Area::from_box((*self.shell_surface).next_geometry) }
+    }
+
+    pub fn geometry(&self) -> Area {
+        unsafe { Area::from_box((*self.shell_surface).geometry) }
+    }
+
+    /// Send a ping to the surface.
+    ///
+    /// If the surface does not respond with a pong within a reasonable amount of time,
+    /// the ping timeout event will be emitted.
+    pub fn ping(&mut self) {
+        unsafe {
+            wlr_xdg_surface_ping(self.shell_surface);
+        }
+    }
+
+    /// Find a surface within this surface at the surface-local coordinates.
+    ///
+    /// Returns the popup and coordinates in the topmost surface coordinate system
+    /// or None if no popup is found at that location.
+    pub fn surface_at(&mut self,
+                      sx: f64,
+                      sy: f64,
+                      sub_sx: &mut f64,
+                      sub_sy: &mut f64)
+                      -> Option<SurfaceHandle> {
+        unsafe {
+            let sub_surface =
+                wlr_xdg_surface_surface_at(self.shell_surface, sx, sy, sub_sx, sub_sy);
+            if sub_surface.is_null() {
+                None
+            } else {
+                Some(SurfaceHandle::from_ptr(sub_surface))
+            }
+        }
+    }
+
+    pub fn for_each_surface(&self, mut iterator: &mut FnMut(SurfaceHandle, i32, i32)) {
+        unsafe {
+            unsafe extern "C" fn c_iterator(wlr_surface: *mut wlr_surface, sx: i32, sy: i32, data: *mut c_void) {
+                let iterator = &mut *(data as *mut &mut FnMut(SurfaceHandle, i32, i32));
+                let surface = SurfaceHandle::from_ptr(wlr_surface);
+                iterator(surface, sx, sy);
+            }
+            let iterator_ptr: *mut c_void = &mut iterator as *mut _ as *mut c_void;
+            wlr_xdg_surface_for_each_surface(self.shell_surface, Some(c_iterator), iterator_ptr);
+        }
+    }
+
+    /// Creates a weak reference to an `XdgShellSurface`.
+    ///
+    /// # Panics
+    /// If this `XdgShellSurface` is a previously upgraded `XdgShellSurfaceHandle`,
+    /// then this function will panic.
+    pub fn weak_reference(&self) -> XdgShellSurfaceHandle {
+        XdgShellSurfaceHandle { handle: Rc::downgrade(&self.liveliness),
+                                  state: match self.state {
+                                      None => None,
+                                      Some(ref state) => unsafe { Some(state.clone()) }
+                                  },
+                                  shell_surface: self.shell_surface }
+    }
+}
+
+impl XdgShellSurfaceHandle {
+    /// Constructs a new XdgShellSurfaceHandle that is always invalid. Calling `run` on this
+    /// will always fail.
+    ///
+    /// This is useful for pre-filling a value before it's provided by the server, or
+    /// for mocking/testing.
+    pub fn new() -> Self {
+        unsafe {
+            XdgShellSurfaceHandle { handle: Weak::new(),
+                                      state: None,
+                                      shell_surface: ptr::null_mut() }
+        }
+    }
+
+    /// Creates a XdgShellSurfaceHandle from the raw pointer, using the saved
+    /// user data to recreate the memory model.
+    pub(crate) unsafe fn from_ptr(shell_surface: *mut wlr_xdg_surface) -> Self {
+        let data = (*shell_surface).data as *mut XdgShellSurfaceState;
+        if data.is_null() {
+            panic!("Cannot construct handle from a shell surface that has not been set up!");
+        }
+        let handle = (*data).handle.clone();
+        let state = match (*data).shell_state {
+            None => None,
+            Some(ref state) => Some(unsafe { state.clone() })
+        };
+        XdgShellSurfaceHandle { handle,
+                                  state,
+                                  shell_surface }
+    }
+
+    /// Upgrades the wayland shell handle to a reference to the backing `XdgShellSurface`.
+    ///
+    /// # Unsafety
+    /// This function is unsafe, because it creates an unbound `XdgShellSurface`
+    /// which may live forever..
+    /// But no surface lives forever and might be disconnected at any time.
+    pub(crate) unsafe fn upgrade(&self) -> HandleResult<XdgShellSurface> {
+        self.handle.upgrade()
+            .ok_or(HandleErr::AlreadyDropped)
+            // NOTE
+            // We drop the Rc here because having two would allow a dangling
+            // pointer to exist!
+            .and_then(|check| {
+                let shell_surface = XdgShellSurface::from_handle(self)?;
+                if check.get() {
+                    return Err(HandleErr::AlreadyBorrowed)
+                }
+                check.set(true);
+                Ok(shell_surface)
+            })
+    }
+
+    /// Run a function on the referenced XdgShellSurface, if it still exists
+    ///
+    /// Returns the result of the function, if successful
+    ///
+    /// # Safety
+    /// By enforcing a rather harsh limit on the lifetime of the output
+    /// to a short lived scope of an anonymous function,
+    /// this function ensures the XdgShellSurface does not live longer
+    /// than it exists.
+    ///
+    /// # Panics
+    /// This function will panic if multiple mutable borrows are detected.
+    /// This will happen if you call `upgrade` directly within this callback,
+    /// or if you run this function within the another run to the same `Output`.
+    ///
+    /// So don't nest `run` calls and everything will be ok :).
+    pub fn run<F, R>(&mut self, runner: F) -> HandleResult<R>
+        where F: FnOnce(&mut XdgShellSurface) -> R
+    {
+        let mut xdg_surface = unsafe { self.upgrade()? };
+        let res = panic::catch_unwind(panic::AssertUnwindSafe(|| runner(&mut xdg_surface)));
+        self.handle.upgrade().map(|check| {
+                                      // Sanity check that it hasn't been tampered with.
+                                      if !check.get() {
+                                          wlr_log!(L_ERROR,
+                                                   "After running XdgShellSurface callback, \
+                                                    mutable lock was false for: {:?}",
+                                                   xdg_surface);
+                                          panic!("Lock in incorrect state!");
+                                      }
+                                      check.set(false);
+                                  });
+        match res {
+            Ok(res) => Ok(res),
+            Err(err) => panic::resume_unwind(err)
+        }
+    }
+
+    unsafe fn as_ptr(&self) -> *mut wlr_xdg_surface {
+        self.shell_surface
+    }
+}
+
+impl Default for XdgShellSurfaceHandle {
+    fn default() -> Self {
+        XdgShellSurfaceHandle::new()
+    }
+}
+
+impl PartialEq for XdgShellSurfaceHandle {
+    fn eq(&self, other: &XdgShellSurfaceHandle) -> bool {
+        self.shell_surface == other.shell_surface
+    }
+}
+
+impl Eq for XdgShellSurfaceHandle {}
+
+impl XdgTopLevel {
+    pub(crate) unsafe fn from_shell(shell_surface: *mut wlr_xdg_surface,
+                                    toplevel: *mut wlr_xdg_toplevel)
+                                    -> XdgTopLevel {
+        XdgTopLevel { shell_surface,
+                        toplevel }
+    }
+
+    /// Get the title associated with this XDG shell toplevel.
+    pub fn title(&self) -> String {
+        unsafe { c_to_rust_string((*self.toplevel).title).expect("Could not parse class as UTF-8") }
+    }
+
+    /// Get the app id associated with this XDG shell toplevel.
+    pub fn app_id(&self) -> String {
+        unsafe {
+            c_to_rust_string((*self.toplevel).app_id).expect("Could not parse class as UTF-8")
+        }
+    }
+
+    /// Get a handle to the base surface of the xdg tree.
+    pub fn base(&self) -> XdgShellSurfaceHandle {
+        unsafe { XdgShellSurfaceHandle::from_ptr((*self.toplevel).base) }
+    }
+
+    /// Get a handle to the parent surface of the xdg tree.
+    pub fn parent(&self) -> XdgShellSurfaceHandle {
+        unsafe { XdgShellSurfaceHandle::from_ptr((*self.toplevel).parent) }
+    }
+
+    pub fn added(&self) -> bool {
+        unsafe { (*self.toplevel).added }
+    }
+
+    /// Get the pending client state.
+    pub fn client_pending_state(&self) -> wlr_xdg_toplevel_state {
+        unsafe { (*self.toplevel).client_pending }
+    }
+
+    /// Get the pending server state.
+    pub fn server_pending_state(&self) -> wlr_xdg_toplevel_state {
+        unsafe { (*self.toplevel).server_pending }
+    }
+
+    /// Get the current configure state.
+    pub fn current_state(&self) -> wlr_xdg_toplevel_state {
+        unsafe { (*self.toplevel).current }
+    }
+
+    /// Request that this toplevel surface be the given size.
+    ///
+    /// Returns the associated configure serial.
+    pub fn set_size(&mut self, width: u32, height: u32) -> u32 {
+        unsafe { wlr_xdg_toplevel_set_size(self.shell_surface, width, height) }
+    }
+
+    /// Request that this toplevel surface show itself in an activated or deactivated
+    /// state.
+    ///
+    /// Returns the associated configure serial.
+    pub fn set_activated(&mut self, activated: bool) -> u32 {
+        unsafe { wlr_xdg_toplevel_set_activated(self.shell_surface, activated) }
+    }
+
+    /// Request that this toplevel surface consider itself maximized or not
+    /// maximized.
+    ///
+    /// Returns the associated configure serial.
+    pub fn set_maximized(&mut self, maximized: bool) -> u32 {
+        unsafe { wlr_xdg_toplevel_set_maximized(self.shell_surface, maximized) }
+    }
+
+    /// Request that this toplevel surface consider itself fullscreen or not
+    /// fullscreen.
+    ///
+    /// Returns the associated configure serial.
+    pub fn set_fullscreen(&mut self, fullscreen: bool) -> u32 {
+        unsafe { wlr_xdg_toplevel_set_fullscreen(self.shell_surface, fullscreen) }
+    }
+
+    /// Request that this toplevel surface consider itself to be resizing or not
+    /// resizing.
+    ///
+    /// Returns the associated configure serial.
+    pub fn set_resizing(&mut self, resizing: bool) -> u32 {
+        unsafe { wlr_xdg_toplevel_set_resizing(self.shell_surface, resizing) }
+    }
+
+    /// Request that this toplevel surface closes.
+    pub fn close(&mut self) {
+        unsafe { wlr_xdg_surface_send_close(self.shell_surface) }
+    }
+
+    pub(crate) unsafe fn as_ptr(&self) -> *mut wlr_xdg_toplevel {
+        self.toplevel
+    }
+}
+
+impl XdgPopup {
+    pub(crate) unsafe fn from_shell(shell_surface: *mut wlr_xdg_surface,
+                                    popup: *mut wlr_xdg_popup)
+                                    -> XdgPopup {
+        XdgPopup { shell_surface,
+                     popup }
+    }
+
+    /// Get a handle to the base surface of the xdg tree.
+    pub fn base(&self) -> XdgShellSurfaceHandle {
+        unsafe { XdgShellSurfaceHandle::from_ptr((*self.popup).base) }
+    }
+
+    /// Get a handle to the parent surface of the xdg tree.
+    pub fn parent(&self) -> XdgShellSurfaceHandle {
+        // TODO FIXME
+        // This is a hack until https://github.com/swaywm/wlroots/pull/1009 is merged
+        unsafe { XdgShellSurfaceHandle::from_ptr(wlr_xdg_surface_from_wlr_surface((*self.popup).parent)) }
+    }
+
+    pub fn committed(&self) -> bool {
+        unsafe { (*self.popup).committed }
+    }
+
+    /// Get a handle to the seat associated with this popup.
+    pub fn seat_handle(&self) -> Option<SeatHandle> {
+        unsafe {
+            let seat = (*self.popup).seat;
+            if seat.is_null() {
+                None
+            } else {
+                Some(SeatHandle::from_ptr(seat))
+            }
+        }
+    }
+
+    pub fn geometry(&self) -> Area {
+        unsafe { Area::from_box((*self.popup).geometry) }
+    }
+}
+
+impl XdgShellState {
+    /// Unsafe copy of the pointer
+    unsafe fn clone(&self) -> Self {
+        use XdgShellState::*;
+        match *self {
+            TopLevel(XdgTopLevel { shell_surface,
+                                     toplevel }) => {
+                TopLevel(XdgTopLevel { shell_surface,
+                                         toplevel })
+            }
+            Popup(XdgPopup { shell_surface,
+                               popup }) => {
+                Popup(XdgPopup { shell_surface,
+                                   popup })
+            }
+        }
+    }
+}

--- a/src/types/surface/surface.rs
+++ b/src/types/surface/surface.rs
@@ -7,7 +7,8 @@ use wayland_sys::server::WAYLAND_SERVER_HANDLE;
 use wayland_sys::server::signal::wl_signal_add;
 use wlroots_sys::{timespec, wlr_subsurface, wlr_surface, wlr_surface_get_root_surface,
                   wlr_surface_has_buffer, wlr_surface_point_accepts_input, wlr_surface_send_enter,
-                  wlr_surface_send_frame_done, wlr_surface_send_leave, wlr_surface_surface_at};
+                  wlr_surface_send_frame_done, wlr_surface_send_leave, wlr_surface_surface_at,
+                  wlr_surface_is_xdg_surface};
 
 use super::{Subsurface, SubsurfaceHandle, SubsurfaceManager, SurfaceState};
 use Output;
@@ -157,6 +158,14 @@ impl Surface {
     /// local coordinates.
     pub fn accepts_input(&self, sx: c_double, sy: c_double) -> bool {
         unsafe { wlr_surface_point_accepts_input(self.surface, sx, sy) }
+    }
+
+    /// Determines if this surface is an XDG surface.
+    ///
+    /// This is really only useful for getting the parent of popups from stable XDG
+    /// shell surfaces.
+    pub fn is_xdg_surface(&self) -> bool {
+        unsafe { wlr_surface_is_xdg_surface(self.surface) }
     }
 
     /// Find a subsurface within this surface at the surface-local coordinates.

--- a/wlroots-sys/src/wlroots.h
+++ b/wlroots-sys/src/wlroots.h
@@ -39,6 +39,7 @@
 #include <wlr/types/wlr_touch.h>
 #include <wlr/types/wlr_wl_shell.h>
 #include <wlr/types/wlr_xdg_shell_v6.h>
+#include <wlr/types/wlr_xdg_shell.h>
 #include <wlr/types/wlr_xcursor_manager.h>
 
 /// Util includes


### PR DESCRIPTION
Added support for stable xdg shell support.

~Blocked by https://github.com/swaywm/wlroots/pull/1009, as that will change the API slightly.~

Turns out a surface is returned because a popup parent can be a layer-shell surface. This is allowed by the protocol.

The API has been changed to reflect this for the stable xdg code. To convert to an xdg shell from a surface, you can use the `XdgShellSurfaceHandle::from_surface` function.

Fixes #95 