### PR TITLE
Dehandle macro

### DIFF
--- a/examples/xdg_shell_v6_test.rs
+++ b/examples/xdg_shell_v6_test.rs
@@ -82,18 +82,19 @@ impl XdgV6ShellManagerHandler for XdgV6ShellManager {
                    compositor: CompositorHandle,
                    shell: XdgV6ShellSurfaceHandle)
                    -> (Option<Box<XdgV6ShellHandler>>, Option<Box<SurfaceHandler>>) {
-        with_handles!([(compositor: {compositor}), (shell: {shell})] => {
+        dehandle!(
+            @compositor = {compositor}?;
+            @shell = {shell}?;
             shell.ping();
             let state: &mut State = compositor.into();
             state.shells.push(shell.weak_reference());
-            with_handles!([(layout: {&mut state.layout})] => {
-                for (mut output, _) in layout.outputs() {
-                    with_handles!([(output: {output})] =>{
-                        output.schedule_frame()
-                    }).ok();
-                }
-            }).expect("Layout was destroyed");
-        }).unwrap();
+            @layout = {&state.layout}?;
+            for (mut output, _) in layout.outputs() {
+                with_handles!([(output: {output})] =>{
+                    output.schedule_frame()
+                }).ok();
+            }
+        ).unwrap().unwrap().unwrap();
         (Some(Box::new(XdgV6ShellHandlerEx)), Some(Box::new(SurfaceEx)))
     }
 }

--- a/examples/xdg_shell_v6_test.rs
+++ b/examples/xdg_shell_v6_test.rs
@@ -89,10 +89,9 @@ impl XdgV6ShellManagerHandler for XdgV6ShellManager {
             let state: &mut State = compositor.into();
             state.shells.push(shell.weak_reference());
             @layout = {&state.layout}?;
-            for (mut output, _) in layout.outputs() {
-                with_handles!([(output: {output})] =>{
-                    output.schedule_frame()
-                }).ok();
+            for (mut output, _) in layout.outputs() => {
+                @output = {output}?;
+                output.schedule_frame()
             }
         ).unwrap().unwrap().unwrap();
         (Some(Box::new(XdgV6ShellHandlerEx)), Some(Box::new(SurfaceEx)))

--- a/examples/xdg_shell_v6_test.rs
+++ b/examples/xdg_shell_v6_test.rs
@@ -83,17 +83,17 @@ impl XdgV6ShellManagerHandler for XdgV6ShellManager {
                    shell: XdgV6ShellSurfaceHandle)
                    -> (Option<Box<XdgV6ShellHandler>>, Option<Box<SurfaceHandler>>) {
         dehandle!(
-            @compositor = {compositor}?;
-            @shell = {shell}?;
+            @compositor = {compositor};
+            @shell = {shell};
             shell.ping();
             let state: &mut State = compositor.into();
             state.shells.push(shell.weak_reference());
-            @layout = {&state.layout}?;
+            @layout = {&state.layout};
             for (mut output, _) in layout.outputs() => {
-                @output = {output}?;
+                @output = {output};
                 output.schedule_frame()
             }
-        ).unwrap().unwrap().unwrap();
+        );
         (Some(Box::new(XdgV6ShellHandlerEx)), Some(Box::new(SurfaceEx)))
     }
 }
@@ -115,15 +115,15 @@ impl OutputManagerHandler for OutputManager {
                              -> Option<OutputBuilderResult<'output>> {
         let mut result = builder.build_best_mode(ExOutput);
         dehandle!(
-            @compositor = {compositor}?;
-            @output = {&mut result.output}?;
+            @compositor = {compositor};
+            @output = {&mut result.output};
             let state: &mut State = compositor.data.downcast_mut().unwrap();
             let xcursor_manager = &mut state.xcursor_manager;
             // TODO use output config if present instead of auto
             let layout = &mut state.layout;
             let cursor = &mut state.cursor;
-            @layout = {layout}?;
-            @cursor = {cursor}?;
+            @layout = {layout};
+            @cursor = {cursor};
             layout.add_auto(output);
             cursor.attach_output_layout(layout);
             xcursor_manager.load(output.scale());
@@ -131,7 +131,7 @@ impl OutputManagerHandler for OutputManager {
             let (x, y) = cursor.coords();
             // https://en.wikipedia.org/wiki/Mouse_warping
             cursor.warp(None, x, y)
-        ).unwrap().unwrap().unwrap().unwrap();
+        );
         Some(result)
     }
 }
