### PR TITLE
Surface standalone

### DIFF
--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -30,6 +30,8 @@ pub trait CompositorHandler {
     fn on_shutdown(&mut self) {}
 }
 
+impl CompositorHandler for () {}
+
 wayland_listener!(InternalCompositor, Box<CompositorHandler>, [
     new_surface_listener => new_surface_notify: |this: &mut InternalCompositor,
                                                  surface_ptr: *mut libc::c_void,|
@@ -67,7 +69,6 @@ wayland_listener!(InternalCompositor, Box<CompositorHandler>, [
                                            _data: *mut libc::c_void,|
     unsafe {
         let handler = &mut this.data;
-        assert!(COMPOSITOR_PTR.is_null(), "COMPOSITOR_PTR was not NULL!");
         handler.on_shutdown();
     };
 ]);
@@ -291,7 +292,8 @@ impl CompositorBuilder {
             };
 
             // Set up compositor handler, if the user provided it.
-            let compositor_handler = self.compositor_handler.map(|handler| {
+            let compositor_handler = self.compositor_handler.or_else(|| Some(Box::new(())));
+            let compositor_handler = compositor_handler.map(|handler| {
                 let mut compositor_handler = InternalCompositor::new(handler);
                 wl_signal_add(&mut (*compositor).events.new_surface as *mut _ as _,
                               compositor_handler.new_surface_listener() as *mut _ as _);

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -4,7 +4,7 @@
 use libc;
 use std::{env, panic, ptr, any::Any, cell::{Cell, UnsafeCell}, ffi::CStr, rc::{Rc, Weak}};
 
-use {DataDeviceManager, SurfaceHandle, XWaylandManagerHandler, XWaylandServer};
+use {DataDeviceManager, Surface, SurfaceHandle, XWaylandManagerHandler, XWaylandServer};
 use errors::{HandleErr, HandleResult};
 use extensions::server_decoration::ServerDecorationManager;
 use manager::{InputManager, InputManagerHandler, OutputManager, OutputManagerHandler,
@@ -24,7 +24,7 @@ pub(crate) static mut COMPOSITOR_PTR: *mut Compositor = 0 as *mut _;
 
 pub trait CompositorHandler {
     /// Callback that's triggered when a surface is provided to the compositor.
-    fn new_surface(&mut self, CompositorHandle, &mut SurfaceHandle) {}
+    fn new_surface(&mut self, CompositorHandle, SurfaceHandle) {}
 
     /// Callback that's triggered during shutdown.
     fn on_shutdown(&mut self) {}
@@ -32,13 +32,37 @@ pub trait CompositorHandler {
 
 wayland_listener!(InternalCompositor, Box<CompositorHandler>, [
     new_surface_listener => new_surface_notify: |this: &mut InternalCompositor,
-                                                 surface: *mut libc::c_void,|
+                                                 surface_ptr: *mut libc::c_void,|
     unsafe {
+        let destroy_listener = this.surface_destroy_listener() as *mut _ as _;
         let handler = &mut this.data;
+        let surface_ptr = surface_ptr as _;
         let compositor = (&mut *COMPOSITOR_PTR).weak_reference();
-        let mut surface = SurfaceHandle::from_ptr(surface as _);
-        handler.new_surface(compositor, &mut surface);
+        let surface = Surface::new(surface_ptr);
+        handler.new_surface(compositor.clone(), surface.weak_reference());
+        with_handles!([(compositor: {compositor})] => {
+            compositor.surfaces.push(surface);
+            wl_signal_add(&mut (*surface_ptr).events.destroy as *mut _ as _,
+                          destroy_listener);
+        }).unwrap();
     };
+    surface_destroy_listener => surface_destroy_notify: |_this: &mut InternalCompositor,
+                                                         surface_ptr: *mut libc::c_void,|
+    unsafe {
+        let surface_ptr = surface_ptr as _;
+        let compositor = match compositor_handle() {
+            Some(handle) => handle,
+            None => return
+        };
+        with_handles!([(compositor: {compositor})] => {
+            let find_index = compositor.surfaces.iter().position(|s| s.as_ptr() == surface_ptr);
+            if let Some(index) = find_index {
+                compositor.surfaces.remove(index);
+            }
+        }).unwrap();
+
+    };
+
     shutdown_listener => shutdown_notify: |this: &mut InternalCompositor,
                                            _data: *mut libc::c_void,|
     unsafe {
@@ -101,6 +125,8 @@ pub struct Compositor {
     data_device_manager: Option<DataDeviceManager>,
     /// The error from the panic, if there was one.
     panic_error: Option<Box<Any + Send>>,
+    /// List of surfaces. This is managed by the compositor.
+    surfaces: Vec<Surface>,
     /// Custom function to run at shutdown (or when a panic occurs).
     user_terminate: Option<fn()>,
     /// Lock used to borrow the compositor globally.
@@ -368,6 +394,7 @@ impl CompositorBuilder {
                                           renderer,
                                           xwayland,
                                           user_terminate,
+                                          surfaces: Vec::new(),
                                           panic_error: None,
                                           lock: Rc::new(Cell::new(false)) };
             compositor.set_lock(true);

--- a/src/manager/wl_shell_handler.rs
+++ b/src/manager/wl_shell_handler.rs
@@ -3,7 +3,7 @@
 use libc;
 use wayland_sys::server::WAYLAND_SERVER_HANDLE;
 
-use {Surface, SurfaceHandle, WlShellSurface, WlShellSurfaceHandle};
+use {SurfaceHandle, WlShellSurface, WlShellSurfaceHandle};
 use compositor::{compositor_handle, CompositorHandle};
 use wl_shell_events::{FullscreenEvent, MaximizeEvent, MoveEvent, ResizeEvent};
 
@@ -54,19 +54,20 @@ pub trait WlShellHandler {
     fn class_change(&mut self, CompositorHandle, SurfaceHandle, WlShellSurfaceHandle) {}
 }
 
-wayland_listener!(WlShell, (WlShellSurface, Surface, Box<WlShellHandler>), [
+wayland_listener!(WlShell, (WlShellSurface, Box<WlShellHandler>), [
     destroy_listener => destroy_notify: |this: &mut WlShell, _data: *mut libc::c_void,|
     unsafe {
         // TODO NLL
         {
-            let (ref shell_surface, ref surface, ref mut manager) = this.data;
+            let (ref mut shell_surface, ref mut manager) = this.data;
+            let surface = shell_surface.surface();
             let compositor = match compositor_handle() {
                 Some(handle) => handle,
                 None => return
             };
 
             manager.destroy(compositor,
-                            surface.weak_reference(),
+                            surface,
                             shell_surface.weak_reference());
         }
         ffi_dispatch!(WAYLAND_SERVER_HANDLE,
@@ -105,19 +106,21 @@ wayland_listener!(WlShell, (WlShellSurface, Surface, Box<WlShellHandler>), [
     };
     ping_timeout_listener => ping_timeout_notify: |this: &mut WlShell, _data: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
 
         manager.ping_timeout(compositor,
-                             surface.weak_reference(),
+                             surface,
                              shell_surface.weak_reference());
     };
     request_move_listener => request_move_notify: |this: &mut WlShell, data: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
@@ -125,14 +128,15 @@ wayland_listener!(WlShell, (WlShellSurface, Surface, Box<WlShellHandler>), [
         let event = MoveEvent::from_ptr(data as _);
 
         manager.move_request(compositor,
-                             surface.weak_reference(),
+                             surface,
                              shell_surface.weak_reference(),
                              &event);
     };
     request_resize_listener => request_resize_notify: |this: &mut WlShell,
                                                        data: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
@@ -140,14 +144,15 @@ wayland_listener!(WlShell, (WlShellSurface, Surface, Box<WlShellHandler>), [
         let event = ResizeEvent::from_ptr(data as _);
 
         manager.resize_request(compositor,
-                               surface.weak_reference(),
+                               surface,
                                shell_surface.weak_reference(),
                                &event);
     };
     request_fullscreen_listener => request_fullscreen_notify: |this: &mut WlShell,
                                                                data: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
@@ -155,14 +160,15 @@ wayland_listener!(WlShell, (WlShellSurface, Surface, Box<WlShellHandler>), [
         let event = FullscreenEvent::from_ptr(data as _);
 
         manager.fullscreen_request(compositor,
-                                   surface.weak_reference(),
+                                   surface,
                                    shell_surface.weak_reference(),
                                    &event);
     };
     request_maximize_listener => request_maximize_notify: |this: &mut WlShell,
                                                            data: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
@@ -170,44 +176,47 @@ wayland_listener!(WlShell, (WlShellSurface, Surface, Box<WlShellHandler>), [
         let event = MaximizeEvent::from_ptr(data as _);
 
         manager.maximize_request(compositor,
-                                 surface.weak_reference(),
+                                 surface,
                                  shell_surface.weak_reference(),
                                  &event);
     };
     set_state_listener => set_state_notify: |this: &mut WlShell, _data: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
 
         manager.state_change(compositor,
-                             surface.weak_reference(),
+                             surface,
                              shell_surface.weak_reference());
     };
     set_title_listener => set_title_notify: |this: &mut WlShell, _data: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
 
         manager.title_change(compositor,
-                             surface.weak_reference(),
+                             surface,
                              shell_surface.weak_reference());
     };
     set_class_listener => set_class_notify: |this: &mut WlShell, _data: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
 
         manager.class_change(compositor,
-                             surface.weak_reference(),
+                             surface,
                              shell_surface.weak_reference());
     };
 ]);

--- a/src/manager/wl_shell_manager.rs
+++ b/src/manager/wl_shell_manager.rs
@@ -5,7 +5,7 @@ use wayland_sys::server::signal::wl_signal_add;
 use wlroots_sys::wlr_wl_shell_surface;
 
 use super::wl_shell_handler::WlShell;
-use {Surface, SurfaceHandle, WlShellHandler, WlShellSurface, WlShellSurfaceHandle};
+use {SurfaceHandle, WlShellHandler, WlShellSurface, WlShellSurfaceHandle};
 use compositor::{compositor_handle, CompositorHandle};
 
 /// Handles making new Wayland shells as reported by clients.
@@ -27,15 +27,15 @@ wayland_listener!(WlShellManager, Box<WlShellManagerHandler>, [
             Some(handle) => handle,
             None => return
         };
-        let surface = Surface::new((*data).surface);
+        let surface = SurfaceHandle::from_ptr((*data).surface);
         let shell_surface = WlShellSurface::new(data);
 
         let new_surface_res = manager.new_surface(compositor,
                                                   shell_surface.weak_reference(),
-                                                  surface.weak_reference());
+                                                  surface);
 
         if let Some(shell_surface_handler) = new_surface_res {
-            let mut shell_surface = WlShell::new((shell_surface, surface, shell_surface_handler));
+            let mut shell_surface = WlShell::new((shell_surface, shell_surface_handler));
             // Add the destroy event to this handler.
             wl_signal_add(&mut (*data).events.destroy as *mut _ as _,
                           shell_surface.destroy_listener() as _);

--- a/src/manager/xdg_shell_handler.rs
+++ b/src/manager/xdg_shell_handler.rs
@@ -4,7 +4,7 @@ use libc;
 
 use wlroots_sys::wlr_xdg_surface;
 
-use {Surface, SurfaceHandle, XdgShellSurface, XdgShellSurfaceHandle};
+use {SurfaceHandle, XdgShellSurface, XdgShellSurfaceHandle};
 use compositor::{compositor_handle, CompositorHandle};
 use xdg_shell_events::{MoveEvent, ResizeEvent, SetFullscreenEvent, ShowWindowMenuEvent};
 
@@ -64,58 +64,63 @@ pub trait XdgShellHandler {
     }
 }
 
-wayland_listener!(XdgShell, (XdgShellSurface, Surface, Box<XdgShellHandler>), [
+wayland_listener!(XdgShell, (XdgShellSurface, Box<XdgShellHandler>), [
     commit_listener => commit_notify: |this: &mut XdgShell, _data: *mut libc::c_void,| unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
 
         manager.on_commit(compositor,
-                          surface.weak_reference(),
+                          surface,
                           shell_surface.weak_reference());
     };
     ping_timeout_listener => ping_timeout_notify: |this: &mut XdgShell,
                                                    _data: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
 
         manager.ping_timeout(compositor,
-                             surface.weak_reference(),
+                             surface,
                              shell_surface.weak_reference());
     };
     new_popup_listener => new_popup_notify: |this: &mut XdgShell, _data: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
 
         manager.new_popup(compositor,
-                          surface.weak_reference(),
+                          surface,
                           shell_surface.weak_reference());
     };
     maximize_listener => maximize_notify: |this: &mut XdgShell, _event: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
 
         manager.maximize_request(compositor,
-                                 surface.weak_reference(),
+                                 surface,
                                  shell_surface.weak_reference());
     };
     fullscreen_listener => fullscreen_notify: |this: &mut XdgShell, event: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
@@ -123,24 +128,26 @@ wayland_listener!(XdgShell, (XdgShellSurface, Surface, Box<XdgShellHandler>), [
         let event = SetFullscreenEvent::from_ptr(event as _);
 
         manager.fullscreen_request(compositor,
-                                   surface.weak_reference(),
+                                   surface,
                                    shell_surface.weak_reference(),
                                    &event);
     };
     minimize_listener => minimize_notify: |this: &mut XdgShell, _event: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
 
         manager.minimize_request(compositor,
-                                 surface.weak_reference(),
+                                 surface,
                                  shell_surface.weak_reference());
     };
     move_listener => move_notify: |this: &mut XdgShell, event: *mut libc::c_void,| unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
@@ -148,12 +155,13 @@ wayland_listener!(XdgShell, (XdgShellSurface, Surface, Box<XdgShellHandler>), [
         let event = MoveEvent::from_ptr(event as _);
 
         manager.move_request(compositor,
-                             surface.weak_reference(),
+                             surface,
                              shell_surface.weak_reference(),
                              &event);
     };
     resize_listener => resize_notify: |this: &mut XdgShell, event: *mut libc::c_void,| unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
@@ -161,14 +169,15 @@ wayland_listener!(XdgShell, (XdgShellSurface, Surface, Box<XdgShellHandler>), [
         let event = ResizeEvent::from_ptr(event as _);
 
         manager.resize_request(compositor,
-                               surface.weak_reference(),
+                               surface,
                                shell_surface.weak_reference(),
                                &event);
     };
     show_window_menu_listener => show_window_menu_notify: |this: &mut XdgShell,
                                                            event: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
@@ -176,7 +185,7 @@ wayland_listener!(XdgShell, (XdgShellSurface, Surface, Box<XdgShellHandler>), [
         let event = ShowWindowMenuEvent::from_ptr(event as _);
 
         manager.show_window_menu_request(compositor,
-                                         surface.weak_reference(),
+                                         surface,
                                          shell_surface.weak_reference(),
                                          &event);
     };

--- a/src/manager/xdg_shell_manager.rs
+++ b/src/manager/xdg_shell_manager.rs
@@ -6,7 +6,7 @@ use wayland_sys::server::signal::wl_signal_add;
 use wlroots_sys::{wlr_xdg_surface, wlr_xdg_surface_role::*};
 
 use super::xdg_shell_handler::XdgShell;
-use {SurfaceHandle, XdgPopup, XdgShellHandler, XdgShellState::*, XdgShellSurface,
+use {XdgPopup, XdgShellHandler, XdgShellState::*, XdgShellSurface,
      XdgShellSurfaceHandle, XdgTopLevel};
 use compositor::{compositor_handle, CompositorHandle};
 
@@ -32,7 +32,6 @@ wayland_listener!(XdgShellManager, (Vec<Box<XdgShell>>, Box<XdgShellManagerHandl
             None => return
         };
         wlr_log!(L_DEBUG, "New xdg_shell_surface request {:p}", data);
-        let surface = SurfaceHandle::from_ptr((*data).surface);
         let state = unsafe {
             match (*data).role {
                 WLR_XDG_SURFACE_ROLE_NONE => None,

--- a/src/manager/xdg_shell_manager.rs
+++ b/src/manager/xdg_shell_manager.rs
@@ -6,7 +6,7 @@ use wayland_sys::server::signal::wl_signal_add;
 use wlroots_sys::{wlr_xdg_surface, wlr_xdg_surface_role::*};
 
 use super::xdg_shell_handler::XdgShell;
-use {Surface, XdgPopup, XdgShellHandler, XdgShellState::*, XdgShellSurface,
+use {SurfaceHandle, XdgPopup, XdgShellHandler, XdgShellState::*, XdgShellSurface,
      XdgShellSurfaceHandle, XdgTopLevel};
 use compositor::{compositor_handle, CompositorHandle};
 
@@ -32,7 +32,7 @@ wayland_listener!(XdgShellManager, (Vec<Box<XdgShell>>, Box<XdgShellManagerHandl
             None => return
         };
         wlr_log!(L_DEBUG, "New xdg_shell_surface request {:p}", data);
-        let surface = Surface::new((*data).surface);
+        let surface = SurfaceHandle::from_ptr((*data).surface);
         let state = unsafe {
             match (*data).role {
                 WLR_XDG_SURFACE_ROLE_NONE => None,
@@ -53,9 +53,7 @@ wayland_listener!(XdgShellManager, (Vec<Box<XdgShell>>, Box<XdgShellManagerHandl
 
         if let Some(shell_surface_handler) = new_surface_res {
 
-            let mut shell_surface = XdgShell::new((shell_surface,
-                                                     surface,
-                                                     shell_surface_handler));
+            let mut shell_surface = XdgShell::new((shell_surface, shell_surface_handler));
 
             // Hook the destroy event into this manager.
             wl_signal_add(&mut (*data).events.destroy as *mut _ as _,

--- a/src/manager/xdg_shell_v6_handler.rs
+++ b/src/manager/xdg_shell_v6_handler.rs
@@ -4,7 +4,7 @@ use libc;
 
 use wlroots_sys::wlr_xdg_surface_v6;
 
-use {Surface, SurfaceHandle, XdgV6ShellSurface, XdgV6ShellSurfaceHandle};
+use {SurfaceHandle, XdgV6ShellSurface, XdgV6ShellSurfaceHandle};
 use compositor::{compositor_handle, CompositorHandle};
 use xdg_shell_v6_events::{MoveEvent, ResizeEvent, SetFullscreenEvent, ShowWindowMenuEvent};
 
@@ -80,58 +80,63 @@ pub trait XdgV6ShellHandler {
     }
 }
 
-wayland_listener!(XdgV6Shell, (XdgV6ShellSurface, Surface, Box<XdgV6ShellHandler>), [
+wayland_listener!(XdgV6Shell, (XdgV6ShellSurface, Box<XdgV6ShellHandler>), [
     commit_listener => commit_notify: |this: &mut XdgV6Shell, _data: *mut libc::c_void,| unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
 
         manager.on_commit(compositor,
-                          surface.weak_reference(),
+                          surface,
                           shell_surface.weak_reference());
     };
     ping_timeout_listener => ping_timeout_notify: |this: &mut XdgV6Shell,
                                                    _data: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
 
         manager.ping_timeout(compositor,
-                             surface.weak_reference(),
+                             surface,
                              shell_surface.weak_reference());
     };
     new_popup_listener => new_popup_notify: |this: &mut XdgV6Shell, _data: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
 
         manager.new_popup(compositor,
-                          surface.weak_reference(),
+                          surface,
                           shell_surface.weak_reference());
     };
     maximize_listener => maximize_notify: |this: &mut XdgV6Shell, _event: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
 
         manager.maximize_request(compositor,
-                                 surface.weak_reference(),
+                                 surface,
                                  shell_surface.weak_reference());
     };
     fullscreen_listener => fullscreen_notify: |this: &mut XdgV6Shell, event: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
@@ -139,24 +144,26 @@ wayland_listener!(XdgV6Shell, (XdgV6ShellSurface, Surface, Box<XdgV6ShellHandler
         let event = SetFullscreenEvent::from_ptr(event as _);
 
         manager.fullscreen_request(compositor,
-                                   surface.weak_reference(),
+                                   surface,
                                    shell_surface.weak_reference(),
                                    &event);
     };
     minimize_listener => minimize_notify: |this: &mut XdgV6Shell, _event: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
 
         manager.minimize_request(compositor,
-                                 surface.weak_reference(),
+                                 surface,
                                  shell_surface.weak_reference());
     };
     move_listener => move_notify: |this: &mut XdgV6Shell, event: *mut libc::c_void,| unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
@@ -164,12 +171,13 @@ wayland_listener!(XdgV6Shell, (XdgV6ShellSurface, Surface, Box<XdgV6ShellHandler
         let event = MoveEvent::from_ptr(event as _);
 
         manager.move_request(compositor,
-                             surface.weak_reference(),
+                             surface,
                              shell_surface.weak_reference(),
                              &event);
     };
     resize_listener => resize_notify: |this: &mut XdgV6Shell, event: *mut libc::c_void,| unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
@@ -177,14 +185,15 @@ wayland_listener!(XdgV6Shell, (XdgV6ShellSurface, Surface, Box<XdgV6ShellHandler
         let event = ResizeEvent::from_ptr(event as _);
 
         manager.resize_request(compositor,
-                               surface.weak_reference(),
+                               surface,
                                shell_surface.weak_reference(),
                                &event);
     };
     show_window_menu_listener => show_window_menu_notify: |this: &mut XdgV6Shell,
                                                            event: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
@@ -192,32 +201,34 @@ wayland_listener!(XdgV6Shell, (XdgV6ShellSurface, Surface, Box<XdgV6ShellHandler
         let event = ShowWindowMenuEvent::from_ptr(event as _);
 
         manager.show_window_menu_request(compositor,
-                                         surface.weak_reference(),
+                                         surface,
                                          shell_surface.weak_reference(),
                                          &event);
     };
 
     map_listener => map_notify: |this: &mut XdgV6Shell, _event: *mut libc::c_void,| unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
 
         manager.map_request(compositor,
-                            surface.weak_reference(),
+                            surface,
                             shell_surface.weak_reference());
     };
 
     unmap_listener => unmap_notify: |this: &mut XdgV6Shell, _event: *mut libc::c_void,| unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
 
         manager.unmap_request(compositor,
-                            surface.weak_reference(),
+                            surface,
                             shell_surface.weak_reference());
     };
 ]);

--- a/src/manager/xdg_shell_v6_manager.rs
+++ b/src/manager/xdg_shell_v6_manager.rs
@@ -6,7 +6,7 @@ use wayland_sys::server::signal::wl_signal_add;
 use wlroots_sys::{wlr_xdg_surface_v6, wlr_xdg_surface_v6_role::*};
 
 use super::xdg_shell_v6_handler::XdgV6Shell;
-use {Surface, XdgV6Popup, XdgV6ShellHandler, XdgV6ShellState::*, XdgV6ShellSurface,
+use {SurfaceHandle, XdgV6Popup, XdgV6ShellHandler, XdgV6ShellState::*, XdgV6ShellSurface,
      XdgV6ShellSurfaceHandle, XdgV6TopLevel};
 use compositor::{compositor_handle, CompositorHandle};
 
@@ -32,7 +32,7 @@ wayland_listener!(XdgV6ShellManager, (Vec<Box<XdgV6Shell>>, Box<XdgV6ShellManage
             None => return
         };
         wlr_log!(L_DEBUG, "New xdg_shell_v6_surface request {:p}", data);
-        let surface = Surface::new((*data).surface);
+        let surface = SurfaceHandle::from_ptr((*data).surface);
         let state = unsafe {
             match (*data).role {
                 WLR_XDG_SURFACE_V6_ROLE_NONE => None,
@@ -53,9 +53,7 @@ wayland_listener!(XdgV6ShellManager, (Vec<Box<XdgV6Shell>>, Box<XdgV6ShellManage
 
         if let Some(shell_surface_handler) = new_surface_res {
 
-            let mut shell_surface = XdgV6Shell::new((shell_surface,
-                                                     surface,
-                                                     shell_surface_handler));
+            let mut shell_surface = XdgV6Shell::new((shell_surface, shell_surface_handler));
 
             // Hook the destroy event into this manager.
             wl_signal_add(&mut (*data).events.destroy as *mut _ as _,

--- a/src/manager/xdg_shell_v6_manager.rs
+++ b/src/manager/xdg_shell_v6_manager.rs
@@ -6,7 +6,7 @@ use wayland_sys::server::signal::wl_signal_add;
 use wlroots_sys::{wlr_xdg_surface_v6, wlr_xdg_surface_v6_role::*};
 
 use super::xdg_shell_v6_handler::XdgV6Shell;
-use {SurfaceHandle, XdgV6Popup, XdgV6ShellHandler, XdgV6ShellState::*, XdgV6ShellSurface,
+use {XdgV6Popup, XdgV6ShellHandler, XdgV6ShellState::*, XdgV6ShellSurface,
      XdgV6ShellSurfaceHandle, XdgV6TopLevel};
 use compositor::{compositor_handle, CompositorHandle};
 
@@ -32,7 +32,6 @@ wayland_listener!(XdgV6ShellManager, (Vec<Box<XdgV6Shell>>, Box<XdgV6ShellManage
             None => return
         };
         wlr_log!(L_DEBUG, "New xdg_shell_v6_surface request {:p}", data);
-        let surface = SurfaceHandle::from_ptr((*data).surface);
         let state = unsafe {
             match (*data).role {
                 WLR_XDG_SURFACE_V6_ROLE_NONE => None,

--- a/src/types/shell/xdg_shell_v6.rs
+++ b/src/types/shell/xdg_shell_v6.rs
@@ -227,6 +227,9 @@ impl XdgV6ShellSurfaceHandle {
     /// Creates a XdgV6ShellSurfaceHandle from the raw pointer, using the saved
     /// user data to recreate the memory model.
     pub(crate) unsafe fn from_ptr(shell_surface: *mut wlr_xdg_surface_v6) -> Self {
+        if shell_surface.is_null() {
+            panic!("shell surface was null")
+        }
         let data = (*shell_surface).data as *mut XdgV6ShellSurfaceState;
         if data.is_null() {
             panic!("Cannot construct handle from a shell surface that has not been set up!");

--- a/src/types/surface/surface.rs
+++ b/src/types/surface/surface.rs
@@ -71,7 +71,7 @@ pub struct SurfaceHandle {
 }
 
 impl Surface {
-    unsafe fn new(surface: *mut wlr_surface) -> Self {
+    pub(crate) unsafe fn new(surface: *mut wlr_surface) -> Self {
         if !(*surface).data.is_null() {
             panic!("Tried to construct a Surface from an already initialized wlr_surface");
         }

--- a/src/types/surface/surface.rs
+++ b/src/types/surface/surface.rs
@@ -71,7 +71,7 @@ pub struct SurfaceHandle {
 }
 
 impl Surface {
-    pub(crate) unsafe fn new(surface: *mut wlr_surface) -> Self {
+    unsafe fn new(surface: *mut wlr_surface) -> Self {
         if !(*surface).data.is_null() {
             panic!("Tried to construct a Surface from an already initialized wlr_surface");
         }

--- a/src/types/surface/surface.rs
+++ b/src/types/surface/surface.rs
@@ -275,6 +275,9 @@ impl SurfaceHandle {
     /// user data to recreate the memory model.
     pub(crate) unsafe fn from_ptr(surface: *mut wlr_surface) -> Self {
         let data = (*surface).data as *mut InternalSurfaceState;
+        if data.is_null() {
+            panic!("Surface has not been set up");
+        }
         let handle = (*data).handle.clone();
         let subsurfaces_manager = (*data).subsurfaces_manager.clone();
         SurfaceHandle { handle,

--- a/src/xwayland/manager.rs
+++ b/src/xwayland/manager.rs
@@ -6,7 +6,6 @@ use wlroots_sys::wlr_xwayland_surface;
 use libc;
 
 use super::surface::{XWaylandShell, XWaylandSurface, XWaylandSurfaceHandle, XWaylandSurfaceHandler};
-use SurfaceHandle;
 use compositor::{compositor_handle, CompositorHandle};
 
 pub trait XWaylandManagerHandler {
@@ -44,7 +43,6 @@ wayland_listener!(XWaylandManager, (Vec<Box<XWaylandShell>>, Box<XWaylandManager
             Some(handle) => handle,
             None => return
         };
-        let surface = SurfaceHandle::from_ptr((*surface_ptr).surface);
         let shell_surface = XWaylandSurface::new(surface_ptr);
         if let Some(handler) = manager.new_surface(compositor, shell_surface.weak_reference()) {
             let mut shell = XWaylandShell::new((shell_surface, handler));

--- a/src/xwayland/surface.rs
+++ b/src/xwayland/surface.rs
@@ -4,7 +4,7 @@ use libc::{self, size_t, int16_t, uint16_t};
 
 use wlroots_sys::{pid_t, wl_event_source, wlr_xwayland_surface, xcb_atom_t, xcb_window_t};
 
-use {Surface, SurfaceHandle, XWaylandSurfaceHints, XWaylandSurfaceSizeHints};
+use {SurfaceHandle, XWaylandSurfaceHints, XWaylandSurfaceSizeHints};
 use compositor::{compositor_handle, CompositorHandle};
 use errors::{HandleErr, HandleResult};
 use events::xwayland_events::{ConfigureEvent, MoveEvent, ResizeEvent};
@@ -59,161 +59,174 @@ pub trait XWaylandSurfaceHandler {
     fn ping_timeout(&mut self, CompositorHandle, SurfaceHandle, XWaylandSurfaceHandle) {}
 }
 
-wayland_listener!(XWaylandShell, (XWaylandSurface, Surface, Box<XWaylandSurfaceHandler>), [
+wayland_listener!(XWaylandShell, (XWaylandSurface, Box<XWaylandSurfaceHandler>), [
     request_configure_listener => request_configure_notify: |this: &mut XWaylandShell,
                                                              data: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
         let event = ConfigureEvent::from_ptr(data as *mut _);
         manager.on_configure(compositor,
-                             surface.weak_reference(),
+                             surface,
                              shell_surface.weak_reference(),
                              &event);
     };
     request_move_listener => request_move_notify: |this: &mut XWaylandShell,
                                                    data: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
         let event = MoveEvent::from_ptr(data as *mut _);
         manager.on_move(compositor,
-                             surface.weak_reference(),
+                             surface,
                              shell_surface.weak_reference(),
                              &event);
     };
     request_resize_listener => request_resize_notify: |this: &mut XWaylandShell,
                                                        data: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
         let event = ResizeEvent::from_ptr(data as *mut _);
         manager.on_resize(compositor,
-                             surface.weak_reference(),
+                             surface,
                              shell_surface.weak_reference(),
                              &event);
     };
     request_maximize_listener => request_maximize_notify: |this: &mut XWaylandShell,
                                                            _data: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
         manager.on_maximize(compositor,
-                             surface.weak_reference(),
+                             surface,
                              shell_surface.weak_reference());
     };
     request_fullscreen_listener => request_fullscreen_notify: |this: &mut XWaylandShell,
                                                                _data: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
         manager.on_fullscreen(compositor,
-                            surface.weak_reference(),
+                            surface,
                             shell_surface.weak_reference());
     };
     map_listener => map_notify: |this: &mut XWaylandShell, _data: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
         manager.on_map(compositor,
-                            surface.weak_reference(),
+                            surface,
                             shell_surface.weak_reference());
     };
     unmap_listener => unmap_notify: |this: &mut XWaylandShell, _data: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
         manager.on_unmap(compositor,
-                       surface.weak_reference(),
+                       surface,
                        shell_surface.weak_reference());
     };
     set_title_listener => set_title_notify: |this: &mut XWaylandShell, _data: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
         manager.title_set(compositor,
-                       surface.weak_reference(),
+                       surface,
                        shell_surface.weak_reference());
     };
     set_class_listener => set_class_notify: |this: &mut XWaylandShell, _data: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
         manager.class_set(compositor,
-                       surface.weak_reference(),
+                       surface,
                        shell_surface.weak_reference());
     };
     set_parent_listener => set_parent_notify: |this: &mut XWaylandShell, _data: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
         manager.parent_set(compositor,
-                       surface.weak_reference(),
+                       surface,
                        shell_surface.weak_reference());
     };
     set_pid_listener => set_pid_notify: |this: &mut XWaylandShell, _data: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
         manager.pid_set(compositor,
-                       surface.weak_reference(),
+                       surface,
                        shell_surface.weak_reference());
     };
     set_window_type_listener => set_window_type_notify: |this: &mut XWaylandShell,
                                                          _data: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
         manager.window_type_set(compositor,
-                       surface.weak_reference(),
+                       surface,
                        shell_surface.weak_reference());
     };
     ping_timeout_listener => ping_timeout_notify: |this: &mut XWaylandShell,
                                                    _data: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
         manager.ping_timeout(compositor,
-                             surface.weak_reference(),
+                             surface,
                              shell_surface.weak_reference());
     };
 ]);
@@ -224,7 +237,7 @@ impl XWaylandShell {
     }
 
     pub(crate) unsafe fn data(&mut self)
-                              -> &mut (XWaylandSurface, Surface, Box<XWaylandSurfaceHandler>) {
+                              -> &mut (XWaylandSurface, Box<XWaylandSurfaceHandler>) {
         &mut self.data
     }
 }

--- a/wlroots-sys/src/wlroots.h
+++ b/wlroots-sys/src/wlroots.h
@@ -1,6 +1,7 @@
 /// Backend includes
 #include <wlr/backend.h>
 #include <wlr/backend/drm.h>
+#include <wlr/backend/headless.h>
 #include <wlr/backend/interface.h>
 #include <wlr/backend/libinput.h>
 #include <wlr/backend/multi.h>


### PR DESCRIPTION
Made surfaces no longer owned by the shells.

Thus is to fix #175 

# TODO
- [ ] segfault when closing compositor when there are surfaces 