### PR TITLE
implement wlr_edges

### DIFF
--- a/src/events/xdg_shell_events.rs
+++ b/src/events/xdg_shell_events.rs
@@ -3,6 +3,7 @@
 use wlroots_sys::{wlr_xdg_toplevel_move_event, wlr_xdg_toplevel_resize_event,
                   wlr_xdg_toplevel_set_fullscreen_event,
                   wlr_xdg_toplevel_show_window_menu_event};
+use utils::Edges;
 
 use {OutputHandle, XdgShellSurfaceHandle};
 
@@ -64,8 +65,14 @@ impl ResizeEvent {
         unsafe { (*self.event).serial }
     }
 
-    pub fn edges(&self) -> u32 {
-        unsafe { (*self.event).edges }
+    pub fn edges(&self) -> Edges {
+        unsafe {
+            let edges_bits = (*self.event).edges;
+            match Edges::from_bits(edges_bits) {
+                Some(edges) => edges,
+                None => panic!("got invalid edges: {}", edges_bits)
+            }
+        }
     }
 }
 

--- a/src/events/xdg_shell_v6_events.rs
+++ b/src/events/xdg_shell_v6_events.rs
@@ -5,6 +5,7 @@ use wlroots_sys::{wlr_xdg_toplevel_v6_move_event, wlr_xdg_toplevel_v6_resize_eve
                   wlr_xdg_toplevel_v6_show_window_menu_event};
 
 use {OutputHandle, XdgV6ShellSurfaceHandle};
+use utils::Edges;
 
 /// Event that triggers when the surface has been moved in coordinate space.
 #[derive(Debug, PartialEq, Eq)]
@@ -64,8 +65,14 @@ impl ResizeEvent {
         unsafe { (*self.event).serial }
     }
 
-    pub fn edges(&self) -> u32 {
-        unsafe { (*self.event).edges }
+    pub fn edges(&self) -> Edges {
+        unsafe {
+            let edges_bits = (*self.event).edges;
+            match Edges::from_bits(edges_bits) {
+                Some(edges) => edges,
+                None => panic!("got invalid edges: {}", edges_bits)
+            }
+        }
     }
 }
 

--- a/src/events/xwayland_events.rs
+++ b/src/events/xwayland_events.rs
@@ -1,6 +1,7 @@
-use libc::{int16_t, uint16_t, uint32_t};
+use libc::{int16_t, uint16_t};
 use wlroots_sys::{wlr_xwayland_move_event, wlr_xwayland_resize_event,
                   wlr_xwayland_surface_configure_event};
+use utils::Edges;
 
 use XWaylandSurfaceHandle;
 
@@ -84,7 +85,13 @@ impl ResizeEvent {
     }
 
     /// Get the resize edge information for the resize action.
-    pub fn edges(&self) -> uint32_t {
-        unsafe { (*self.event).edges }
+    pub fn edges(&self) -> Edges {
+        unsafe {
+            let edges_bits = (*self.event).edges;
+            match Edges::from_bits(edges_bits) {
+                Some(edges) => edges,
+                None => panic!("got invalid edges: {}", edges_bits)
+            }
+        }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -120,3 +120,16 @@ pub fn current_time() -> Duration {
         Duration::new(ts.tv_sec as u64, ts.tv_nsec as u32)
     }
 }
+
+extern crate bitflags;
+use wlroots_sys::{wlr_edges};
+
+bitflags! {
+    pub struct Edges: u32 {
+        const WLR_EDGE_NONE = wlr_edges::WLR_EDGE_NONE as u32;
+        const WLR_EDGE_TOP = wlr_edges::WLR_EDGE_TOP as u32;
+        const WLR_EDGE_BOTTOM = wlr_edges::WLR_EDGE_BOTTOM as u32;
+        const WLR_EDGE_LEFT = wlr_edges::WLR_EDGE_LEFT as u32;
+        const WLR_EDGE_RIGHT = wlr_edges::WLR_EDGE_RIGHT as u32;
+    }
+}

--- a/wlroots-sys/src/wlroots.h
+++ b/wlroots-sys/src/wlroots.h
@@ -46,6 +46,7 @@
 
 /// Util includes
 #include <wlr/util/log.h>
+#include <wlr/util/edges.h>
 
 /// Misc includes
 #include <xcursor.h>


### PR DESCRIPTION
`wlr_edges` are an enum common to all the resize events to determine what edge is being resized.