@@ -142,7 +142,7 @@ impl KeyboardHandler for ExKeyboardHandler {
               _: KeyboardHandle,
               key_event: &KeyEvent) {
         dehandle!(
-            @compositor = {compositor}?;
+            @compositor = {compositor};
             for key in key_event.pressed_keys() {
                 if key == KEY_Escape {
                     wlroots::terminate();
@@ -162,7 +162,7 @@ impl KeyboardHandler for ExKeyboardHandler {
                                          key_event.keycode(),
                                          key_event.key_state() as u32);
             }).unwrap()
-        ).unwrap();
+        );
     }
 }
 
@@ -172,31 +172,31 @@ impl PointerHandler for ExPointer {
                           _: PointerHandle,
                           event: &AbsoluteMotionEvent) {
         dehandle!(
-            @compositor = {compositor}?;
+            @compositor = {compositor};
             let state: &mut State = compositor.into();
             let (x, y) = event.pos();
-            @cursor = {&state.cursor}?;
+            @cursor = {&state.cursor};
             cursor.warp_absolute(event.device(), x, y)
-        ).unwrap().unwrap();
+        );
     }
 
     fn on_motion(&mut self, compositor: CompositorHandle, _: PointerHandle, event: &MotionEvent) {
         dehandle!(
-            @compositor = {compositor}?;
+            @compositor = {compositor};
             let state: &mut State = compositor.into();
             let (delta_x, delta_y) = event.delta();
-            @cursor = {&state.cursor}?;
+            @cursor = {&state.cursor};
             cursor.move_to(event.device(), delta_x, delta_y)
-        ).unwrap().unwrap();
+        );
     }
 
     fn on_button(&mut self, compositor: CompositorHandle, _: PointerHandle, _: &ButtonEvent) {
         dehandle!(
-            @compositor = {compositor}?;
+            @compositor = {compositor};
             let state: &mut State = compositor.into();
             let seat = state.seat_handle.clone().unwrap();
             let keyboard = state.keyboard.clone().unwrap();
-            @shell = {&state.shells[0]}?;
+            @shell = {&state.shells[0]};
             match shell.state() {
                 Some(&mut XdgV6ShellState::TopLevel(ref mut toplevel)) => {
                     toplevel.set_activated(true);
@@ -204,22 +204,22 @@ impl PointerHandler for ExPointer {
                 _ => {}
             };
             let surface = shell.surface();
-            @seat = {seat}?;
-            @keyboard = {keyboard}?;
-            @surface = {surface}?;
+            @seat = {seat};
+            @keyboard = {keyboard};
+            @surface = {surface};
             seat.set_keyboard(keyboard.input_device());
             seat.keyboard_notify_enter(surface,
                                        &mut keyboard.keycodes(),
                                        &mut keyboard.get_modifier_masks())
-        ).unwrap().unwrap().unwrap().unwrap().unwrap();
+        );
     }
 }
 
 impl OutputHandler for ExOutput {
     fn on_frame(&mut self, compositor: CompositorHandle, output: OutputHandle) {
         dehandle!(
-            @compositor = {compositor}?;
-            @output = {output}?;
+            @compositor = {compositor};
+            @output = {output};
             let state: &mut State = compositor.data.downcast_mut().unwrap();
             let renderer = compositor.renderer
                 .as_mut()
@@ -227,7 +227,7 @@ impl OutputHandler for ExOutput {
             let mut render_context = renderer.render(output, None);
             render_context.clear([0.25, 0.25, 0.25, 1.0]);
             render_shells(state, &mut render_context)
-        ).unwrap().unwrap();
+        );
     }
 }
 
