### PR TITLE
Use vsprintf to format the message to LogCallback

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ wayland-sys = { version = "0.9.*", features = ["client", "dlopen", "server",] }
 lazy_static = "0.2"
 xkbcommon = "0.3"
 bitflags = "1.0"
+vsprintf = "1.0.1"
 
 [dev-dependencies]
 wayland-client = { version = "0.12.*" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
 extern crate bitflags;
 extern crate lazy_static;
 extern crate libc;
+extern crate vsprintf;
 #[macro_use]
 pub extern crate wayland_sys;
 pub extern crate wlroots_sys;


### PR DESCRIPTION
## Includes
- Add the [vsprintf](https://docs.rs/vsprintf/1.0.1/vsprintf/) module
- Formatting the message in utils -> log_callback

## Preview:
**Before: **
![before_format](https://user-images.githubusercontent.com/35472759/47609730-66935c00-da12-11e8-98a3-ceca4509dbc4.png)

**After: **
![after_format](https://user-images.githubusercontent.com/35472759/47609739-a8240700-da12-11e8-9656-e50654039d42.png)
