### PR TITLE
Fix for linking errors

### DIFF
--- a/wlroots-sys/build.rs
+++ b/wlroots-sys/build.rs
@@ -56,6 +56,7 @@ fn main() {
     println!("cargo:rustc-link-lib=dylib=xcb-shm");
     println!("cargo:rustc-link-lib=dylib=xcb-icccm");
     println!("cargo:rustc-link-lib=dylib=xcb-xkb");
+    println!("cargo:rustc-link-lib=dylib=xcb-errors");
     println!("cargo:rustc-link-lib=dylib=wayland-egl");
     println!("cargo:rustc-link-lib=dylib=wayland-client");
     println!("cargo:rustc-link-lib=dylib=wayland-server");


### PR DESCRIPTION
When writing an hello-world compositor, I got "undefined reference" linking errors for symbols like "xcb_errors_get_name_for_major_code" when compiling. This PR fixes those errors for me.