### PR TITLE
Surfaces are set up correctly, the destroy listener is removed correctly, subsurfaces has a manager, and also shells can specify surface handlers

### DIFF
--- a/examples/xdg_shell_v6_test.rs
+++ b/examples/xdg_shell_v6_test.rs
@@ -3,7 +3,6 @@ extern crate wlroots;
 
 use std::process::Command;
 use std::thread;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use wlroots::{project_box, Area, Capability, CompositorBuilder, CompositorHandle, Cursor,
               CursorHandle, CursorHandler, InputManagerHandler, KeyboardHandle, KeyboardHandler,

--- a/examples/xdg_shell_v6_test.rs
+++ b/examples/xdg_shell_v6_test.rs
@@ -81,7 +81,7 @@ impl XdgV6ShellManagerHandler for XdgV6ShellManager {
     fn new_surface(&mut self,
                    compositor: CompositorHandle,
                    shell: XdgV6ShellSurfaceHandle)
-                   -> Option<(Box<XdgV6ShellHandler>, Box<SurfaceHandler>)> {
+                   -> (Option<Box<XdgV6ShellHandler>>, Option<Box<SurfaceHandler>>) {
         with_handles!([(compositor: {compositor}), (shell: {shell})] => {
             shell.ping();
             let state: &mut State = compositor.into();
@@ -94,7 +94,7 @@ impl XdgV6ShellManagerHandler for XdgV6ShellManager {
                 }
             }).expect("Layout was destroyed");
         }).unwrap();
-        Some((Box::new(XdgV6ShellHandlerEx), Box::new(SurfaceEx)))
+        (Some(Box::new(XdgV6ShellHandlerEx)), Some(Box::new(SurfaceEx)))
     }
 }
 

--- a/examples/xdg_shell_v6_test.rs
+++ b/examples/xdg_shell_v6_test.rs
@@ -11,7 +11,7 @@ use wlroots::{project_box, Area, Capability, CompositorBuilder, CompositorHandle
               OutputLayout, OutputLayoutHandle, OutputLayoutHandler, OutputManagerHandler,
               PointerHandle, PointerHandler, Renderer, Seat, SeatHandle, SeatHandler, Size,
               XCursorManager, XdgV6ShellHandler, XdgV6ShellManagerHandler, XdgV6ShellState,
-              XdgV6ShellSurfaceHandle};
+              XdgV6ShellSurfaceHandle, SurfaceHandler, SurfaceHandle};
 use wlroots::key_events::KeyEvent;
 use wlroots::pointer_events::{AbsoluteMotionEvent, ButtonEvent, MotionEvent};
 use wlroots::utils::{init_logging, L_DEBUG, current_time};
@@ -69,11 +69,19 @@ impl XdgV6ShellHandler for XdgV6ShellHandlerEx {
     }
 }
 
+struct SurfaceEx;
+
+impl SurfaceHandler for SurfaceEx {
+    fn on_commit(&mut self, _: CompositorHandle, surface: SurfaceHandle) {
+        wlr_log!(L_DEBUG, "Commiting for surface {:?}", surface);
+    }
+}
+
 impl XdgV6ShellManagerHandler for XdgV6ShellManager {
     fn new_surface(&mut self,
                    compositor: CompositorHandle,
                    shell: XdgV6ShellSurfaceHandle)
-                   -> Option<Box<XdgV6ShellHandler>> {
+                   -> Option<(Box<XdgV6ShellHandler>, Box<SurfaceHandler>)> {
         with_handles!([(compositor: {compositor}), (shell: {shell})] => {
             shell.ping();
             let state: &mut State = compositor.into();
@@ -86,7 +94,7 @@ impl XdgV6ShellManagerHandler for XdgV6ShellManager {
                 }
             }).expect("Layout was destroyed");
         }).unwrap();
-        Some(Box::new(XdgV6ShellHandlerEx))
+        Some((Box::new(XdgV6ShellHandlerEx), Box::new(SurfaceEx)))
     }
 }
 

--- a/examples/xdg_shell_v6_test.rs
+++ b/examples/xdg_shell_v6_test.rs
@@ -57,7 +57,18 @@ struct OutputLayoutEx;
 
 impl OutputLayoutHandler for OutputLayoutEx {}
 
-impl XdgV6ShellHandler for XdgV6ShellHandlerEx {}
+impl XdgV6ShellHandler for XdgV6ShellHandlerEx {
+    fn destroyed(&mut self, compositor: CompositorHandle, shell: XdgV6ShellSurfaceHandle) {
+        with_handles!([(compositor: {compositor})] => {
+            let state: &mut State = compositor.into();
+            let weak = shell;
+            if let Some(index) = state.shells.iter().position(|s| *s == weak) {
+                state.shells.remove(index);
+            }
+        }).unwrap();
+    }
+}
+
 impl XdgV6ShellManagerHandler for XdgV6ShellManager {
     fn new_surface(&mut self,
                    compositor: CompositorHandle,
@@ -76,16 +87,6 @@ impl XdgV6ShellManagerHandler for XdgV6ShellManager {
             }).expect("Layout was destroyed");
         }).unwrap();
         Some(Box::new(XdgV6ShellHandlerEx))
