### PR TITLE
Use libc::{clock_t, c_char} to allow compilation on ARM

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -40,7 +40,7 @@ macro_rules! wl_list_for_each {
 #[macro_export]
 macro_rules! c_str {
     ($s:expr) => {
-        concat!($s, "\0").as_ptr() as *const i8
+        concat!($s, "\0").as_ptr() as *const ::libc::c_char
     }
 }
 

--- a/src/types/output/output.rs
+++ b/src/types/output/output.rs
@@ -7,7 +7,7 @@ use std::mem::ManuallyDrop;
 use std::rc::{Rc, Weak};
 use std::time::Duration;
 
-use libc::{c_float, c_int};
+use libc::{c_float, c_int, clock_t};
 use wayland_sys::server::WAYLAND_SERVER_HANDLE;
 use wlroots_sys::{timespec, wl_list, wl_output_subpixel, wl_output_transform, wlr_output,
                   wlr_output_damage, wlr_output_effective_resolution, wlr_output_enable,
@@ -320,8 +320,8 @@ impl Output {
               U: Into<Option<&'a mut PixmanRegion>>
     {
         let when = when.into().map(|duration| {
-                                       timespec { tv_sec: duration.as_secs() as i64,
-                                                  tv_nsec: duration.subsec_nanos() as i64 }
+                                       timespec { tv_sec: duration.as_secs() as clock_t,
+                                                  tv_nsec: duration.subsec_nanos() as clock_t }
                                    });
         let when_ptr =
             when.map(|mut duration| &mut duration as *mut _).unwrap_or_else(|| ptr::null_mut());

--- a/src/types/output/output_damage.rs
+++ b/src/types/output/output_damage.rs
@@ -1,4 +1,4 @@
-use libc::{c_int, c_uint};
+use libc::{c_int, c_uint, clock_t};
 use std::{mem, ptr, time::Duration};
 use wlroots_sys::{timespec, wlr_output, wlr_output_damage, wlr_output_damage_add,
                   wlr_output_damage_add_box, wlr_output_damage_add_whole,
@@ -118,8 +118,8 @@ impl OutputDamage {
     {
         unsafe {
             let when = when.into().map(|duration| {
-                                           timespec { tv_sec: duration.as_secs() as i64,
-                                                      tv_nsec: duration.subsec_nanos() as i64 }
+                                           timespec { tv_sec: duration.as_secs() as clock_t,
+                                                      tv_nsec: duration.subsec_nanos() as clock_t }
                                        });
             let when_ptr =
                 when.map(|mut duration| &mut duration as *mut _).unwrap_or_else(|| ptr::null_mut());

--- a/src/types/surface/surface.rs
+++ b/src/types/surface/surface.rs
@@ -292,8 +292,8 @@ impl Surface {
             // FIXME
             // This is converting from a u64 -> i64
             // Something bad could happen!
-            let when = timespec { tv_sec: duration.as_secs() as i64,
-                                  tv_nsec: duration.subsec_nanos() as i64 };
+            let when = timespec { tv_sec: duration.as_secs() as libc::clock_t,
+                                  tv_nsec: duration.subsec_nanos() as libc::clock_t };
             wlr_surface_send_frame_done(self.surface, &when);
         }
     }


### PR DESCRIPTION
This is related to but does not 100% solve Issue #205.

The style difference (`::libc` versus `use libc::{ ... }`) is just because I used whatever I saw in the particular source file I was editing. `macros.rs` doesn't seem to `use`-import anything.