### PR TITLE
XWayland: fix segfault on new surface

### DIFF
--- a/src/xwayland/manager.rs
+++ b/src/xwayland/manager.rs
@@ -5,10 +5,8 @@ use wlroots_sys::wlr_xwayland_surface;
 
 use libc;
 
-use types::surface::InternalSurfaceState;
 use super::surface::{XWaylandShell, XWaylandSurface, XWaylandSurfaceHandle, XWaylandSurfaceHandler, XWaylandSurfaceState };
 use compositor::{compositor_handle, CompositorHandle};
-use SurfaceHandler;
 
 pub trait XWaylandManagerHandler {
     /// Callback that's triggered when the XWayland library is ready.
@@ -19,7 +17,7 @@ pub trait XWaylandManagerHandler {
     fn new_surface(&mut self,
                    CompositorHandle,
                    XWaylandSurfaceHandle)
-                   -> (Option<Box<XWaylandSurfaceHandler>>, Option<Box<SurfaceHandler>>);
+                   -> Option<Box<XWaylandSurfaceHandler>>;
 }
 
 wayland_listener!(XWaylandManager, Box<XWaylandManagerHandler>, [
@@ -43,14 +41,8 @@ wayland_listener!(XWaylandManager, Box<XWaylandManagerHandler>, [
             None => return
         };
         let shell_surface = XWaylandSurface::new(surface_ptr);
-        let (xwayland_handler, surface_handler) =
-        manager.new_surface(compositor, shell_surface.weak_reference());
+        let xwayland_handler = manager.new_surface(compositor, shell_surface.weak_reference());
         let mut shell = XWaylandShell::new((shell_surface, xwayland_handler));
-        let surface_state = (*(*surface_ptr).surface).data as *mut InternalSurfaceState;
-        if let Some(surface_handler) = surface_handler {
-            (*(*surface_state).surface).data().1 = surface_handler;
-        }
-
 
         wl_signal_add(&mut (*surface_ptr).events.destroy as *mut _ as _,
                         shell.destroy_listener() as *mut _ as _);


### PR DESCRIPTION
On the new_surface event, the xwayland shell surface does not have a
cooresponding wlr_surface so trying to access it will segfault.

XWayland shell surfaces gain a new surface on each map event, so accept
the SurfaceHandler on that event instead of when the shell surface is
created.

Update some places in the code that assume the XWayland shell surface
will always have a wlr surface.