@@ -244,13 +244,13 @@ impl InputManagerHandler for InputManager {
                       keyboard: KeyboardHandle)
                       -> Option<Box<KeyboardHandler>> {
         dehandle!(
-            @compositor = {compositor}?;
-            @keyboard = {keyboard}?;
+            @compositor = {compositor};
+            @keyboard = {keyboard};
             let state: &mut State = compositor.into();
             state.keyboard = Some(keyboard.weak_reference());
-            @seat = {state.seat_handle.as_ref().unwrap()}?;
+            @seat = {state.seat_handle.as_ref().unwrap()};
             seat.set_keyboard(keyboard.input_device())
-        ).unwrap().unwrap().unwrap();
+        );
         Some(Box::new(ExKeyboardHandler))
     }
 }
@@ -291,9 +291,9 @@ fn render_shells(state: &mut State, renderer: &mut Renderer) {
     let shells = state.shells.clone();
     for mut shell in shells {
         dehandle!(
-            @shell = {shell}?;
-            @surface = {shell.surface()}?;
-            @layout = {&state.layout}?;
+            @shell = {shell};
+            @surface = {shell.surface()};
+            @layout = {&state.layout};
             let (width, height) = surface.current_state().size();
             let (render_width, render_height) =
                 (width * renderer.output.scale() as i32,
@@ -314,6 +314,6 @@ fn render_shells(state: &mut State, renderer: &mut Renderer) {
                 surface.send_frame_done(current_time());
             };
             ()
-        ).unwrap().unwrap().unwrap();
+        );
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -279,23 +279,69 @@ macro_rules! with_handles {
 /// Here is some code using `with_handles`:
 #[macro_export]
 macro_rules! dehandle {
+    // Handles going into an extra scope
+    ({$($b: tt)*}) => {
+        #[allow(unused_must_use)]
+        {dehandle!($($b)*)}
+    };
+    // Handles going into an extra scope with more things after it
+    ({$($b: tt)*} $($rest: tt)*) => {{
+        #[allow(unused_must_use)]
+        {dehandle!($($b)*)};
+        dehandle!($($rest)*)
+    }};
+    // While loop, nothing after it
+    (while $_: expr => {$($b: tt)*}) => {{
+        #[allow(unused_must_use)]
+        while $_ {
+            dehandle!($($b)*);
+        }
+    }};
+    // While loop, more stuff after it
+    (while $_: expr => {$($b: tt)*} $($rest: tt)*) => {{
+        #[allow(unused_must_use)]
+        while $_ {
+            dehandle!($($b)*);
+        }
+        dehandle!($($rest)*)
+    }};
+
+    // For loop, nothing after it
+    (for $_: pat in $__: expr => {$($b: tt)*}) => {{
+        #[allow(unused_must_use)]
+        for $_ in $__ {
+            dehandle!($($b)*);
+        }
+    }};
+    // For loop, more stuff after it
+    (for $_: pat in $__: expr => {$($b: tt)*} $($rest: tt)*) => {{
+        #[allow(unused_must_use)]
+        for $_ in $__ {
+            dehandle!($($b)*);
+        }
+        dehandle!($($rest)*)
+    }};
+    // @unhandle = {handle}?;
     (@$handle_name: ident = $unhandle_name: block?; $($rest: tt)+) => {
         with_handles!([($handle_name: $unhandle_name)] => {
             dehandle!($($rest)+)
         })
     };
+    // General expressions
     ($line: expr; $($rest: tt)*) => {
         {
             $line;
             dehandle!($($rest)*)
         }
     };
+    // General lines
     ($line: stmt; $($rest: tt)*) => {
         {
             $line;
             dehandle!($($rest)*)
         }
     };
+    // Result of the dehandle block
     ($line: expr) => {
         $line
     };

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -277,6 +277,41 @@ macro_rules! with_handles {
 /// To make this more clear, it is mandated that a ? is appended to each of these lines.
 ///
 /// Here is some code using `with_handles`:
+///
+/// ```no_run,no_run,ignore
+/// with_handles!([(compositor: {compositor})] => {
+///     let state: &mut State = compositor.into();
+///     with_handles!([(shell: {&state.shell_handle})] => {
+///         // Do stuff with shell
+///     }).unwrap();
+/// }).unwrap();
+/// ```
+///
+/// Here is that some code using `dehandle!`
+/// ```no_run,no_run,ignore
+///dehandle!(
+///    @compositor = {compositor_handle}?;
+///    let state: &mut State = compositor.into()
+///    @shell = {&state.shell_handle}?;
+///    // do stuff with shell
+///).unwrap().unwrap();
+///```
+///
+///
+/// Now here is that same code in dehandle! but this time without the ? error handling:
+/// ```no_run,no_run,ignore
+///dehandle!(
+///    @compositor = {compositor_handle};
+///    let state: &mut State = compositor.into()
+///    @shell = {&state.shell_handle};
+///    // do stuff with shell
+///);
+///```
+///
+/// If an error occurs in the `@` lines with out the `?` it will panic with
+/// an ok-ish stacktrace and an error message pointing out exactly which one
+/// failed (e.g. it would say unwrapping `{&state.shell_handle}` and
+/// placing the result in `shell` failed)
 #[macro_export]
 macro_rules! dehandle {
     // Handles going into an extra scope

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -321,6 +321,13 @@ macro_rules! dehandle {
         }
         dehandle!($($rest)*)
     }};
+    // @unhandle = {handle};
+    // This one will automatically unwrap the result.
+    (@$handle_name: ident = $unhandle_name: block; $($rest: tt)+) => {
+        with_handles!([($handle_name: $unhandle_name)] => {
+            dehandle!($($rest)+)
+        }).expect(concat!("Could not upgrade ", stringify!(unhandle_name), " and set the result to ", stringify!(handle_name)));
+    };
     // @unhandle = {handle}?;
     (@$handle_name: ident = $unhandle_name: block?; $($rest: tt)+) => {
         with_handles!([($handle_name: $unhandle_name)] => {


### PR DESCRIPTION
Add another way to strip handles away. This one is much nicer than `with_handles` but has a few limitations that means you will still need `with_handles`.

With `dehandle!` you can nest handle unwrapping but without having to indent:

```rust
dehandle!(
    @compositor = {compositor_handle}?;
    let state: &mut State = compositor.into()
    @shell = {state.shell_handle}?;
    // do stuff with shell
).unwrap().unwrap();
```
# Limitations
However, as you can see from the above (short) example there are limations.

First of all the errors are no longer joined into one and must be dealt with separately. This means many `unwrap`s or many `?`. This is something that cannot be fixed with this macro.

However, if you omit the `?` it will automatically unwrap it (with a good `expect` message) which is _usually_ what you want.

```rust
dehandle!(
    @compositor = {compositor_handle};
    let state: &mut State = compositor.into()
    @shell = {state.shell_handle};
    // do stuff with shell
);
```

~Second, you cannot use the `@` construct within nested blocks of the macro. This is a limitation that might be able to be worked around, but my ability to write Rust macros is not sufficient to do that currently. If anyone can offer a fix it would be greatly appreciated :smile:~

This has been fixed! You can now use `@` with in most nested contexts (I probably didn't cover all of them, for the ones I didn't the consensus is to use `with_handles!`).

Finally, the control flow is slightly harder to understand. I added the `?` to the `@` lines to make it clearer that this line might fail and that code before this line will have been executed but lines after it might not be if the handle is stale.

I have updated xdg shell test example with this new macro. There's only two places where it would not work. One was solved using the old `with_handles!` macro and the other is solved using a bare `run` call.