### PR TITLE
Add unstable-features to wlroots-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,9 @@ byteorder = "1"
 tempfile = "2"
 
 [features]
-default = ["static", "libcap", "systemd", "elogind"]
+default = ["static", "libcap", "systemd", "elogind", "unstable-features"]
 static = ["wlroots-sys/static"]
 libcap = ["wlroots-sys/libcap"]
 systemd = ["wlroots-sys/systemd"]
 elogind = ["wlroots-sys/elogind"]
+unstable-features = ["wlroots-sys/unstable-features"]


### PR DESCRIPTION
Currently wlroots-rs isn't building because wlroots-sys requires the `unstable-features` feature to compile. This has been added to the default features for wlroots-sys, but wlroots-rs had the defaults disabled in PR #136. This change adds `unstable-features` to the defaults for wlroots-rs.