### PR TITLE
Fixed the safety hole with textures

### DIFF
--- a/examples/rotation.rs
+++ b/examples/rotation.rs
@@ -33,7 +33,7 @@ impl Iterator for StepRange {
 }
 
 struct CompositorState {
-    cat_texture: Option<Texture>,
+    cat_texture: Option<Texture<'static>>,
     rotation: wl_output_transform,
     last_frame: Instant,
     x_offs: f32,

--- a/examples/touch.rs
+++ b/examples/touch.rs
@@ -21,7 +21,7 @@ struct TouchPoint {
 }
 
 struct State {
-    cat_texture: Option<Texture>,
+    cat_texture: Option<Texture<'static>>,
     touch_points: Vec<TouchPoint>
 }
 

--- a/src/render/texture.rs
+++ b/src/render/texture.rs
@@ -1,3 +1,5 @@
+use std::marker::PhantomData;
+
 use libc::c_int;
 use wlroots_sys::{wl_shm_format, wlr_texture, wlr_texture_get_size};
 
@@ -73,14 +75,19 @@ impl Into<wl_shm_format> for TextureFormat {
     }
 }
 
-#[derive(Debug)]
-pub struct Texture {
-    texture: *mut wlr_texture
+#[derive(Debug, Eq, PartialEq, Hash)]
+/// A wrapper for a wlr_texture.
+///
+/// For textures created from `GenericRenderer::create_texture_from_pixels`, the lifetime
+/// will be `'static` because the memory will be owned by the user.
+pub struct Texture<'surface> {
+    texture: *mut wlr_texture,
+    phantom: PhantomData<&'surface ()>
 }
 
-impl Texture {
-    pub(crate) unsafe fn from_ptr(texture: *mut wlr_texture) -> Self {
-        Texture { texture }
+impl <'surface> Texture<'surface> {
+    pub(crate) unsafe fn from_ptr<'unbound>(texture: *mut wlr_texture) -> Texture<'unbound> {
+        Texture { texture, phantom: PhantomData }
     }
 
     pub(crate) unsafe fn as_ptr(&self) -> *mut wlr_texture {

--- a/src/types/output/output_cursor.rs
+++ b/src/types/output/output_cursor.rs
@@ -125,7 +125,7 @@ impl OutputCursor {
 
     /// Gets the texture for the cursor, if a software cursor is used without a
     /// surface.
-    pub fn texture(&self) -> Option<Texture> {
+    pub fn texture<'surface>(&'surface self) -> Option<Texture<'surface>> {
         unsafe {
             let texture = (*self.cursor).texture;
             if texture.is_null() {

--- a/src/types/surface/surface.rs
+++ b/src/types/surface/surface.rs
@@ -202,7 +202,7 @@ impl Surface {
     }
 
     /// Get the texture of this surface.
-    pub fn texture(&self) -> Texture {
+    pub fn texture<'surface>(&'surface self) -> Texture<'surface> {
         unsafe { Texture::from_ptr((*self.surface).texture) }
     }
 


### PR DESCRIPTION
You can also destroy them now. This helps fix a bad memory leak in Way
Cooler (and any other WMs that create their own textures).

The memory model is a little weird, but it's required due to contraints
on when you can free the texture.

Specifically you can't free the texture when the renderer has begun
drawing, so it needs to be defined on the GenericRenderer.

Finally, you can only free ones you've created. In order to only have
one type, you can specify a type owned by the library user by creating
it and having the 'static lifetime associated with the struct. Only
instances with this lifetime can be freed (as otherwise it's handled
internally by wlroots, e.g. with surfaces from shell clients)