### PR TITLE
Fix shell destruction, clean up xdg shell data, update wayland-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,6 @@ xkbcommon = "0.3"
 bitflags = "1.0"
 vsprintf = "1.0.1"
 
-[dev-dependencies]
-
 [features]
 default = ["static", "libcap", "systemd", "elogind", "unstable-features"]
 static = ["wlroots-sys/static"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,16 +20,12 @@ libc = "^0.2.*"
 rust-ini = "0.10.0"
 wlroots-sys = { path = "wlroots-sys", default-features = false }
 wlroots-dehandle = { path = "wlroots-dehandle" }
-wayland-sys = { version = "0.21.*", features = ["client", "dlopen", "server",] }
 lazy_static = "0.2"
 xkbcommon = "0.3"
 bitflags = "1.0"
 vsprintf = "1.0.1"
 
 [dev-dependencies]
-wayland-client = { version = "0.21.*", features = ["native_lib"] }
-byteorder = "1"
-tempfile = "2"
 
 [features]
 default = ["static", "libcap", "systemd", "elogind", "unstable-features"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,14 +20,14 @@ libc = "^0.2.*"
 rust-ini = "0.10.0"
 wlroots-sys = { path = "wlroots-sys", default-features = false }
 wlroots-dehandle = { path = "wlroots-dehandle" }
-wayland-sys = { version = "0.9.*", features = ["client", "dlopen", "server",] }
+wayland-sys = { version = "0.21.*", features = ["client", "dlopen", "server",] }
 lazy_static = "0.2"
 xkbcommon = "0.3"
 bitflags = "1.0"
 vsprintf = "1.0.1"
 
 [dev-dependencies]
-wayland-client = { version = "0.12.*" }
+wayland-client = { version = "0.21.*", features = ["native_lib"] }
 byteorder = "1"
 tempfile = "2"
 

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -536,7 +536,12 @@ impl Compositor {
 
 impl Drop for Compositor {
     fn drop(&mut self) {
-        unsafe { wlr_compositor_destroy(self.compositor) }
+        unsafe {
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_display_destroy_clients,
+                          self.display);
+            wlr_compositor_destroy(self.compositor)
+        }
     }
 }
 

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -20,7 +20,6 @@ use wlroots_sys::{wlr_backend_destroy, wlr_backend_start,
                   wlr_compositor, wlr_compositor_create, wlr_compositor_destroy,
                   wlr_xdg_shell_v6, wlr_xdg_shell_v6_create,
                   wlr_xdg_shell, wlr_xdg_shell_create};
-use wlroots_sys::wayland_server::sys::wl_display_init_shm;
 
 /// Global compositor pointer, used to refer to the compositor state unsafely.
 pub(crate) static mut COMPOSITOR_PTR: *mut Compositor = 0 as *mut _;
@@ -329,7 +328,9 @@ impl CompositorBuilder {
                               -> Compositor
         where D: Any + 'static {
             // Set up shared memory buffer for Wayland clients.
-            let shm_fd = wl_display_init_shm(display as *mut _);
+            let shm_fd = ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                                       wl_display_init_shm,
+                                       display as *mut _);
             // Create optional extensions.
             let server_decoration_manager = if self.server_decoration_manager {
                 ServerDecorationManager::new(display)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,12 +12,12 @@ extern crate lazy_static;
 pub extern crate libc;
 extern crate vsprintf;
 #[macro_use]
-pub extern crate wayland_sys;
 pub extern crate wlroots_sys;
 pub extern crate wlroots_dehandle;
 pub extern crate xkbcommon;
 
 pub use wlroots_dehandle::wlroots_dehandle;
+pub use wlroots_sys::wayland_sys;
 
 #[macro_use]
 mod macros;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -152,7 +152,7 @@ macro_rules! wayland_listener {
 
         impl $struct_name {
             pub(crate) fn new(data: $data) -> Box<$struct_name> {
-                use $crate::wayland_sys::server::WAYLAND_SERVER_HANDLE;
+                use $crate::wlroots_sys::server::WAYLAND_SERVER_HANDLE;
                 Box::new($struct_name {
                     data,
                     $($($listener: unsafe {

--- a/src/manager/drag_icon_handler.rs
+++ b/src/manager/drag_icon_handler.rs
@@ -1,8 +1,8 @@
 //! Handler for drag icons
 
 use libc;
+use wlroots_sys::WAYLAND_SERVER_HANDLE;
 
-use wayland_sys::server::WAYLAND_SERVER_HANDLE;
 use compositor::{compositor_handle};
 use {CompositorHandle, DragIcon, DragIconHandle};
 

--- a/src/manager/output_handler.rs
+++ b/src/manager/output_handler.rs
@@ -1,11 +1,12 @@
 //! Handler for outputs
 
+use libc;
+use wayland_sys::server::WAYLAND_SERVER_HANDLE;
+use wlroots_sys::wlr_output;
+
 use {Output, OutputHandle, OutputState};
 use errors::HandleErr;
-use wayland_sys::server::WAYLAND_SERVER_HANDLE;
 use compositor::{compositor_handle, CompositorHandle};
-use libc;
-use wlroots_sys::wlr_output;
 
 pub trait OutputHandler {
     /// Called every time the output frame is updated.

--- a/src/manager/xdg_shell_handler.rs
+++ b/src/manager/xdg_shell_handler.rs
@@ -16,7 +16,6 @@ pub trait XdgShellHandler {
     fn on_commit(&mut self, CompositorHandle, SurfaceHandle, XdgShellSurfaceHandle) {}
 
     /// Called when the wayland shell is destroyed (e.g by the user)
-
     fn destroyed(&mut self, CompositorHandle, XdgShellSurfaceHandle) {}
 
     /// Called when the ping request timed out.
@@ -290,6 +289,9 @@ impl XdgShell {
 impl Drop for XdgShell {
     fn drop(&mut self) {
         unsafe {
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
+                          &mut (*self.destroy_listener()).link as *mut _ as _);
             ffi_dispatch!(WAYLAND_SERVER_HANDLE,
                         wl_list_remove,
                         &mut (*self.commit_listener()).link as *mut _ as _);

--- a/src/manager/xdg_shell_v6_handler.rs
+++ b/src/manager/xdg_shell_v6_handler.rs
@@ -292,6 +292,9 @@ impl Drop for XdgV6Shell {
         unsafe {
             ffi_dispatch!(WAYLAND_SERVER_HANDLE,
                           wl_list_remove,
+                          &mut (*self.destroy_listener()).link as *mut _ as _);
+            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                          wl_list_remove,
                           &mut (*self.commit_listener()).link as *mut _ as _);
             ffi_dispatch!(WAYLAND_SERVER_HANDLE,
                           wl_list_remove,

--- a/src/types/output/output.rs
+++ b/src/types/output/output.rs
@@ -466,7 +466,7 @@ impl Drop for Output {
         // That is handled by the backend automatically
 
         // NOTE
-        // We do _not_ need to call wlr_output_damage_detroy for the output,
+        // We do _not_ need to call wlr_output_damage_destroy for the output,
         // that is handled automatically by the listeners in wlroots.
         if Rc::strong_count(&self.liveliness) == 1 {
             wlr_log!(WLR_DEBUG, "Dropped output {:p}", self.output);

--- a/src/types/shell/xdg_shell_v6.rs
+++ b/src/types/shell/xdg_shell_v6.rs
@@ -77,7 +77,6 @@ impl XdgV6ShellSurface {
         where T: Into<Option<XdgV6ShellState>>
     {
         let state = state.into();
-        // TODO FIXME Free state in drop impl when Rc == 1
         (*shell_surface).data = ptr::null_mut();
         let liveliness = Rc::new(Cell::new(false));
         let shell_state =
@@ -208,6 +207,26 @@ impl XdgV6ShellSurface {
                                       Some(ref state) => unsafe { Some(state.clone()) }
                                   },
                                   shell_surface: self.shell_surface }
+    }
+}
+
+impl Drop for XdgV6ShellSurface {
+    fn drop(&mut self) {
+        if Rc::strong_count(&self.liveliness) == 1 {
+            wlr_log!(WLR_DEBUG, "Dropped xdg v6 shell {:p}", self.shell_surface);
+            let weak_count = Rc::weak_count(&self.liveliness);
+            if weak_count > 0 {
+                wlr_log!(WLR_DEBUG,
+                         "Still {} weak pointers to xdg v6 shell {:p}",
+                         weak_count,
+                         self.shell_surface);
+            }
+        } else {
+            return
+        }
+        unsafe {
+            let _ = Box::from_raw((*self.shell_surface).data as *mut XdgV6ShellSurfaceState);
+        }
     }
 }
 

--- a/wlroots-sys/Cargo.toml
+++ b/wlroots-sys/Cargo.toml
@@ -13,14 +13,15 @@ build = "build.rs"
 [build-dependencies]
 bindgen = "0.30.*"
 meson = { version = "1.0", optional = true }
-wayland-scanner = "0.12.*"
+wayland-scanner = "0.21.*"
 # For building optional dependencies
 pkg-config = "0.3.*"
 
 [dependencies]
 libc = "^0.2.*"
-wayland-sys = {version = "0.12.*" }
-wayland-server = { version = "0.12.*" }
+wayland-commons = { version = "0.21.*", features = ["native_lib"] }
+wayland-server = { version = "0.21.*", features = ["native_lib"] }
+wayland-sys = { version = "0.21.*" }
 
 [features]
 default = ["static", "libcap", "systemd", "elogind", "unstable-features"]

--- a/wlroots-sys/Cargo.toml
+++ b/wlroots-sys/Cargo.toml
@@ -21,7 +21,7 @@ pkg-config = "0.3.*"
 libc = "^0.2.*"
 wayland-commons = { version = "0.21.*", features = ["native_lib"] }
 wayland-server = { version = "0.21.*", features = ["native_lib"] }
-wayland-sys = { version = "0.21.*" }
+wayland-sys = { version = "0.21.*", features = ["dlopen", "server"] }
 
 [features]
 default = ["static", "libcap", "systemd", "elogind", "unstable-features"]

--- a/wlroots-sys/build.rs
+++ b/wlroots-sys/build.rs
@@ -167,15 +167,15 @@ fn generate_protocols() {
     let protocols = &[("./wlroots/protocol/server-decoration.xml", "server_decoration")];
 
     for protocol in protocols {
-        wayland_scanner::generate_code(protocol.0,
-                                       output_dir.join(format!("{}_server_api.rs", protocol.1)),
-                                       wayland_scanner::Side::Server);
-        wayland_scanner::generate_code(protocol.0,
-                                       output_dir.join(format!("{}_client_api.rs", protocol.1)),
-                                       wayland_scanner::Side::Client);
-        wayland_scanner::generate_interfaces(protocol.0,
-                                             output_dir.join(format!("{}_interfaces.rs",
-                                                                     protocol.1)));
+        wayland_scanner::generate_c_code(protocol.0,
+                                         output_dir.join(format!("{}_server_api.rs", protocol.1)),
+                                         wayland_scanner::Side::Server);
+        wayland_scanner::generate_c_code(protocol.0,
+                                         output_dir.join(format!("{}_client_api.rs", protocol.1)),
+                                         wayland_scanner::Side::Client);
+        wayland_scanner::generate_c_interfaces(protocol.0,
+                                               output_dir.join(format!("{}_interfaces.rs",
+                                                                       protocol.1)));
     }
 }
 

--- a/wlroots-sys/src/lib.rs
+++ b/wlroots-sys/src/lib.rs
@@ -6,6 +6,8 @@ pub extern crate wayland_server;
 #[macro_use]
 pub extern crate wayland_sys;
 
+pub use wayland_sys::{*, pid_t, gid_t, uid_t, server::{self, WAYLAND_SERVER_HANDLE}};
+
 #[allow(non_camel_case_types, non_snake_case, non_upper_case_globals)]
 mod generated {
     use libc;

--- a/wlroots-sys/src/lib.rs
+++ b/wlroots-sys/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(non_camel_case_types, non_upper_case_globals)]
 
 extern crate libc;
+pub extern crate wayland_commons;
 pub extern crate wayland_server;
 #[macro_use]
 pub extern crate wayland_sys;
@@ -15,15 +16,20 @@ mod generated {
     pub mod protocols {
         pub mod server_decoration {
             #![allow(unused_imports)]
-            pub mod server {
-                mod interfaces {
-                    pub(crate) use wayland_server::protocol_interfaces::wl_surface_interface;
-                    include!(concat!(env!("OUT_DIR"), "/server_decoration_interfaces.rs"));
-                }
+            #![allow(unused_variables)]
+            mod c_interfaces {
+                use wayland_server::sys::protocol_interfaces::wl_surface_interface;
+                include!(concat!(env!("OUT_DIR"), "/server_decoration_interfaces.rs"));
+            }
 
-                use wayland_server::{Client, EventLoopHandle, EventResult, Implementable,
-                                     Liveness, Resource};
-                use wayland_server::protocol::wl_surface;
+            pub mod server {
+                pub(crate) use wayland_server::{NewResource, Resource};
+                pub(crate) use wayland_commons::{AnonymousObject, Interface, MessageGroup,
+                                                 wire::{Argument, ArgumentType, Message, MessageDesc},
+                                                 map::{Object, ObjectMetadata}};
+                pub(crate) use wayland_sys as sys;
+                use wayland_server::{*, protocol::wl_surface};
+                use wayland_sys::common::{wl_interface, wl_argument};
                 include!(concat!(env!("OUT_DIR"), "/server_decoration_server_api.rs"));
             }
         }


### PR DESCRIPTION
* Fixes shells not being destroyed properly during destruction of the compositor
  + Required updating wayland-rs
* Only wlroots-sys has wayland-rs now, this will simplify dependency management
* xdg shell user data properly cleaned up
* Removed all outdated dev dependencies
* Generally updated dependencies