### PR TITLE
Dynamic link by default

### DIFF
--- a/.build.yml
+++ b/.build.yml
@@ -40,10 +40,10 @@ tasks:
       cd ../
 
       cargo build --verbose
-      cargo build --verbose --features=unstable
+      cargo build --verbose --features="static, unstable"
       cargo build --examples
-      cargo build --examples --features=unstable
+      cargo build --examples --features="static, unstable"
       # For doc tests
       cargo doc
-      cargo doc --features=unstable
-      cargo test --all --features=unstable
+      cargo doc --features="static, unstable"
+      cargo test --all --features="static, unstable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ bitflags = "1.0"
 vsprintf = "1.0.1"
 
 [features]
-default = ["static", "libcap", "systemd", "elogind"]
+default = ["libcap", "systemd", "elogind"]
 static = ["wlroots-sys/static"]
 libcap = ["wlroots-sys/libcap"]
 systemd = ["wlroots-sys/systemd"]

--- a/makefile
+++ b/makefile
@@ -1,0 +1,11 @@
+default: unstable_static_build
+
+unstable_static_build:
+	cargo build --features "unstable static"
+
+.PHONY: examples
+examples:
+	cargo build  --examples --features "unstable static"
+
+build:
+	cargo build

--- a/wlroots-dehandle/Cargo.toml
+++ b/wlroots-dehandle/Cargo.toml
@@ -2,6 +2,8 @@
 name = "wlroots-dehandle"
 version = "1.0.0"
 authors = ["Timidger <APragmaticPlace@gmail.com>"]
+description = "Procedural macro to upgrade wlroots handles without callback hell"
+license = "MIT"
 
 [lib]
 proc-macro = true

--- a/wlroots-sys/Cargo.toml
+++ b/wlroots-sys/Cargo.toml
@@ -24,7 +24,7 @@ wayland-server = { version = "0.21.*", features = ["native_lib"] }
 wayland-sys = { version = "0.21.*", features = ["dlopen", "server"] }
 
 [features]
-default = ["static", "libcap", "systemd", "elogind", "unstable"]
+default = ["libcap", "systemd", "elogind"]
 static = ["meson"]
 libcap = []
 systemd = []


### PR DESCRIPTION
This is the default for libraries on linux, even though right now no one should really be doing this because wlroots doesn't guarantee any ABI compatibility for non-stable interfaces.

This will also fix the documentation generation at docs.rs