-    }
-
-    fn surface_destroyed(&mut self, compositor: CompositorHandle, shell: XdgV6ShellSurfaceHandle) {
-        with_handles!([(compositor: {compositor})] => {
-            let state: &mut State = compositor.into();
-            let weak = shell;
-            if let Some(index) = state.shells.iter().position(|s| *s == weak) {
-                state.shells.remove(index);
-            }
-        }).unwrap();
     }
 }
 

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -42,7 +42,6 @@ wayland_listener!(InternalCompositor, Box<CompositorHandler>, [
         let compositor = (&mut *COMPOSITOR_PTR).weak_reference();
         let surface = Surface::new(surface_ptr);
         handler.new_surface(compositor.clone(), surface.weak_reference());
-        // TODO Not ()
         let mut internal_surface = InternalSurface::new((surface, Box::new(())));
         wl_signal_add(&mut (*surface_ptr).events.commit as *mut _ as _,
                       internal_surface.on_commit_listener() as _);

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -4,7 +4,7 @@
 use libc;
 use std::{env, panic, ptr, any::Any, cell::{Cell, UnsafeCell}, ffi::CStr, rc::{Rc, Weak}};
 
-use {DataDeviceManager, SurfaceHandle, XWaylandManagerHandler, XWaylandServer};
+use {DataDeviceManager, Surface, SurfaceHandle, XWaylandManagerHandler, XWaylandServer};
 use errors::{HandleErr, HandleResult};
 use extensions::server_decoration::ServerDecorationManager;
 use manager::{InputManager, InputManagerHandler, OutputManager, OutputManagerHandler,
@@ -24,7 +24,7 @@ pub(crate) static mut COMPOSITOR_PTR: *mut Compositor = 0 as *mut _;
 
 pub trait CompositorHandler {
     /// Callback that's triggered when a surface is provided to the compositor.
-    fn new_surface(&mut self, CompositorHandle, &mut SurfaceHandle) {}
+    fn new_surface(&mut self, CompositorHandle, SurfaceHandle) {}
 
     /// Callback that's triggered during shutdown.
     fn on_shutdown(&mut self) {}
@@ -32,13 +32,37 @@ pub trait CompositorHandler {
 
 wayland_listener!(InternalCompositor, Box<CompositorHandler>, [
     new_surface_listener => new_surface_notify: |this: &mut InternalCompositor,
-                                                 surface: *mut libc::c_void,|
+                                                 surface_ptr: *mut libc::c_void,|
     unsafe {
+        let destroy_listener = this.surface_destroy_listener() as *mut _ as _;
         let handler = &mut this.data;
+        let surface_ptr = surface_ptr as _;
         let compositor = (&mut *COMPOSITOR_PTR).weak_reference();
-        let mut surface = SurfaceHandle::from_ptr(surface as _);
-        handler.new_surface(compositor, &mut surface);
+        let surface = Surface::new(surface_ptr);
+        handler.new_surface(compositor.clone(), surface.weak_reference());
+        with_handles!([(compositor: {compositor})] => {
+            compositor.surfaces.push(surface);
+            wl_signal_add(&mut (*surface_ptr).events.destroy as *mut _ as _,
+                          destroy_listener);
+        }).unwrap();
     };
+    surface_destroy_listener => surface_destroy_notify: |_this: &mut InternalCompositor,
+                                                         surface_ptr: *mut libc::c_void,|
+    unsafe {
+        let surface_ptr = surface_ptr as _;
+        let compositor = match compositor_handle() {
+            Some(handle) => handle,
+            None => return
+        };
+        with_handles!([(compositor: {compositor})] => {
+            let find_index = compositor.surfaces.iter().position(|s| s.as_ptr() == surface_ptr);
+            if let Some(index) = find_index {
+                compositor.surfaces.remove(index);
+            }
+        }).unwrap();
+
+    };
+
     shutdown_listener => shutdown_notify: |this: &mut InternalCompositor,
                                            _data: *mut libc::c_void,|
     unsafe {
@@ -96,6 +120,8 @@ pub struct Compositor {
     data_device_manager: Option<DataDeviceManager>,
     /// The error from the panic, if there was one.
     panic_error: Option<Box<Any + Send>>,
+    /// List of surfaces. This is managed by the compositor.
+    surfaces: Vec<Surface>,
     /// Custom function to run at shutdown (or when a panic occurs).
     user_terminate: Option<fn()>,
     /// Lock used to borrow the compositor globally.
@@ -340,6 +366,7 @@ impl CompositorBuilder {
                                           renderer,
                                           xwayland,
                                           user_terminate,
+                                          surfaces: Vec::new(),
                                           panic_error: None,
                                           lock: Rc::new(Cell::new(false)) };
             compositor.set_lock(true);

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -308,7 +308,7 @@ impl CompositorBuilder {
             let mut xdg_shell_global = ptr::null_mut();
             let xdg_shell_manager = self.xdg_shell_manager_handler.map(|handler| {
                 xdg_shell_global = wlr_xdg_shell_create(display as *mut _);
-                let mut xdg_shell_manager = XdgShellManager::new((vec![], handler));
+                let mut xdg_shell_manager = XdgShellManager::new(handler);
                 wl_signal_add(&mut (*xdg_shell_global).events.new_surface as *mut _ as _,
                               xdg_shell_manager.add_listener() as *mut _ as _);
                 xdg_shell_manager
@@ -319,7 +319,7 @@ impl CompositorBuilder {
             let mut xdg_v6_shell_global = ptr::null_mut();
             let xdg_v6_shell_manager = self.xdg_v6_shell_manager_handler.map(|handler| {
                 xdg_v6_shell_global = wlr_xdg_shell_v6_create(display as *mut _);
-                let mut xdg_v6_shell_manager = XdgV6ShellManager::new((vec![], handler));
+                let mut xdg_v6_shell_manager = XdgV6ShellManager::new(handler);
                 wl_signal_add(&mut (*xdg_v6_shell_global).events.new_surface as *mut _ as _,
                               xdg_v6_shell_manager.add_listener() as *mut _ as _);
                 xdg_v6_shell_manager

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -108,8 +108,6 @@ pub struct Compositor {
     data_device_manager: Option<DataDeviceManager>,
     /// The error from the panic, if there was one.
     panic_error: Option<Box<Any + Send>>,
-    /// List of surfaces. This is managed by the compositor.
-    surfaces: Vec<Surface>,
     /// Custom function to run at shutdown (or when a panic occurs).
     user_terminate: Option<fn()>,
     /// Lock used to borrow the compositor globally.
@@ -356,7 +354,6 @@ impl CompositorBuilder {
                                           renderer,
                                           xwayland,
                                           user_terminate,
-                                          surfaces: Vec::new(),
                                           panic_error: None,
                                           lock: Rc::new(Cell::new(false)) };
             compositor.set_lock(true);

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -230,7 +230,8 @@ impl CompositorBuilder {
                 ffi_dispatch!(WAYLAND_SERVER_HANDLE, wl_display_create,) as *mut wl_display;
             let event_loop =
                 ffi_dispatch!(WAYLAND_SERVER_HANDLE, wl_display_get_event_loop, display);
-            let backend = wlr_backend_autocreate(display as *mut _);
+            // TODO Make optional
+            let backend = wlr_backend_autocreate(display as *mut _, None);
             if backend.is_null() {
                 // NOTE Rationale for panicking:
                 // * Won't be in C land just yet, so it's safe to panic

--- a/src/manager/xdg_shell_handler.rs
+++ b/src/manager/xdg_shell_handler.rs
@@ -4,7 +4,7 @@ use libc;
 
 use wlroots_sys::wlr_xdg_surface;
 
-use {Surface, SurfaceHandle, XdgShellSurface, XdgShellSurfaceHandle};
+use {SurfaceHandle, XdgShellSurface, XdgShellSurfaceHandle};
 use compositor::{compositor_handle, CompositorHandle};
 use xdg_shell_events::{MoveEvent, ResizeEvent, SetFullscreenEvent, ShowWindowMenuEvent};
 
@@ -64,58 +64,63 @@ pub trait XdgShellHandler {
     }
 }
 
-wayland_listener!(XdgShell, (XdgShellSurface, Surface, Box<XdgShellHandler>), [
+wayland_listener!(XdgShell, (XdgShellSurface, Box<XdgShellHandler>), [
     commit_listener => commit_notify: |this: &mut XdgShell, _data: *mut libc::c_void,| unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
 
         manager.on_commit(compositor,
-                          surface.weak_reference(),
+                          surface,
                           shell_surface.weak_reference());
     };
     ping_timeout_listener => ping_timeout_notify: |this: &mut XdgShell,
                                                    _data: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
 
         manager.ping_timeout(compositor,
-                             surface.weak_reference(),
+                             surface,
                              shell_surface.weak_reference());
     };
     new_popup_listener => new_popup_notify: |this: &mut XdgShell, _data: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
 
         manager.new_popup(compositor,
-                          surface.weak_reference(),
+                          surface,
                           shell_surface.weak_reference());
     };
     maximize_listener => maximize_notify: |this: &mut XdgShell, _event: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
 
         manager.maximize_request(compositor,
-                                 surface.weak_reference(),
+                                 surface,
                                  shell_surface.weak_reference());
     };
     fullscreen_listener => fullscreen_notify: |this: &mut XdgShell, event: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
@@ -123,24 +128,26 @@ wayland_listener!(XdgShell, (XdgShellSurface, Surface, Box<XdgShellHandler>), [
         let event = SetFullscreenEvent::from_ptr(event as _);
 
         manager.fullscreen_request(compositor,
-                                   surface.weak_reference(),
+                                   surface,
                                    shell_surface.weak_reference(),
                                    &event);
     };
     minimize_listener => minimize_notify: |this: &mut XdgShell, _event: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
 
         manager.minimize_request(compositor,
-                                 surface.weak_reference(),
+                                 surface,
                                  shell_surface.weak_reference());
     };
     move_listener => move_notify: |this: &mut XdgShell, event: *mut libc::c_void,| unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
@@ -148,12 +155,13 @@ wayland_listener!(XdgShell, (XdgShellSurface, Surface, Box<XdgShellHandler>), [
         let event = MoveEvent::from_ptr(event as _);
 
         manager.move_request(compositor,
-                             surface.weak_reference(),
+                             surface,
                              shell_surface.weak_reference(),
                              &event);
     };
     resize_listener => resize_notify: |this: &mut XdgShell, event: *mut libc::c_void,| unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
@@ -161,14 +169,15 @@ wayland_listener!(XdgShell, (XdgShellSurface, Surface, Box<XdgShellHandler>), [
         let event = ResizeEvent::from_ptr(event as _);
 
         manager.resize_request(compositor,
-                               surface.weak_reference(),
+                               surface,
                                shell_surface.weak_reference(),
                                &event);
     };
     show_window_menu_listener => show_window_menu_notify: |this: &mut XdgShell,
                                                            event: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
@@ -176,7 +185,7 @@ wayland_listener!(XdgShell, (XdgShellSurface, Surface, Box<XdgShellHandler>), [
         let event = ShowWindowMenuEvent::from_ptr(event as _);
 
         manager.show_window_menu_request(compositor,
-                                         surface.weak_reference(),
+                                         surface,
                                          shell_surface.weak_reference(),
                                          &event);
     };

--- a/src/manager/xdg_shell_handler.rs
+++ b/src/manager/xdg_shell_handler.rs
@@ -2,10 +2,12 @@
 
 use libc;
 
+use wayland_sys::server::WAYLAND_SERVER_HANDLE;
 use wlroots_sys::wlr_xdg_surface;
 
 use {SurfaceHandle, XdgShellSurface, XdgShellSurfaceHandle};
 use compositor::{compositor_handle, CompositorHandle};
+use types::shell::XdgShellSurfaceState;
 use xdg_shell_events::{MoveEvent, ResizeEvent, SetFullscreenEvent, ShowWindowMenuEvent};
 
 /// Handles events from the client stable XDG shells.
@@ -15,7 +17,7 @@ pub trait XdgShellHandler {
 
     /// Called when the wayland shell is destroyed (e.g by the user)
 
-    fn destroy(&mut self, CompositorHandle, SurfaceHandle, XdgShellSurfaceHandle) {}
+    fn destroyed(&mut self, CompositorHandle, XdgShellSurfaceHandle) {}
 
     /// Called when the ping request timed out.
     ///
@@ -65,6 +67,17 @@ pub trait XdgShellHandler {
 }
 
 wayland_listener!(XdgShell, (XdgShellSurface, Box<XdgShellHandler>), [
+    destroy_listener => destroy_notify: |this: &mut XdgShell, data: *mut libc::c_void,| unsafe {
+        let (ref shell_surface, ref mut manager) = this.data;
+        let compositor = match compositor_handle() {
+            Some(handle) => handle,
+            None => return
+        };
+        manager.destroyed(compositor, shell_surface.weak_reference());
+        let surface_ptr = data as *mut wlr_xdg_surface;
+        let shell_state_ptr = (*surface_ptr).data as *mut XdgShellSurfaceState;
+        Box::from_raw((*shell_state_ptr).shell);
+    };
     commit_listener => commit_notify: |this: &mut XdgShell, _data: *mut libc::c_void,| unsafe {
         let (ref mut shell_surface, ref mut manager) = this.data;
         let surface = shell_surface.surface();
@@ -192,11 +205,41 @@ wayland_listener!(XdgShell, (XdgShellSurface, Box<XdgShellHandler>), [
 ]);
 
 impl XdgShell {
-    pub(crate) unsafe fn surface_ptr(&self) -> *mut wlr_xdg_surface {
-        self.data.0.as_ptr()
-    }
-
     pub(crate) fn surface_mut(&mut self) -> XdgShellSurfaceHandle {
         self.data.0.weak_reference()
+    }
+}
+
+impl Drop for XdgShell {
+    fn drop(&mut self) {
+        unsafe {
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                        wl_list_remove,
+                        &mut (*self.commit_listener()).link as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                        wl_list_remove,
+                        &mut (*self.ping_timeout_listener()).link as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                        wl_list_remove,
+                        &mut (*self.new_popup_listener()).link as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                        wl_list_remove,
+                        &mut (*self.maximize_listener()).link as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                        wl_list_remove,
+                        &mut (*self.fullscreen_listener()).link as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                        wl_list_remove,
+                        &mut (*self.minimize_listener()).link as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                        wl_list_remove,
+                        &mut (*self.move_listener()).link as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                        wl_list_remove,
+                        &mut (*self.resize_listener()).link as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                        wl_list_remove,
+                        &mut (*self.show_window_menu_listener()).link as *mut _ as _);
+        }
     }
 }

--- a/src/manager/xdg_shell_manager.rs
+++ b/src/manager/xdg_shell_manager.rs
@@ -15,7 +15,7 @@ pub trait XdgShellManagerHandler {
     fn new_surface(&mut self,
                    CompositorHandle,
                    XdgShellSurfaceHandle)
-                   -> Option<(Box<XdgShellHandler>, Box<SurfaceHandler>)>;
+                   -> (Option<Box<XdgShellHandler>>, Option<Box<SurfaceHandler>>);
 }
 
 wayland_listener!(XdgShellManager, Box<XdgShellManagerHandler>, [
@@ -46,11 +46,13 @@ wayland_listener!(XdgShellManager, Box<XdgShellManagerHandler>, [
         let new_surface_res = manager.new_surface(compositor,
                                                   shell_surface.weak_reference());
 
-        if let Some((shell_surface_handler, surface_handler)) = new_surface_res {
+        if let (Some(shell_surface_handler), surface_handler) = new_surface_res {
 
             let mut shell_surface = XdgShell::new((shell_surface, shell_surface_handler));
             let surface_state = (*(*data).surface).data as *mut InternalSurfaceState;
-            (*(*surface_state).surface).data().1 = surface_handler;
+            if let Some(surface_handler) = surface_handler {
+                (*(*surface_state).surface).data().1 = surface_handler;
+            }
 
             wl_signal_add(&mut (*data).events.destroy as *mut _ as _,
                           shell_surface.destroy_listener() as _);

--- a/src/manager/xdg_shell_manager.rs
+++ b/src/manager/xdg_shell_manager.rs
@@ -1,10 +1,10 @@
 //! Manager for stable XDG shell client.
 
 use libc;
-use wayland_sys::server::WAYLAND_SERVER_HANDLE;
 use wayland_sys::server::signal::wl_signal_add;
 use wlroots_sys::{wlr_xdg_surface, wlr_xdg_surface_role::*};
 
+use types::shell::XdgShellSurfaceState;
 use super::xdg_shell_handler::XdgShell;
 use {XdgPopup, XdgShellHandler, XdgShellState::*, XdgShellSurface,
      XdgShellSurfaceHandle, XdgTopLevel};
@@ -16,16 +16,12 @@ pub trait XdgShellManagerHandler {
                    CompositorHandle,
                    XdgShellSurfaceHandle)
                    -> Option<Box<XdgShellHandler>>;
-
-    /// Callback that is triggered when an stable XDG shell surface is destroyed.
-    fn surface_destroyed(&mut self, CompositorHandle, XdgShellSurfaceHandle);
 }
 
-wayland_listener!(XdgShellManager, (Vec<Box<XdgShell>>, Box<XdgShellManagerHandler>), [
+wayland_listener!(XdgShellManager, Box<XdgShellManagerHandler>, [
     add_listener => add_notify: |this: &mut XdgShellManager, data: *mut libc::c_void,|
     unsafe {
-        let remove_listener = this.remove_listener() as *mut _ as _;
-        let (ref mut shells, ref mut manager) = this.data;
+        let manager = &mut this.data;
         let data = data as *mut wlr_xdg_surface;
         let compositor = match compositor_handle() {
             Some(handle) => handle,
@@ -54,14 +50,10 @@ wayland_listener!(XdgShellManager, (Vec<Box<XdgShell>>, Box<XdgShellManagerHandl
 
             let mut shell_surface = XdgShell::new((shell_surface, shell_surface_handler));
 
-            // Hook the destroy event into this manager.
             wl_signal_add(&mut (*data).events.destroy as *mut _ as _,
-                          remove_listener);
-
-            // Hook the commit signal from the surface into the shell handler.
+                          shell_surface.destroy_listener() as _);
             wl_signal_add(&mut (*(*data).surface).events.commit as *mut _ as _,
                           shell_surface.commit_listener() as _);
-
             wl_signal_add(&mut (*data).events.ping_timeout as *mut _ as _,
                           shell_surface.ping_timeout_listener() as _);
             wl_signal_add(&mut (*data).events.new_popup as *mut _ as _,
@@ -86,51 +78,8 @@ wayland_listener!(XdgShellManager, (Vec<Box<XdgShell>>, Box<XdgShellManagerHandl
                 wl_signal_add(&mut events.request_show_window_menu as *mut _ as _,
                               shell_surface.show_window_menu_listener() as _);
             }
-
-            shells.push(shell_surface);
-        }
-    };
-    remove_listener => remove_notify: |this: &mut XdgShellManager, data: *mut libc::c_void,|
-    unsafe {
-        let (ref mut shells, ref mut manager) = this.data;
-        let data = data as *mut wlr_xdg_surface;
-        let compositor = match compositor_handle() {
-            Some(handle) => handle,
-            None => return
-        };
-        if let Some(shell) = shells.iter_mut().find(|shell| shell.surface_ptr() == data) {
-            let mut shell_surface = shell.surface_mut();
-            manager.surface_destroyed(compositor, shell_surface);
-        }
-        if let Some(index) = shells.iter().position(|shell| shell.surface_ptr() == data) {
-            let mut removed_shell = shells.remove(index);
-            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
-                          wl_list_remove,
-                          &mut (*removed_shell.commit_listener()).link as *mut _ as _);
-            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
-                          wl_list_remove,
-                          &mut (*removed_shell.ping_timeout_listener()).link as *mut _ as _);
-            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
-                          wl_list_remove,
-                          &mut (*removed_shell.new_popup_listener()).link as *mut _ as _);
-            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
-                          wl_list_remove,
-                          &mut (*removed_shell.maximize_listener()).link as *mut _ as _);
-            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
-                          wl_list_remove,
-                          &mut (*removed_shell.fullscreen_listener()).link as *mut _ as _);
-            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
-                          wl_list_remove,
-                          &mut (*removed_shell.minimize_listener()).link as *mut _ as _);
-            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
-                          wl_list_remove,
-                          &mut (*removed_shell.move_listener()).link as *mut _ as _);
-            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
-                          wl_list_remove,
-                          &mut (*removed_shell.resize_listener()).link as *mut _ as _);
-            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
-                          wl_list_remove,
-                          &mut (*removed_shell.show_window_menu_listener()).link as *mut _ as _);
+            let shell_data = (*data).data as *mut XdgShellSurfaceState;
+            (*shell_data).shell = Box::into_raw(shell_surface);
         }
     };
 ]);

--- a/src/manager/xdg_shell_manager.rs
+++ b/src/manager/xdg_shell_manager.rs
@@ -4,9 +4,9 @@ use libc;
 use wayland_sys::server::signal::wl_signal_add;
 use wlroots_sys::{wlr_xdg_surface, wlr_xdg_surface_role::*};
 
-use types::shell::XdgShellSurfaceState;
+use types::{shell::XdgShellSurfaceState, surface::InternalSurfaceState};
 use super::xdg_shell_handler::XdgShell;
-use {XdgPopup, XdgShellHandler, XdgShellState::*, XdgShellSurface,
+use {SurfaceHandler, XdgPopup, XdgShellHandler, XdgShellState::*, XdgShellSurface,
      XdgShellSurfaceHandle, XdgTopLevel};
 use compositor::{compositor_handle, CompositorHandle};
 
@@ -15,7 +15,7 @@ pub trait XdgShellManagerHandler {
     fn new_surface(&mut self,
                    CompositorHandle,
                    XdgShellSurfaceHandle)
-                   -> Option<Box<XdgShellHandler>>;
+                   -> Option<(Box<XdgShellHandler>, Box<SurfaceHandler>)>;
 }
 
 wayland_listener!(XdgShellManager, Box<XdgShellManagerHandler>, [
@@ -46,9 +46,11 @@ wayland_listener!(XdgShellManager, Box<XdgShellManagerHandler>, [
         let new_surface_res = manager.new_surface(compositor,
                                                   shell_surface.weak_reference());
 
-        if let Some(shell_surface_handler) = new_surface_res {
+        if let Some((shell_surface_handler, surface_handler)) = new_surface_res {
 
             let mut shell_surface = XdgShell::new((shell_surface, shell_surface_handler));
+            let surface_state = (*(*data).surface).data as *mut InternalSurfaceState;
+            (*(*surface_state).surface).data().1 = surface_handler;
 
             wl_signal_add(&mut (*data).events.destroy as *mut _ as _,
                           shell_surface.destroy_listener() as _);

--- a/src/manager/xdg_shell_manager.rs
+++ b/src/manager/xdg_shell_manager.rs
@@ -6,7 +6,7 @@ use wayland_sys::server::signal::wl_signal_add;
 use wlroots_sys::{wlr_xdg_surface, wlr_xdg_surface_role::*};
 
 use super::xdg_shell_handler::XdgShell;
-use {SurfaceHandle, XdgPopup, XdgShellHandler, XdgShellState::*, XdgShellSurface,
+use {XdgPopup, XdgShellHandler, XdgShellState::*, XdgShellSurface,
      XdgShellSurfaceHandle, XdgTopLevel};
 use compositor::{compositor_handle, CompositorHandle};
 
@@ -32,7 +32,6 @@ wayland_listener!(XdgShellManager, (Vec<Box<XdgShell>>, Box<XdgShellManagerHandl
             None => return
         };
         wlr_log!(L_DEBUG, "New xdg_shell_surface request {:p}", data);
-        let surface = SurfaceHandle::from_ptr((*data).surface);
         let state = unsafe {
             match (*data).role {
                 WLR_XDG_SURFACE_ROLE_NONE => None,

--- a/src/manager/xdg_shell_manager.rs
+++ b/src/manager/xdg_shell_manager.rs
@@ -6,7 +6,7 @@ use wayland_sys::server::signal::wl_signal_add;
 use wlroots_sys::{wlr_xdg_surface, wlr_xdg_surface_role::*};
 
 use super::xdg_shell_handler::XdgShell;
-use {Surface, XdgPopup, XdgShellHandler, XdgShellState::*, XdgShellSurface,
+use {SurfaceHandle, XdgPopup, XdgShellHandler, XdgShellState::*, XdgShellSurface,
      XdgShellSurfaceHandle, XdgTopLevel};
 use compositor::{compositor_handle, CompositorHandle};
 
@@ -32,7 +32,7 @@ wayland_listener!(XdgShellManager, (Vec<Box<XdgShell>>, Box<XdgShellManagerHandl
             None => return
         };
         wlr_log!(L_DEBUG, "New xdg_shell_surface request {:p}", data);
-        let surface = Surface::new((*data).surface);
+        let surface = SurfaceHandle::from_ptr((*data).surface);
         let state = unsafe {
             match (*data).role {
                 WLR_XDG_SURFACE_ROLE_NONE => None,
@@ -53,9 +53,7 @@ wayland_listener!(XdgShellManager, (Vec<Box<XdgShell>>, Box<XdgShellManagerHandl
 
         if let Some(shell_surface_handler) = new_surface_res {
 
-            let mut shell_surface = XdgShell::new((shell_surface,
-                                                     surface,
-                                                     shell_surface_handler));
+            let mut shell_surface = XdgShell::new((shell_surface, shell_surface_handler));
 
             // Hook the destroy event into this manager.
             wl_signal_add(&mut (*data).events.destroy as *mut _ as _,

--- a/src/manager/xdg_shell_v6_handler.rs
+++ b/src/manager/xdg_shell_v6_handler.rs
@@ -246,10 +246,6 @@ wayland_listener!(XdgV6Shell, (XdgV6ShellSurface, Box<XdgV6ShellHandler>), [
 ]);
 
 impl XdgV6Shell {
-    pub(crate) unsafe fn surface_ptr(&self) -> *mut wlr_xdg_surface_v6 {
-        self.data.0.as_ptr()
-    }
-
     pub(crate) fn surface_mut(&mut self) -> XdgV6ShellSurfaceHandle {
         self.data.0.weak_reference()
     }

--- a/src/manager/xdg_shell_v6_handler.rs
+++ b/src/manager/xdg_shell_v6_handler.rs
@@ -2,10 +2,12 @@
 
 use libc;
 
+use wayland_sys::server::WAYLAND_SERVER_HANDLE;
 use wlroots_sys::wlr_xdg_surface_v6;
 
 use {SurfaceHandle, XdgV6ShellSurface, XdgV6ShellSurfaceHandle};
 use compositor::{compositor_handle, CompositorHandle};
+use types::shell::XdgV6ShellSurfaceState;
 use xdg_shell_v6_events::{MoveEvent, ResizeEvent, SetFullscreenEvent, ShowWindowMenuEvent};
 
 /// Handles events from the client XDG v6 shells.
@@ -14,8 +16,7 @@ pub trait XdgV6ShellHandler {
     fn on_commit(&mut self, CompositorHandle, SurfaceHandle, XdgV6ShellSurfaceHandle) {}
 
     /// Called when the wayland shell is destroyed (e.g by the user)
-
-    fn destroy(&mut self, CompositorHandle, SurfaceHandle, XdgV6ShellSurfaceHandle) {}
+    fn destroyed(&mut self, CompositorHandle, XdgV6ShellSurfaceHandle) {}
 
     /// Called when the ping request timed out.
     ///
@@ -81,6 +82,18 @@ pub trait XdgV6ShellHandler {
 }
 
 wayland_listener!(XdgV6Shell, (XdgV6ShellSurface, Box<XdgV6ShellHandler>), [
+    destroy_listener => destroy_notify: |this: &mut XdgV6Shell, data: *mut libc::c_void,| unsafe {
+        let (ref shell_surface, ref mut manager) = this.data;
+        let compositor = match compositor_handle() {
+            Some(handle) => handle,
+            None => return
+        };
+        manager.destroyed(compositor, shell_surface.weak_reference());
+        let surface_ptr = data as *mut wlr_xdg_surface_v6;
+        wlr_log!(L_ERROR, "DESTROYED {:p}", surface_ptr);
+        let shell_state_ptr = (*surface_ptr).data as *mut XdgV6ShellSurfaceState;
+        Box::from_raw((*shell_state_ptr).shell);
+    };
     commit_listener => commit_notify: |this: &mut XdgV6Shell, _data: *mut libc::c_void,| unsafe {
         let (ref mut shell_surface, ref mut manager) = this.data;
         let surface = shell_surface.surface();
@@ -240,5 +253,45 @@ impl XdgV6Shell {
 
     pub(crate) fn surface_mut(&mut self) -> XdgV6ShellSurfaceHandle {
         self.data.0.weak_reference()
+    }
+}
+
+impl Drop for XdgV6Shell {
+    fn drop(&mut self) {
+        unsafe {
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          &mut (*self.commit_listener()).link as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          &mut (*self.ping_timeout_listener()).link as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          &mut (*self.new_popup_listener()).link as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          &mut (*self.maximize_listener()).link as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          &mut (*self.fullscreen_listener()).link as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          &mut (*self.minimize_listener()).link as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          &mut (*self.move_listener()).link as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          &mut (*self.resize_listener()).link as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          &mut (*self.show_window_menu_listener()).link as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          &mut (*self.map_listener()).link as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          &mut (*self.unmap_listener()).link as *mut _ as _);
+        }
     }
 }

--- a/src/manager/xdg_shell_v6_handler.rs
+++ b/src/manager/xdg_shell_v6_handler.rs
@@ -90,7 +90,6 @@ wayland_listener!(XdgV6Shell, (XdgV6ShellSurface, Box<XdgV6ShellHandler>), [
         };
         manager.destroyed(compositor, shell_surface.weak_reference());
         let surface_ptr = data as *mut wlr_xdg_surface_v6;
-        wlr_log!(L_ERROR, "DESTROYED {:p}", surface_ptr);
         let shell_state_ptr = (*surface_ptr).data as *mut XdgV6ShellSurfaceState;
         Box::from_raw((*shell_state_ptr).shell);
     };

--- a/src/manager/xdg_shell_v6_handler.rs
+++ b/src/manager/xdg_shell_v6_handler.rs
@@ -4,7 +4,7 @@ use libc;
 
 use wlroots_sys::wlr_xdg_surface_v6;
 
-use {Surface, SurfaceHandle, XdgV6ShellSurface, XdgV6ShellSurfaceHandle};
+use {SurfaceHandle, XdgV6ShellSurface, XdgV6ShellSurfaceHandle};
 use compositor::{compositor_handle, CompositorHandle};
 use xdg_shell_v6_events::{MoveEvent, ResizeEvent, SetFullscreenEvent, ShowWindowMenuEvent};
 
@@ -80,58 +80,63 @@ pub trait XdgV6ShellHandler {
     }
 }
 
-wayland_listener!(XdgV6Shell, (XdgV6ShellSurface, Surface, Box<XdgV6ShellHandler>), [
+wayland_listener!(XdgV6Shell, (XdgV6ShellSurface, Box<XdgV6ShellHandler>), [
     commit_listener => commit_notify: |this: &mut XdgV6Shell, _data: *mut libc::c_void,| unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
 
         manager.on_commit(compositor,
-                          surface.weak_reference(),
+                          surface,
                           shell_surface.weak_reference());
     };
     ping_timeout_listener => ping_timeout_notify: |this: &mut XdgV6Shell,
                                                    _data: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
 
         manager.ping_timeout(compositor,
-                             surface.weak_reference(),
+                             surface,
                              shell_surface.weak_reference());
     };
     new_popup_listener => new_popup_notify: |this: &mut XdgV6Shell, _data: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
 
         manager.new_popup(compositor,
-                          surface.weak_reference(),
+                          surface,
                           shell_surface.weak_reference());
     };
     maximize_listener => maximize_notify: |this: &mut XdgV6Shell, _event: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
 
         manager.maximize_request(compositor,
-                                 surface.weak_reference(),
+                                 surface,
                                  shell_surface.weak_reference());
     };
     fullscreen_listener => fullscreen_notify: |this: &mut XdgV6Shell, event: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
@@ -139,24 +144,26 @@ wayland_listener!(XdgV6Shell, (XdgV6ShellSurface, Surface, Box<XdgV6ShellHandler
         let event = SetFullscreenEvent::from_ptr(event as _);
 
         manager.fullscreen_request(compositor,
-                                   surface.weak_reference(),
+                                   surface,
                                    shell_surface.weak_reference(),
                                    &event);
     };
     minimize_listener => minimize_notify: |this: &mut XdgV6Shell, _event: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
 
         manager.minimize_request(compositor,
-                                 surface.weak_reference(),
+                                 surface,
                                  shell_surface.weak_reference());
     };
     move_listener => move_notify: |this: &mut XdgV6Shell, event: *mut libc::c_void,| unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
@@ -164,12 +171,13 @@ wayland_listener!(XdgV6Shell, (XdgV6ShellSurface, Surface, Box<XdgV6ShellHandler
         let event = MoveEvent::from_ptr(event as _);
 
         manager.move_request(compositor,
-                             surface.weak_reference(),
+                             surface,
                              shell_surface.weak_reference(),
                              &event);
     };
     resize_listener => resize_notify: |this: &mut XdgV6Shell, event: *mut libc::c_void,| unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
@@ -177,14 +185,15 @@ wayland_listener!(XdgV6Shell, (XdgV6ShellSurface, Surface, Box<XdgV6ShellHandler
         let event = ResizeEvent::from_ptr(event as _);
 
         manager.resize_request(compositor,
-                               surface.weak_reference(),
+                               surface,
                                shell_surface.weak_reference(),
                                &event);
     };
     show_window_menu_listener => show_window_menu_notify: |this: &mut XdgV6Shell,
                                                            event: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
@@ -192,32 +201,34 @@ wayland_listener!(XdgV6Shell, (XdgV6ShellSurface, Surface, Box<XdgV6ShellHandler
         let event = ShowWindowMenuEvent::from_ptr(event as _);
 
         manager.show_window_menu_request(compositor,
-                                         surface.weak_reference(),
+                                         surface,
                                          shell_surface.weak_reference(),
                                          &event);
     };
 
     map_listener => map_notify: |this: &mut XdgV6Shell, _event: *mut libc::c_void,| unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
 
         manager.map_request(compositor,
-                            surface.weak_reference(),
+                            surface,
                             shell_surface.weak_reference());
     };
 
     unmap_listener => unmap_notify: |this: &mut XdgV6Shell, _event: *mut libc::c_void,| unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
 
         manager.unmap_request(compositor,
-                            surface.weak_reference(),
+                            surface,
                             shell_surface.weak_reference());
     };
 ]);

--- a/src/manager/xdg_shell_v6_manager.rs
+++ b/src/manager/xdg_shell_v6_manager.rs
@@ -15,7 +15,7 @@ pub trait XdgV6ShellManagerHandler {
     fn new_surface(&mut self,
                    CompositorHandle,
                    XdgV6ShellSurfaceHandle)
-                   -> Option<(Box<XdgV6ShellHandler>, Box<SurfaceHandler>)>;
+                   -> (Option<Box<XdgV6ShellHandler>>, Option<Box<SurfaceHandler>>);
 }
 
 wayland_listener!(XdgV6ShellManager, Box<XdgV6ShellManagerHandler>, [
@@ -46,11 +46,13 @@ wayland_listener!(XdgV6ShellManager, Box<XdgV6ShellManagerHandler>, [
         let new_surface_res = manager.new_surface(compositor,
                                                   shell_surface.weak_reference());
 
-        if let Some((shell_surface_handler, surface_handler)) = new_surface_res {
+        if let (Some(shell_surface_handler), surface_handler) = new_surface_res {
 
             let mut shell_surface = XdgV6Shell::new((shell_surface, shell_surface_handler));
             let surface_state = (*(*data).surface).data as *mut InternalSurfaceState;
-            (*(*surface_state).surface).data().1 = surface_handler;
+            if let Some(surface_handler) = surface_handler {
+                (*(*surface_state).surface).data().1 = surface_handler;
+            }
 
             wl_signal_add(&mut (*data).events.destroy as *mut _ as _,
                           shell_surface.destroy_listener() as _);

--- a/src/manager/xdg_shell_v6_manager.rs
+++ b/src/manager/xdg_shell_v6_manager.rs
@@ -6,7 +6,7 @@ use wayland_sys::server::signal::wl_signal_add;
 use wlroots_sys::{wlr_xdg_surface_v6, wlr_xdg_surface_v6_role::*};
 
 use super::xdg_shell_v6_handler::XdgV6Shell;
-use {Surface, XdgV6Popup, XdgV6ShellHandler, XdgV6ShellState::*, XdgV6ShellSurface,
+use {SurfaceHandle, XdgV6Popup, XdgV6ShellHandler, XdgV6ShellState::*, XdgV6ShellSurface,
      XdgV6ShellSurfaceHandle, XdgV6TopLevel};
 use compositor::{compositor_handle, CompositorHandle};
 
@@ -32,7 +32,7 @@ wayland_listener!(XdgV6ShellManager, (Vec<Box<XdgV6Shell>>, Box<XdgV6ShellManage
             None => return
         };
         wlr_log!(L_DEBUG, "New xdg_shell_v6_surface request {:p}", data);
-        let surface = Surface::new((*data).surface);
+        let surface = SurfaceHandle::from_ptr((*data).surface);
         let state = unsafe {
             match (*data).role {
                 WLR_XDG_SURFACE_V6_ROLE_NONE => None,
@@ -53,9 +53,7 @@ wayland_listener!(XdgV6ShellManager, (Vec<Box<XdgV6Shell>>, Box<XdgV6ShellManage
 
         if let Some(shell_surface_handler) = new_surface_res {
 
-            let mut shell_surface = XdgV6Shell::new((shell_surface,
-                                                     surface,
-                                                     shell_surface_handler));
+            let mut shell_surface = XdgV6Shell::new((shell_surface, shell_surface_handler));
 
             // Hook the destroy event into this manager.
             wl_signal_add(&mut (*data).events.destroy as *mut _ as _,

--- a/src/manager/xdg_shell_v6_manager.rs
+++ b/src/manager/xdg_shell_v6_manager.rs
@@ -6,7 +6,7 @@ use wayland_sys::server::signal::wl_signal_add;
 use wlroots_sys::{wlr_xdg_surface_v6, wlr_xdg_surface_v6_role::*};
 
 use super::xdg_shell_v6_handler::XdgV6Shell;
-use {SurfaceHandle, XdgV6Popup, XdgV6ShellHandler, XdgV6ShellState::*, XdgV6ShellSurface,
+use {XdgV6Popup, XdgV6ShellHandler, XdgV6ShellState::*, XdgV6ShellSurface,
      XdgV6ShellSurfaceHandle, XdgV6TopLevel};
 use compositor::{compositor_handle, CompositorHandle};
 
@@ -32,7 +32,6 @@ wayland_listener!(XdgV6ShellManager, (Vec<Box<XdgV6Shell>>, Box<XdgV6ShellManage
             None => return
         };
         wlr_log!(L_DEBUG, "New xdg_shell_v6_surface request {:p}", data);
-        let surface = SurfaceHandle::from_ptr((*data).surface);
         let state = unsafe {
             match (*data).role {
                 WLR_XDG_SURFACE_V6_ROLE_NONE => None,

--- a/src/types/shell/xdg_shell.rs
+++ b/src/types/shell/xdg_shell.rs
@@ -94,10 +94,6 @@ impl XdgShellSurface {
                           shell_surface }
     }
 
-    pub(crate) unsafe fn as_ptr(&self) -> *mut wlr_xdg_surface {
-        self.shell_surface
-    }
-
     unsafe fn from_handle(handle: &XdgShellSurfaceHandle) -> HandleResult<Self> {
         let liveliness = handle.handle
                                .upgrade()

--- a/src/types/shell/xdg_shell.rs
+++ b/src/types/shell/xdg_shell.rs
@@ -15,10 +15,13 @@ use wlroots_sys::{wlr_xdg_popup, wlr_xdg_surface, wlr_xdg_surface_ping,
 use {Area, SeatHandle, SurfaceHandle, Surface};
 use errors::{HandleErr, HandleResult};
 use utils::c_to_rust_string;
+use manager::XdgShell;
 use libc::c_void;
 
 /// Used internally to reclaim a handle from just a *mut wlr_xdg_surface.
-struct XdgShellSurfaceState {
+pub(crate) struct XdgShellSurfaceState {
+    /// Pointer to the backing storage.
+    pub(crate) shell: *mut XdgShell,
     handle: Weak<Cell<bool>>,
     shell_state: Option<XdgShellState>
 }
@@ -79,15 +82,16 @@ impl XdgShellSurface {
         (*shell_surface).data = ptr::null_mut();
         let liveliness = Rc::new(Cell::new(false));
         let shell_state =
-            Box::new(XdgShellSurfaceState { handle: Rc::downgrade(&liveliness),
-                                              shell_state: match state {
-                                                  None => None,
-                                                  Some(ref state) => Some(state.clone())
-                                              } });
+            Box::new(XdgShellSurfaceState { shell: ptr::null_mut(),
+                                            handle: Rc::downgrade(&liveliness),
+                                            shell_state: match state {
+                                                None => None,
+                                                Some(ref state) => Some(state.clone())
+                                            } });
         (*shell_surface).data = Box::into_raw(shell_state) as *mut _;
         XdgShellSurface { liveliness,
-                            state: state,
-                            shell_surface }
+                          state: state,
+                          shell_surface }
     }
 
     pub(crate) unsafe fn as_ptr(&self) -> *mut wlr_xdg_surface {

--- a/src/types/shell/xdg_shell_v6.rs
+++ b/src/types/shell/xdg_shell_v6.rs
@@ -93,10 +93,6 @@ impl XdgV6ShellSurface {
                             shell_surface }
     }
 
-    pub(crate) unsafe fn as_ptr(&self) -> *mut wlr_xdg_surface_v6 {
-        self.shell_surface
-    }
-
     unsafe fn from_handle(handle: &XdgV6ShellSurfaceHandle) -> HandleResult<Self> {
         let liveliness = handle.handle
                                .upgrade()

--- a/src/types/shell/xdg_shell_v6.rs
+++ b/src/types/shell/xdg_shell_v6.rs
@@ -15,10 +15,12 @@ use wlroots_sys::{wlr_xdg_popup_v6, wlr_xdg_surface_v6, wlr_xdg_surface_v6_ping,
 use {Area, SeatHandle, SurfaceHandle};
 use errors::{HandleErr, HandleResult};
 use utils::c_to_rust_string;
+use manager::XdgV6Shell;
 use libc::c_void;
 
 /// Used internally to reclaim a handle from just a *mut wlr_xdg_surface_v6.
-struct XdgV6ShellSurfaceState {
+pub(crate) struct XdgV6ShellSurfaceState {
+    pub(crate) shell: *mut XdgV6Shell,
     handle: Weak<Cell<bool>>,
     shell_state: Option<XdgV6ShellState>
 }
@@ -79,7 +81,8 @@ impl XdgV6ShellSurface {
         (*shell_surface).data = ptr::null_mut();
         let liveliness = Rc::new(Cell::new(false));
         let shell_state =
-            Box::new(XdgV6ShellSurfaceState { handle: Rc::downgrade(&liveliness),
+            Box::new(XdgV6ShellSurfaceState { shell: ptr::null_mut(),
+                                              handle: Rc::downgrade(&liveliness),
                                               shell_state: match state {
                                                   None => None,
                                                   Some(ref state) => Some(state.clone())

--- a/src/types/shell/xdg_shell_v6.rs
+++ b/src/types/shell/xdg_shell_v6.rs
@@ -227,6 +227,9 @@ impl XdgV6ShellSurfaceHandle {
     /// Creates a XdgV6ShellSurfaceHandle from the raw pointer, using the saved
     /// user data to recreate the memory model.
     pub(crate) unsafe fn from_ptr(shell_surface: *mut wlr_xdg_surface_v6) -> Self {
+        if shell_surface.is_null() {
+            panic!("shell surface was null")
+        }
         let data = (*shell_surface).data as *mut XdgV6ShellSurfaceState;
         if data.is_null() {
             panic!("Cannot construct handle from a shell surface that has not been set up!");

--- a/src/types/surface/sub_surface.rs
+++ b/src/types/surface/sub_surface.rs
@@ -11,7 +11,7 @@ use compositor::{compositor_handle, CompositorHandle};
 use errors::{HandleErr, HandleResult};
 
 pub trait SubsurfaceHandler {
-    fn on_destroy(&mut self, CompositorHandle, SubsurfaceHandle) {}
+    fn on_destroy(&mut self, CompositorHandle, SubsurfaceHandle, SurfaceHandle) {}
 }
 
 wayland_listener!(InternalSubsurface, (Subsurface, Box<SubsurfaceHandler>), [
@@ -19,12 +19,13 @@ wayland_listener!(InternalSubsurface, (Subsurface, Box<SubsurfaceHandler>), [
                                                data: *mut libc::c_void,|
     unsafe {
         let (ref mut subsurface, ref mut manager) = this.data;
+        let subsurface_ptr = data as *mut wlr_subsurface;
+        let surface = SurfaceHandle::from_ptr((*subsurface_ptr).surface);
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
-        let subsurface_ptr = data as *mut wlr_subsurface;
-        manager.on_destroy(compositor, subsurface.weak_reference());
+        manager.on_destroy(compositor, subsurface.weak_reference(), surface);
         Box::from_raw((*subsurface_ptr).data as *mut InternalSubsurface);
     };
 ]);

--- a/src/types/surface/surface.rs
+++ b/src/types/surface/surface.rs
@@ -71,7 +71,7 @@ pub struct SurfaceHandle {
 }
 
 impl Surface {
-    unsafe fn new(surface: *mut wlr_surface) -> Self {
+    pub(crate) unsafe fn new(surface: *mut wlr_surface) -> Self {
         if !(*surface).data.is_null() {
             panic!("Tried to construct a Surface from an already initialized wlr_surface");
         }

--- a/src/types/surface/surface.rs
+++ b/src/types/surface/surface.rs
@@ -71,7 +71,7 @@ pub struct SurfaceHandle {
 }
 
 impl Surface {
-    pub(crate) unsafe fn new(surface: *mut wlr_surface) -> Self {
+    unsafe fn new(surface: *mut wlr_surface) -> Self {
         if !(*surface).data.is_null() {
             panic!("Tried to construct a Surface from an already initialized wlr_surface");
         }

--- a/src/types/surface/surface.rs
+++ b/src/types/surface/surface.rs
@@ -275,6 +275,9 @@ impl SurfaceHandle {
     /// user data to recreate the memory model.
     pub(crate) unsafe fn from_ptr(surface: *mut wlr_surface) -> Self {
         let data = (*surface).data as *mut InternalSurfaceState;
+        if data.is_null() {
+            panic!("Surface has not been set up");
+        }
         let handle = (*data).handle.clone();
         let subsurfaces_manager = (*data).subsurfaces_manager.clone();
         SurfaceHandle { handle,

--- a/src/types/surface/surface.rs
+++ b/src/types/surface/surface.rs
@@ -27,8 +27,7 @@ pub trait SurfaceHandler {
     fn on_destroy(&mut self, CompositorHandle, SurfaceHandle) {}
 }
 
-// TODO remove
-impl SurfaceHandler for (){}
+impl SurfaceHandler for () {}
 
 wayland_listener!(InternalSurface, (Surface, Box<SurfaceHandler>), [
     on_commit_listener => on_commit_notify: |this: &mut InternalSurface, _data: *mut libc::c_void,|
@@ -65,6 +64,12 @@ wayland_listener!(InternalSurface, (Surface, Box<SurfaceHandler>), [
         Box::<InternalSurface>::from_raw((*surface_state_ptr).surface);
     };
 ]);
+
+impl InternalSurface {
+    pub(crate) unsafe fn data(&mut self) -> &mut (Surface, Box<SurfaceHandler>) {
+        &mut self.data
+    }
+}
 
 /// The state stored in the wlr_surface user data.
 pub(crate) struct InternalSurfaceState {
@@ -418,7 +423,7 @@ impl Drop for Surface {
                      self.surface);
         }
         unsafe {
-            let state = Box::from_raw((*self.surface).data as *mut InternalSurfaceState);
+            Box::from_raw((*self.surface).data as *mut InternalSurfaceState);
         }
     }
 }

--- a/src/xwayland/manager.rs
+++ b/src/xwayland/manager.rs
@@ -5,8 +5,10 @@ use wlroots_sys::wlr_xwayland_surface;
 
 use libc;
 
-use super::surface::{XWaylandShell, XWaylandSurface, XWaylandSurfaceHandle, XWaylandSurfaceHandler};
+use types::surface::InternalSurfaceState;
+use super::surface::{XWaylandShell, XWaylandSurface, XWaylandSurfaceHandle, XWaylandSurfaceHandler, XWaylandSurfaceState };
 use compositor::{compositor_handle, CompositorHandle};
+use SurfaceHandler;
 
 pub trait XWaylandManagerHandler {
     /// Callback that's triggered when the XWayland library is ready.
@@ -17,15 +19,15 @@ pub trait XWaylandManagerHandler {
     fn new_surface(&mut self,
                    CompositorHandle,
                    XWaylandSurfaceHandle)
-                   -> Option<Box<XWaylandSurfaceHandler>> {
+                   -> Option<(Box<XWaylandSurfaceHandler>, Box<SurfaceHandler>)> {
         None
     }
 }
 
-wayland_listener!(XWaylandManager, (Vec<Box<XWaylandShell>>, Box<XWaylandManagerHandler>), [
+wayland_listener!(XWaylandManager, Box<XWaylandManagerHandler>, [
     on_ready_listener => on_ready_notify: |this: &mut XWaylandManager, _data: *mut libc::c_void,|
     unsafe {
-        let (_, ref mut manager) = this.data;
+        let ref mut manager = this.data;
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
@@ -36,21 +38,22 @@ wayland_listener!(XWaylandManager, (Vec<Box<XWaylandShell>>, Box<XWaylandManager
     new_surface_listener => new_surface_notify: |this: &mut XWaylandManager,
                                                  data: *mut libc::c_void,|
     unsafe {
-        let surface_destroyed_listener = this.surface_destroyed_listener() as *mut _ as _;
-        let (ref mut shells, ref mut manager) = this.data;
+        let ref mut manager = this.data;
         let surface_ptr = data as *mut wlr_xwayland_surface;
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
         let shell_surface = XWaylandSurface::new(surface_ptr);
-        if let Some(handler) = manager.new_surface(compositor, shell_surface.weak_reference()) {
-            let mut shell = XWaylandShell::new((shell_surface, handler));
-            // Listen to destroy signal in this struct to free user data.
-            wl_signal_add(&mut (*surface_ptr).events.destroy as *mut _ as _,
-                          surface_destroyed_listener);
+        let res = manager.new_surface(compositor, shell_surface.weak_reference());
+        if let Some((xwayland_handler, surface_handler)) = res {
+            let mut shell = XWaylandShell::new((shell_surface, xwayland_handler));
+            let surface_state = (*(*surface_ptr).surface).data as *mut InternalSurfaceState;
+            (*(*surface_state).surface).data().1 = surface_handler;
 
-            // Add events to shell so user callbacks work.
+
+            wl_signal_add(&mut (*surface_ptr).events.destroy as *mut _ as _,
+                          shell.destroy_listener() as *mut _ as _);
             wl_signal_add(&mut (*surface_ptr).events.request_configure as *mut _ as _,
                           shell.request_configure_listener() as *mut _ as _);
             wl_signal_add(&mut (*surface_ptr).events.request_move as *mut _ as _,
@@ -77,28 +80,9 @@ wayland_listener!(XWaylandManager, (Vec<Box<XWaylandShell>>, Box<XWaylandManager
                           shell.set_window_type_listener() as *mut _ as _);
             wl_signal_add(&mut (*surface_ptr).events.ping_timeout as *mut _ as _,
                           shell.ping_timeout_listener() as *mut _ as _);
-            shells.push(shell);
+            let shell_data = (*surface_ptr).data as *mut XWaylandSurfaceState;
+            (*shell_data).shell = Box::into_raw(shell);
         }
         // TODO Pass in the new surface from the data
-    };
-    surface_destroyed_listener => surface_destroyed_notify: |this: &mut XWaylandManager,
-                                                             data: *mut libc::c_void,|
-    unsafe {
-        let (ref mut shells, _) = this.data;
-        let surface = data as *mut wlr_xwayland_surface;
-        let compositor = match compositor_handle() {
-            Some(handle) => handle,
-            None => return
-        };
-        let find_index = shells.iter()
-            .position(|shell| shell.as_ptr() == surface);
-        if let Some(index) = find_index {
-            let mut removed_shell = shells.remove(index);
-            let (ref shell_surface, ref mut manager) = *removed_shell.data();
-            let surface = shell_surface.surface();
-            manager.destroy(compositor,
-                            surface,
-                            shell_surface.weak_reference())
-        }
     };
 ]);

--- a/src/xwayland/manager.rs
+++ b/src/xwayland/manager.rs
@@ -19,9 +19,7 @@ pub trait XWaylandManagerHandler {
     fn new_surface(&mut self,
                    CompositorHandle,
                    XWaylandSurfaceHandle)
-                   -> Option<(Box<XWaylandSurfaceHandler>, Box<SurfaceHandler>)> {
-        None
-    }
+                   -> (Option<Box<XWaylandSurfaceHandler>>, Option<Box<SurfaceHandler>>);
 }
 
 wayland_listener!(XWaylandManager, Box<XWaylandManagerHandler>, [
@@ -46,10 +44,12 @@ wayland_listener!(XWaylandManager, Box<XWaylandManagerHandler>, [
         };
         let shell_surface = XWaylandSurface::new(surface_ptr);
         let res = manager.new_surface(compositor, shell_surface.weak_reference());
-        if let Some((xwayland_handler, surface_handler)) = res {
+        if let (Some(xwayland_handler), surface_handler) = res {
             let mut shell = XWaylandShell::new((shell_surface, xwayland_handler));
             let surface_state = (*(*surface_ptr).surface).data as *mut InternalSurfaceState;
-            (*(*surface_state).surface).data().1 = surface_handler;
+            if let Some(surface_handler) = surface_handler {
+                (*(*surface_state).surface).data().1 = surface_handler;
+            }
 
 
             wl_signal_add(&mut (*surface_ptr).events.destroy as *mut _ as _,

--- a/src/xwayland/manager.rs
+++ b/src/xwayland/manager.rs
@@ -6,7 +6,6 @@ use wlroots_sys::wlr_xwayland_surface;
 use libc;
 
 use super::surface::{XWaylandShell, XWaylandSurface, XWaylandSurfaceHandle, XWaylandSurfaceHandler};
-use SurfaceHandle;
 use compositor::{compositor_handle, CompositorHandle};
 
 pub trait XWaylandManagerHandler {
@@ -44,7 +43,6 @@ wayland_listener!(XWaylandManager, (Vec<Box<XWaylandShell>>, Box<XWaylandManager
             Some(handle) => handle,
             None => return
         };
-        let surface = SurfaceHandle::from_ptr((*surface_ptr).surface);
         let shell_surface = XWaylandSurface::new(surface_ptr);
         if let Some(handler) = manager.new_surface(compositor, shell_surface.weak_reference()) {
             let mut shell = XWaylandShell::new((shell_surface, handler));

--- a/src/xwayland/server.rs
+++ b/src/xwayland/server.rs
@@ -20,7 +20,7 @@ impl XWaylandServer {
         if xwayland.is_null() {
             panic!("Could not start XWayland server")
         }
-        let mut manager = XWaylandManager::new((vec![], manager));
+        let mut manager = XWaylandManager::new(manager);
         wl_signal_add(&mut (*xwayland).events.ready as *mut _ as _,
                       manager.on_ready_listener() as *mut _ as _);
         wl_signal_add(&mut (*xwayland).events.new_surface as *mut _ as _,

--- a/src/xwayland/surface.rs
+++ b/src/xwayland/surface.rs
@@ -4,7 +4,7 @@ use libc::{self, size_t, int16_t, uint16_t};
 
 use wlroots_sys::{pid_t, wl_event_source, wlr_xwayland_surface, xcb_atom_t, xcb_window_t};
 
-use {Surface, SurfaceHandle, XWaylandSurfaceHints, XWaylandSurfaceSizeHints};
+use {SurfaceHandle, XWaylandSurfaceHints, XWaylandSurfaceSizeHints};
 use compositor::{compositor_handle, CompositorHandle};
 use errors::{HandleErr, HandleResult};
 use events::xwayland_events::{ConfigureEvent, MoveEvent, ResizeEvent};
@@ -59,161 +59,174 @@ pub trait XWaylandSurfaceHandler {
     fn ping_timeout(&mut self, CompositorHandle, SurfaceHandle, XWaylandSurfaceHandle) {}
 }
 
-wayland_listener!(XWaylandShell, (XWaylandSurface, Surface, Box<XWaylandSurfaceHandler>), [
+wayland_listener!(XWaylandShell, (XWaylandSurface, Box<XWaylandSurfaceHandler>), [
     request_configure_listener => request_configure_notify: |this: &mut XWaylandShell,
                                                              data: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
         let event = ConfigureEvent::from_ptr(data as *mut _);
         manager.on_configure(compositor,
-                             surface.weak_reference(),
+                             surface,
                              shell_surface.weak_reference(),
                              &event);
     };
     request_move_listener => request_move_notify: |this: &mut XWaylandShell,
                                                    data: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
         let event = MoveEvent::from_ptr(data as *mut _);
         manager.on_move(compositor,
-                             surface.weak_reference(),
+                             surface,
                              shell_surface.weak_reference(),
                              &event);
     };
     request_resize_listener => request_resize_notify: |this: &mut XWaylandShell,
                                                        data: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
         let event = ResizeEvent::from_ptr(data as *mut _);
         manager.on_resize(compositor,
-                             surface.weak_reference(),
+                             surface,
                              shell_surface.weak_reference(),
                              &event);
     };
     request_maximize_listener => request_maximize_notify: |this: &mut XWaylandShell,
                                                            _data: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
         manager.on_maximize(compositor,
-                             surface.weak_reference(),
+                             surface,
                              shell_surface.weak_reference());
     };
     request_fullscreen_listener => request_fullscreen_notify: |this: &mut XWaylandShell,
                                                                _data: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
         manager.on_fullscreen(compositor,
-                            surface.weak_reference(),
+                            surface,
                             shell_surface.weak_reference());
     };
     map_listener => map_notify: |this: &mut XWaylandShell, _data: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
         manager.on_map(compositor,
-                            surface.weak_reference(),
+                            surface,
                             shell_surface.weak_reference());
     };
     unmap_listener => unmap_notify: |this: &mut XWaylandShell, _data: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
         manager.on_unmap(compositor,
-                       surface.weak_reference(),
+                       surface,
                        shell_surface.weak_reference());
     };
     set_title_listener => set_title_notify: |this: &mut XWaylandShell, _data: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
         manager.title_set(compositor,
-                       surface.weak_reference(),
+                       surface,
                        shell_surface.weak_reference());
     };
     set_class_listener => set_class_notify: |this: &mut XWaylandShell, _data: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
         manager.class_set(compositor,
-                       surface.weak_reference(),
+                       surface,
                        shell_surface.weak_reference());
     };
     set_parent_listener => set_parent_notify: |this: &mut XWaylandShell, _data: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
         manager.parent_set(compositor,
-                       surface.weak_reference(),
+                       surface,
                        shell_surface.weak_reference());
     };
     set_pid_listener => set_pid_notify: |this: &mut XWaylandShell, _data: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
         manager.pid_set(compositor,
-                       surface.weak_reference(),
+                       surface,
                        shell_surface.weak_reference());
     };
     set_window_type_listener => set_window_type_notify: |this: &mut XWaylandShell,
                                                          _data: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
         manager.window_type_set(compositor,
-                       surface.weak_reference(),
+                       surface,
                        shell_surface.weak_reference());
     };
     ping_timeout_listener => ping_timeout_notify: |this: &mut XWaylandShell,
                                                    _data: *mut libc::c_void,|
     unsafe {
-        let (ref shell_surface, ref surface, ref mut manager) = this.data;
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
         let compositor = match compositor_handle() {
             Some(handle) => handle,
             None => return
         };
         manager.ping_timeout(compositor,
-                             surface.weak_reference(),
+                             surface,
                              shell_surface.weak_reference());
     };
 ]);
@@ -224,7 +237,7 @@ impl XWaylandShell {
     }
 
     pub(crate) unsafe fn data(&mut self)
-                              -> &mut (XWaylandSurface, Surface, Box<XWaylandSurfaceHandler>) {
+                              -> &mut (XWaylandSurface, Box<XWaylandSurfaceHandler>) {
         &mut self.data
     }
 }

--- a/src/xwayland/surface.rs
+++ b/src/xwayland/surface.rs
@@ -2,6 +2,7 @@ use std::{panic, ptr, cell::Cell, rc::{Rc, Weak}};
 
 use libc::{self, size_t, int16_t, uint16_t};
 
+use wayland_sys::server::WAYLAND_SERVER_HANDLE;
 use wlroots_sys::{pid_t, wl_event_source, wlr_xwayland_surface, xcb_atom_t, xcb_window_t};
 
 use {SurfaceHandle, XWaylandSurfaceHints, XWaylandSurfaceSizeHints};
@@ -12,7 +13,7 @@ use utils::c_to_rust_string;
 
 pub trait XWaylandSurfaceHandler {
     /// Called when the XWayland surface is destroyed (e.g by the user).
-    fn destroy(&mut self, CompositorHandle, SurfaceHandle, XWaylandSurfaceHandle) {}
+    fn destroyed(&mut self, CompositorHandle, SurfaceHandle, XWaylandSurfaceHandle) {}
 
     /// Called when the XWayland surface wants to be configured.
     fn on_configure(&mut self,
@@ -60,6 +61,19 @@ pub trait XWaylandSurfaceHandler {
 }
 
 wayland_listener!(XWaylandShell, (XWaylandSurface, Box<XWaylandSurfaceHandler>), [
+    destroy_listener => destroy_notify: |this: &mut XWaylandShell, data: *mut libc::c_void,|
+    unsafe {
+        let (ref mut shell_surface, ref mut manager) = this.data;
+        let surface = shell_surface.surface();
+        let compositor = match compositor_handle() {
+            Some(handle) => handle,
+            None => return
+        };
+        manager.destroyed(compositor, surface, shell_surface.weak_reference());
+        let surface_ptr = data as *mut wlr_xwayland_surface;
+        let shell_state_ptr = (*surface_ptr).data as *mut XWaylandSurfaceState;
+        Box::from_raw((*shell_state_ptr).shell);
+    };
     request_configure_listener => request_configure_notify: |this: &mut XWaylandShell,
                                                              data: *mut libc::c_void,|
     unsafe {
@@ -231,18 +245,8 @@ wayland_listener!(XWaylandShell, (XWaylandSurface, Box<XWaylandSurfaceHandler>),
     };
 ]);
 
-impl XWaylandShell {
-    pub(crate) unsafe fn as_ptr(&self) -> *mut wlr_xwayland_surface {
-        self.data.0.as_ptr()
-    }
-
-    pub(crate) unsafe fn data(&mut self)
-                              -> &mut (XWaylandSurface, Box<XWaylandSurfaceHandler>) {
-        &mut self.data
-    }
-}
-
-struct XWaylandSurfaceState {
+pub(crate) struct XWaylandSurfaceState {
+    pub(crate) shell: *mut XWaylandShell,
     handle: Weak<Cell<bool>>
 }
 
@@ -270,7 +274,7 @@ impl XWaylandSurface {
     pub(crate) unsafe fn new(shell_surface: *mut wlr_xwayland_surface) -> Self {
         (*shell_surface).data = ptr::null_mut();
         let liveliness = Rc::new(Cell::new(false));
-        let state = Box::new(XWaylandSurfaceState { handle: Rc::downgrade(&liveliness) });
+        let state = Box::new(XWaylandSurfaceState { shell: ptr::null_mut(), handle: Rc::downgrade(&liveliness) });
         (*shell_surface).data = Box::into_raw(state) as *mut _;
         XWaylandSurface { liveliness,
                           shell_surface }
@@ -288,10 +292,6 @@ impl XWaylandSurface {
     pub fn weak_reference(&self) -> XWaylandSurfaceHandle {
         XWaylandSurfaceHandle { handle: Rc::downgrade(&self.liveliness),
                                 shell_surface: self.shell_surface }
-    }
-
-    unsafe fn as_ptr(&self) -> *mut wlr_xwayland_surface {
-        self.shell_surface
     }
 
     /// Get the window id for this surface.
@@ -572,3 +572,52 @@ impl PartialEq for XWaylandSurfaceHandle {
 }
 
 impl Eq for XWaylandSurfaceHandle {}
+
+impl Drop for XWaylandShell {
+    fn drop(&mut self) {
+        unsafe {
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          self.destroy_listener() as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          self.request_configure_listener() as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          self.request_move_listener() as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          self.request_resize_listener() as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          self.request_maximize_listener() as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          self.request_fullscreen_listener() as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          self.map_listener() as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          self.unmap_listener() as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          self.set_title_listener() as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          self.set_class_listener() as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          self.set_parent_listener() as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          self.set_pid_listener() as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          self.set_window_type_listener() as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          self.ping_timeout_listener() as *mut _ as _);
+        }
+    }
+}

--- a/wlroots-sys/src/wlroots.h
+++ b/wlroots-sys/src/wlroots.h
@@ -1,6 +1,7 @@
 /// Backend includes
 #include <wlr/backend.h>
 #include <wlr/backend/drm.h>
+#include <wlr/backend/headless.h>
 #include <wlr/backend/interface.h>
 #include <wlr/backend/libinput.h>
 #include <wlr/backend/multi.h>


### PR DESCRIPTION
This PR fixes enough of the problems that #183 should be well and truely closed.

CC @acrisci to make sure the API is where it should be.