### PR TITLE
Unmapped xdg shell

### DIFF
--- a/src/manager/xdg_shell_handler.rs
+++ b/src/manager/xdg_shell_handler.rs
@@ -16,7 +16,6 @@ pub trait XdgShellHandler {
     fn on_commit(&mut self, CompositorHandle, SurfaceHandle, XdgShellSurfaceHandle) {}
 
     /// Called when the wayland shell is destroyed (e.g by the user)
-
     fn destroyed(&mut self, CompositorHandle, XdgShellSurfaceHandle) {}
 
     /// Called when the ping request timed out.
@@ -290,6 +289,9 @@ impl XdgShell {
 impl Drop for XdgShell {
     fn drop(&mut self) {
         unsafe {
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          &mut (*self.destroy_listener()).link as *mut _ as _);
             ffi_dispatch!(WAYLAND_SERVER_HANDLE,
                         wl_list_remove,
                         &mut (*self.commit_listener()).link as *mut _ as _);

--- a/src/manager/xdg_shell_manager.rs
+++ b/src/manager/xdg_shell_manager.rs
@@ -66,9 +66,9 @@ wayland_listener!(XdgShellManager, Box<XdgShellManagerHandler>, [
                         shell_surface.unmap_listener() as _);
         let events = with_handles!([(shell_surface: {shell_surface.surface_mut()})] => {
             match shell_surface.state() {
-                None | Some(&mut Popup(_)) | Some(&mut PopupInert(_)) => None,
+                None | Some(&mut Popup(_)) | Some(&mut PopupUnmapped(_)) => None,
                 Some(&mut TopLevel(ref mut toplevel)) |
-                Some(&mut TopLevelInert(ref mut toplevel)) => Some((*toplevel.as_ptr()).events)
+                Some(&mut TopLevelUnmapped(ref mut toplevel)) => Some((*toplevel.as_ptr()).events)
             }
         }).expect("Cannot borrow xdg shell surface");
         if let Some(mut events) = events {

--- a/src/manager/xdg_shell_manager.rs
+++ b/src/manager/xdg_shell_manager.rs
@@ -66,8 +66,9 @@ wayland_listener!(XdgShellManager, Box<XdgShellManagerHandler>, [
                         shell_surface.unmap_listener() as _);
         let events = with_handles!([(shell_surface: {shell_surface.surface_mut()})] => {
             match shell_surface.state() {
-                None | Some(&mut Popup(_)) => None,
-                Some(&mut TopLevel(ref mut toplevel)) => Some((*toplevel.as_ptr()).events)
+                None | Some(&mut Popup(_)) | Some(&mut PopupInert(_)) => None,
+                Some(&mut TopLevel(ref mut toplevel)) |
+                Some(&mut TopLevelInert(ref mut toplevel)) => Some((*toplevel.as_ptr()).events)
             }
         }).expect("Cannot borrow xdg shell surface");
         if let Some(mut events) = events {

--- a/src/manager/xdg_shell_v6_handler.rs
+++ b/src/manager/xdg_shell_v6_handler.rs
@@ -292,6 +292,9 @@ impl Drop for XdgV6Shell {
         unsafe {
             ffi_dispatch!(WAYLAND_SERVER_HANDLE,
                           wl_list_remove,
+                          &mut (*self.destroy_listener()).link as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
                           &mut (*self.commit_listener()).link as *mut _ as _);
             ffi_dispatch!(WAYLAND_SERVER_HANDLE,
                           wl_list_remove,

--- a/src/manager/xdg_shell_v6_manager.rs
+++ b/src/manager/xdg_shell_v6_manager.rs
@@ -66,9 +66,9 @@ wayland_listener!(XdgV6ShellManager, Box<XdgV6ShellManagerHandler>, [
                         shell_surface.unmap_listener() as _);
         let events = with_handles!([(shell_surface: {shell_surface.surface_mut()})] => {
             match shell_surface.state() {
-                None | Some(&mut Popup(_)) | Some(&mut PopupInert(_)) => None,
+                None | Some(&mut Popup(_)) | Some(&mut PopupUnmapped(_)) => None,
                 Some(&mut TopLevel(ref mut toplevel)) |
-                Some(&mut TopLevelInert(ref mut toplevel)) => Some((*toplevel.as_ptr()).events)
+                Some(&mut TopLevelUnmapped(ref mut toplevel)) => Some((*toplevel.as_ptr()).events)
             }
         }).expect("Cannot borrow xdg shell surface");
         if let Some(mut events) = events {

--- a/src/manager/xdg_shell_v6_manager.rs
+++ b/src/manager/xdg_shell_v6_manager.rs
@@ -66,8 +66,9 @@ wayland_listener!(XdgV6ShellManager, Box<XdgV6ShellManagerHandler>, [
                         shell_surface.unmap_listener() as _);
         let events = with_handles!([(shell_surface: {shell_surface.surface_mut()})] => {
             match shell_surface.state() {
-                None | Some(&mut Popup(_)) => None,
-                Some(&mut TopLevel(ref mut toplevel)) => Some((*toplevel.as_ptr()).events)
+                None | Some(&mut Popup(_)) | Some(&mut PopupInert(_)) => None,
+                Some(&mut TopLevel(ref mut toplevel)) |
+                Some(&mut TopLevelInert(ref mut toplevel)) => Some((*toplevel.as_ptr()).events)
             }
         }).expect("Cannot borrow xdg shell surface");
         if let Some(mut events) = events {

--- a/src/types/shell/xdg_shell.rs
+++ b/src/types/shell/xdg_shell.rs
@@ -49,14 +49,14 @@ pub enum XdgShellState {
     ///
     /// If the client reuses the xdg surface it must make a top level as the role,
     /// so this could become non-inert again.
-    TopLevelInert(XdgTopLevel),
+    TopLevelUnmapped(XdgTopLevel),
     Popup(XdgPopup),
     /// A popup that has been destroyed. The state is not dropped but none
     /// of the functions can be used.
     ///
     /// If the client reuses the xdg surface it must make a popup as the role,
     /// so this could become non-inert again.
-    PopupInert(XdgPopup)
+    PopupUnmapped(XdgPopup)
 }
 
 #[derive(Debug)]
@@ -312,15 +312,15 @@ impl XdgShellSurfaceHandle {
         let mut xdg_surface = unsafe { self.upgrade()? };
         match (xdg_surface.role(), xdg_surface.state.take()) {
             (WLR_XDG_SURFACE_ROLE_NONE, Some(XdgShellState::TopLevel(toplevel))) => {
-                xdg_surface.state = Some(XdgShellState::TopLevelInert(toplevel))
+                xdg_surface.state = Some(XdgShellState::TopLevelUnmapped(toplevel))
             }
-            (WLR_XDG_SURFACE_ROLE_TOPLEVEL, Some(XdgShellState::TopLevelInert(toplevel))) => {
+            (WLR_XDG_SURFACE_ROLE_TOPLEVEL, Some(XdgShellState::TopLevelUnmapped(toplevel))) => {
                 xdg_surface.state = Some(XdgShellState::TopLevel(toplevel))
             }
             (WLR_XDG_SURFACE_ROLE_NONE, Some(XdgShellState::Popup(popup))) => {
-                xdg_surface.state = Some(XdgShellState::PopupInert(popup))
+                xdg_surface.state = Some(XdgShellState::PopupUnmapped(popup))
             }
-            (WLR_XDG_SURFACE_ROLE_POPUP, Some(XdgShellState::PopupInert(popup))) => {
+            (WLR_XDG_SURFACE_ROLE_POPUP, Some(XdgShellState::PopupUnmapped(popup))) => {
                 xdg_surface.state = Some(XdgShellState::Popup(popup))
             }
             (_, state) => {
@@ -541,9 +541,9 @@ impl XdgShellState {
                 TopLevel(XdgTopLevel { shell_surface,
                                        toplevel })
             }
-            TopLevelInert(XdgTopLevel { shell_surface,
+            TopLevelUnmapped(XdgTopLevel { shell_surface,
                                         toplevel }) => {
-                TopLevelInert(XdgTopLevel { shell_surface,
+                TopLevelUnmapped(XdgTopLevel { shell_surface,
                                             toplevel })
             }
             Popup(XdgPopup { shell_surface,
@@ -551,9 +551,9 @@ impl XdgShellState {
                 Popup(XdgPopup { shell_surface,
                                  popup })
             }
-            PopupInert(XdgPopup { shell_surface,
+            PopupUnmapped(XdgPopup { shell_surface,
                                   popup }) => {
-                PopupInert(XdgPopup { shell_surface,
+                PopupUnmapped(XdgPopup { shell_surface,
                                       popup })
             }
         }

--- a/src/types/shell/xdg_shell.rs
+++ b/src/types/shell/xdg_shell.rs
@@ -338,8 +338,10 @@ impl XdgTopLevel {
     pub(crate) unsafe fn from_shell(shell_surface: *mut wlr_xdg_surface,
                                     toplevel: *mut wlr_xdg_toplevel)
                                     -> XdgTopLevel {
-        XdgTopLevel { shell_surface,
-                        toplevel }
+        let toplevel = XdgTopLevel { shell_surface,
+                                     toplevel };
+        toplevel.assert_toplevel();
+        toplevel
     }
 
     /// Get the title associated with this XDG shell toplevel.

--- a/src/types/shell/xdg_shell.rs
+++ b/src/types/shell/xdg_shell.rs
@@ -344,11 +344,13 @@ impl XdgTopLevel {
 
     /// Get the title associated with this XDG shell toplevel.
     pub fn title(&self) -> String {
+        self.assert_toplevel();
         unsafe { c_to_rust_string((*self.toplevel).title).expect("Could not parse class as UTF-8") }
     }
 
     /// Get the app id associated with this XDG shell toplevel.
     pub fn app_id(&self) -> String {
+        self.assert_toplevel();
         unsafe {
             c_to_rust_string((*self.toplevel).app_id).expect("Could not parse class as UTF-8")
         }
@@ -356,30 +358,36 @@ impl XdgTopLevel {
 
     /// Get a handle to the base surface of the xdg tree.
     pub fn base(&self) -> XdgShellSurfaceHandle {
+        self.assert_toplevel();
         unsafe { XdgShellSurfaceHandle::from_ptr((*self.toplevel).base) }
     }
 
     /// Get a handle to the parent surface of the xdg tree.
     pub fn parent(&self) -> XdgShellSurfaceHandle {
+        self.assert_toplevel();
         unsafe { XdgShellSurfaceHandle::from_ptr((*self.toplevel).parent) }
     }
 
     pub fn added(&self) -> bool {
+        self.assert_toplevel();
         unsafe { (*self.toplevel).added }
     }
 
     /// Get the pending client state.
     pub fn client_pending_state(&self) -> wlr_xdg_toplevel_state {
+        self.assert_toplevel();
         unsafe { (*self.toplevel).client_pending }
     }
 
     /// Get the pending server state.
     pub fn server_pending_state(&self) -> wlr_xdg_toplevel_state {
+        self.assert_toplevel();
         unsafe { (*self.toplevel).server_pending }
     }
 
     /// Get the current configure state.
     pub fn current_state(&self) -> wlr_xdg_toplevel_state {
+        self.assert_toplevel();
         unsafe { (*self.toplevel).current }
     }
 
@@ -387,6 +395,7 @@ impl XdgTopLevel {
     ///
     /// Returns the associated configure serial.
     pub fn set_size(&mut self, width: u32, height: u32) -> u32 {
+        self.assert_toplevel();
         unsafe { wlr_xdg_toplevel_set_size(self.shell_surface, width, height) }
     }
 
@@ -395,6 +404,7 @@ impl XdgTopLevel {
     ///
     /// Returns the associated configure serial.
     pub fn set_activated(&mut self, activated: bool) -> u32 {
+        self.assert_toplevel();
         unsafe { wlr_xdg_toplevel_set_activated(self.shell_surface, activated) }
     }
 
@@ -403,6 +413,7 @@ impl XdgTopLevel {
     ///
     /// Returns the associated configure serial.
     pub fn set_maximized(&mut self, maximized: bool) -> u32 {
+        self.assert_toplevel();
         unsafe { wlr_xdg_toplevel_set_maximized(self.shell_surface, maximized) }
     }
 
@@ -411,6 +422,7 @@ impl XdgTopLevel {
     ///
     /// Returns the associated configure serial.
     pub fn set_fullscreen(&mut self, fullscreen: bool) -> u32 {
+        self.assert_toplevel();
         unsafe { wlr_xdg_toplevel_set_fullscreen(self.shell_surface, fullscreen) }
     }
 
@@ -419,16 +431,27 @@ impl XdgTopLevel {
     ///
     /// Returns the associated configure serial.
     pub fn set_resizing(&mut self, resizing: bool) -> u32 {
+        self.assert_toplevel();
         unsafe { wlr_xdg_toplevel_set_resizing(self.shell_surface, resizing) }
     }
 
     /// Request that this toplevel surface closes.
     pub fn close(&mut self) {
+        self.assert_toplevel();
         unsafe { wlr_xdg_surface_send_close(self.shell_surface) }
     }
 
     pub(crate) unsafe fn as_ptr(&self) -> *mut wlr_xdg_toplevel {
         self.toplevel
+    }
+
+    /// Asserts that this is indeed a toplevel. This is done in wlroots, but is
+    /// also added here to make it easier to detect bugs.
+    fn assert_toplevel(&self) {
+        use wlroots_sys::wlr_xdg_surface_role::WLR_XDG_SURFACE_ROLE_TOPLEVEL;
+        unsafe {
+            assert!((*self.shell_surface).role == WLR_XDG_SURFACE_ROLE_TOPLEVEL);
+        }
     }
 }
 

--- a/src/types/shell/xdg_shell.rs
+++ b/src/types/shell/xdg_shell.rs
@@ -450,7 +450,12 @@ impl XdgTopLevel {
     fn assert_toplevel(&self) {
         use wlroots_sys::wlr_xdg_surface_role::WLR_XDG_SURFACE_ROLE_TOPLEVEL;
         unsafe {
-            assert!((*self.shell_surface).role == WLR_XDG_SURFACE_ROLE_TOPLEVEL);
+            if (*self.shell_surface).role != WLR_XDG_SURFACE_ROLE_TOPLEVEL {
+                wlr_log!(WLR_ERROR, "Expected {:?} got {:?}",
+                         WLR_XDG_SURFACE_ROLE_TOPLEVEL,
+                         (*self.shell_surface).role);
+                assert!((*self.shell_surface).role == WLR_XDG_SURFACE_ROLE_TOPLEVEL);
+            }
         }
     }
 }

--- a/src/types/shell/xdg_shell_v6.rs
+++ b/src/types/shell/xdg_shell_v6.rs
@@ -334,11 +334,13 @@ impl XdgV6TopLevel {
 
     /// Get the title associated with this XDG shell toplevel.
     pub fn title(&self) -> String {
+        self.assert_toplevel();
         unsafe { c_to_rust_string((*self.toplevel).title).expect("Could not parse class as UTF-8") }
     }
 
     /// Get the app id associated with this XDG shell toplevel.
     pub fn app_id(&self) -> String {
+        self.assert_toplevel();
         unsafe {
             c_to_rust_string((*self.toplevel).app_id).expect("Could not parse class as UTF-8")
         }
@@ -346,30 +348,36 @@ impl XdgV6TopLevel {
 
     /// Get a handle to the base surface of the xdg tree.
     pub fn base(&self) -> XdgV6ShellSurfaceHandle {
+        self.assert_toplevel();
         unsafe { XdgV6ShellSurfaceHandle::from_ptr((*self.toplevel).base) }
     }
 
     /// Get a handle to the parent surface of the xdg tree.
     pub fn parent(&self) -> XdgV6ShellSurfaceHandle {
+        self.assert_toplevel();
         unsafe { XdgV6ShellSurfaceHandle::from_ptr((*self.toplevel).parent) }
     }
 
     pub fn added(&self) -> bool {
+        self.assert_toplevel();
         unsafe { (*self.toplevel).added }
     }
 
     /// Get the pending client state.
     pub fn client_pending_state(&self) -> wlr_xdg_toplevel_v6_state {
+        self.assert_toplevel();
         unsafe { (*self.toplevel).client_pending }
     }
 
     /// Get the pending server state.
     pub fn server_pending_state(&self) -> wlr_xdg_toplevel_v6_state {
+        self.assert_toplevel();
         unsafe { (*self.toplevel).server_pending }
     }
 
     /// Get the current configure state.
     pub fn current_state(&self) -> wlr_xdg_toplevel_v6_state {
+        self.assert_toplevel();
         unsafe { (*self.toplevel).current }
     }
 
@@ -377,6 +385,7 @@ impl XdgV6TopLevel {
     ///
     /// Returns the associated configure serial.
     pub fn set_size(&mut self, width: u32, height: u32) -> u32 {
+        self.assert_toplevel();
         unsafe { wlr_xdg_toplevel_v6_set_size(self.shell_surface, width, height) }
     }
 
@@ -385,6 +394,7 @@ impl XdgV6TopLevel {
     ///
     /// Returns the associated configure serial.
     pub fn set_activated(&mut self, activated: bool) -> u32 {
+        self.assert_toplevel();
         unsafe { wlr_xdg_toplevel_v6_set_activated(self.shell_surface, activated) }
     }
 
@@ -393,6 +403,7 @@ impl XdgV6TopLevel {
     ///
     /// Returns the associated configure serial.
     pub fn set_maximized(&mut self, maximized: bool) -> u32 {
+        self.assert_toplevel();
         unsafe { wlr_xdg_toplevel_v6_set_maximized(self.shell_surface, maximized) }
     }
 
@@ -401,6 +412,7 @@ impl XdgV6TopLevel {
     ///
     /// Returns the associated configure serial.
     pub fn set_fullscreen(&mut self, fullscreen: bool) -> u32 {
+        self.assert_toplevel();
         unsafe { wlr_xdg_toplevel_v6_set_fullscreen(self.shell_surface, fullscreen) }
     }
 
@@ -409,16 +421,27 @@ impl XdgV6TopLevel {
     ///
     /// Returns the associated configure serial.
     pub fn set_resizing(&mut self, resizing: bool) -> u32 {
+        self.assert_toplevel();
         unsafe { wlr_xdg_toplevel_v6_set_resizing(self.shell_surface, resizing) }
     }
 
     /// Request that this toplevel surface closes.
     pub fn close(&mut self) {
+        self.assert_toplevel();
         unsafe { wlr_xdg_surface_v6_send_close(self.shell_surface) }
     }
 
     pub(crate) unsafe fn as_ptr(&self) -> *mut wlr_xdg_toplevel_v6 {
         self.toplevel
+    }
+
+    /// Asserts that this is indeed a toplevel. This is done in wlroots, but is
+    /// also added here to make it easier to detect bugs.
+    fn assert_toplevel(&self) {
+        use wlroots_sys::wlr_xdg_surface_v6_role::WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL;
+        unsafe {
+            assert!((*self.shell_surface).role == WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL);
+        }
     }
 }
 

--- a/src/types/shell/xdg_shell_v6.rs
+++ b/src/types/shell/xdg_shell_v6.rs
@@ -358,8 +358,10 @@ impl XdgV6TopLevel {
     pub(crate) unsafe fn from_shell(shell_surface: *mut wlr_xdg_surface_v6,
                                     toplevel: *mut wlr_xdg_toplevel_v6)
                                     -> XdgV6TopLevel {
-        XdgV6TopLevel { shell_surface,
-                        toplevel }
+        let toplevel = XdgV6TopLevel { shell_surface,
+                                       toplevel };
+        toplevel.assert_toplevel();
+        toplevel
     }
 
     /// Get the title associated with this XDG shell toplevel.

--- a/src/types/shell/xdg_shell_v6.rs
+++ b/src/types/shell/xdg_shell_v6.rs
@@ -440,7 +440,12 @@ impl XdgV6TopLevel {
     fn assert_toplevel(&self) {
         use wlroots_sys::wlr_xdg_surface_v6_role::WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL;
         unsafe {
-            assert!((*self.shell_surface).role == WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL);
+            if (*self.shell_surface).role != WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL {
+                wlr_log!(WLR_ERROR, "Expected {:?} got {:?}",
+                         WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL,
+                         (*self.shell_surface).role);
+                assert!((*self.shell_surface).role == WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL);
+            }
         }
     }
 }

--- a/src/types/shell/xdg_shell_v6.rs
+++ b/src/types/shell/xdg_shell_v6.rs
@@ -48,14 +48,14 @@ pub enum XdgV6ShellState {
     ///
     /// If the client reuses the xdg surface it must make a top level as the role,
     /// so this could become non-inert again.
-    TopLevelInert(XdgV6TopLevel),
+    TopLevelUnmapped(XdgV6TopLevel),
     Popup(XdgV6Popup),
     /// A popup that has been destroyed. The state is not dropped but none
     /// of the functions can be used.
     ///
     /// If the client reuses the xdg surface it must make a popup as the role,
     /// so this could become non-inert again.
-    PopupInert(XdgV6Popup)
+    PopupUnmapped(XdgV6Popup)
 }
 
 #[derive(Debug)]
@@ -302,15 +302,15 @@ impl XdgV6ShellSurfaceHandle {
         let mut xdg_surface = unsafe { self.upgrade()? };
         match (xdg_surface.role(), xdg_surface.state.take()) {
             (WLR_XDG_SURFACE_V6_ROLE_NONE, Some(XdgV6ShellState::TopLevel(toplevel))) => {
-                xdg_surface.state = Some(XdgV6ShellState::TopLevelInert(toplevel))
+                xdg_surface.state = Some(XdgV6ShellState::TopLevelUnmapped(toplevel))
             }
-            (WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL, Some(XdgV6ShellState::TopLevelInert(toplevel))) => {
+            (WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL, Some(XdgV6ShellState::TopLevelUnmapped(toplevel))) => {
                 xdg_surface.state = Some(XdgV6ShellState::TopLevel(toplevel))
             }
             (WLR_XDG_SURFACE_V6_ROLE_NONE, Some(XdgV6ShellState::Popup(popup))) => {
-                xdg_surface.state = Some(XdgV6ShellState::PopupInert(popup))
+                xdg_surface.state = Some(XdgV6ShellState::PopupUnmapped(popup))
             }
-            (WLR_XDG_SURFACE_V6_ROLE_POPUP, Some(XdgV6ShellState::PopupInert(popup))) => {
+            (WLR_XDG_SURFACE_V6_ROLE_POPUP, Some(XdgV6ShellState::PopupUnmapped(popup))) => {
                 xdg_surface.state = Some(XdgV6ShellState::Popup(popup))
             }
             (_, state) => {
@@ -531,9 +531,9 @@ impl XdgV6ShellState {
                 TopLevel(XdgV6TopLevel { shell_surface,
                                          toplevel })
             }
-            TopLevelInert(XdgV6TopLevel { shell_surface,
+            TopLevelUnmapped(XdgV6TopLevel { shell_surface,
                                           toplevel }) => {
-                TopLevelInert(XdgV6TopLevel { shell_surface,
+                TopLevelUnmapped(XdgV6TopLevel { shell_surface,
                                               toplevel })
             }
             Popup(XdgV6Popup { shell_surface,
@@ -541,9 +541,9 @@ impl XdgV6ShellState {
                 Popup(XdgV6Popup { shell_surface,
                                    popup })
             }
-            PopupInert(XdgV6Popup { shell_surface,
+            PopupUnmapped(XdgV6Popup { shell_surface,
                                     popup }) => {
-                PopupInert(XdgV6Popup { shell_surface,
+                PopupUnmapped(XdgV6Popup { shell_surface,
                                         popup })
             }
         }


### PR DESCRIPTION
Adds an "unmapped" state for the xdg shells. 

This handles the case where the toplevel (or popup) is destroyed but the xdg surface isn't. In this case wlroots doesn't delete the user data (i.e the compositor struct) but it does unset the role because the wayland object was destroyed.

This isn't a _great_ solution, but it should cover most cases. The only case this might not cover is if the `TopLevel` or `Popup` is currently already upgraded once it is made inert in which case you'd need to manually check the state in `role` (so it is possible to work around).

Note that we only go into this case once we lose our role, it's up to the compositor writer to wait until the `map` call to actually render the xdg shell state. i.e `unmapped` only refers to the case where we lost the role.