### PR TITLE
Cleaning the pointer example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,8 @@ If you don't want to compile against wlroots statically, add the `--no-default-f
 
 # Examples
 See [the examples directory](https://github.com/swaywm/wlroots-rs/tree/master/examples) for basic examples using this library and at [Way Cooler the primary user of this library](https://github.com/way-cooler/way-cooler).
+
+You can run an example using the following command:
+```bash
+cargo run --example <name of the example>
+```


### PR DESCRIPTION
## Includes:
- Add the cargo command to run an example from the examples directory
- Cleaning the `pointer.rs` example

The following enhancements will also be added in future pull requests:
- Cleaning the `rotation.rs` example
- Cleaning the `tablet.rs` example
- Cleaning the `touch.rs` example
- Cleaning the `xdg_shell_v6_test.rs` example
