### PR TITLE
Static managers

### DIFF
--- a/examples/pointer.rs
+++ b/examples/pointer.rs
@@ -40,33 +40,29 @@ impl cursor::Handler for ExCursor {}
 struct ExOutputLayout;
 impl output::layout::Handler for ExOutputLayout {}
 
-struct OutputManager;
-impl output::ManagerHandler for OutputManager {
-    fn output_added<'output>(&mut self,
-                             compositor_handle: compositor::Handle,
-                             output_builder: output::Builder<'output>)
-                             -> Option<output::BuilderResult<'output>> {
-        let mut result = output_builder.build_best_mode(ExOutput);
-        with_handles!([(compositor: {compositor_handle})] => {
-            let compositor_state: &mut CompositorState = compositor.data.downcast_mut().unwrap();
-            let layout_handle = &mut compositor_state.layout_handle;
-            let cursor_handle = &mut compositor_state.cursor_handle;
-            let xcursor_manager = &mut compositor_state.xcursor_manager;
-            // TODO use output config if present instead of auto
-            with_handles!([(layout: {layout_handle}),
-                          (cursor: {cursor_handle}),
-                          (output: {&mut result.output})] => {
-                layout.add_auto(output);
-                cursor.attach_output_layout(layout);
-                xcursor_manager.load(output.scale());
-                xcursor_manager.set_cursor_image("left_ptr".to_string(), cursor);
-                let (x, y) = cursor.coords();
-                // https://en.wikipedia.org/wiki/Mouse_warping
-                cursor.warp(None, x, y);
-            }).unwrap();
-            Some(result)
-        }).unwrap()
-    }
+fn output_added<'output>(compositor_handle: compositor::Handle,
+                         output_builder: output::Builder<'output>)
+                         -> Option<output::BuilderResult<'output>> {
+    let mut result = output_builder.build_best_mode(ExOutput);
+    with_handles!([(compositor: {compositor_handle})] => {
+        let compositor_state: &mut CompositorState = compositor.data.downcast_mut().unwrap();
+        let layout_handle = &mut compositor_state.layout_handle;
+        let cursor_handle = &mut compositor_state.cursor_handle;
+        let xcursor_manager = &mut compositor_state.xcursor_manager;
+        // TODO use output config if present instead of auto
+        with_handles!([(layout: {layout_handle}),
+                        (cursor: {cursor_handle}),
+                        (output: {&mut result.output})] => {
+            layout.add_auto(output);
+            cursor.attach_output_layout(layout);
+            xcursor_manager.load(output.scale());
+            xcursor_manager.set_cursor_image("left_ptr".to_string(), cursor);
+            let (x, y) = cursor.coords();
+            // https://en.wikipedia.org/wiki/Mouse_warping
+            cursor.warp(None, x, y);
+        }).unwrap();
+        Some(result)
+    }).unwrap()
 }
 
 struct ExKeyboardHandler;
@@ -202,10 +198,12 @@ fn main() {
     let (xcursor_manager, cursor_handle) = load_xcursor();
     let layout_handle = output::layout::Layout::create(Box::new(ExOutputLayout));
 
+    let output_builder = output::ManagerBuilder::default()
+        .output_added(output_added);
     let compositor =
         compositor::Builder::new().gles2(true)
                                 .input_manager(Box::new(InputManager))
-                                .output_manager(Box::new(OutputManager))
+                                .output_manager(output_builder)
                                 .build_auto(CompositorState::new(xcursor_manager, layout_handle, cursor_handle));
     compositor.run();
 }

--- a/examples/pointer.rs
+++ b/examples/pointer.rs
@@ -193,9 +193,9 @@ fn main() {
     let (xcursor_manager, cursor_handle) = load_xcursor();
     let layout_handle = output::layout::Layout::create(Box::new(ExOutputLayout));
 
-    let output_builder = output::ManagerBuilder::default()
+    let output_builder = output::manager::Builder::default()
         .output_added(output_added);
-    let input_builder = input::ManagerBuilder::default()
+    let input_builder = input::manager::Builder::default()
         .pointer_added(pointer_added)
         .keyboard_added(keyboard_added);
     let compositor =

--- a/examples/rotation.rs
+++ b/examples/rotation.rs
@@ -111,14 +111,10 @@ impl output::Handler for ExOutput {
     }
 }
 
-struct InputManager;
-impl input::ManagerHandler for InputManager {
-    fn keyboard_added(&mut self,
-                      _compositor_handle: compositor::Handle,
-                      _keyboard_handle: keyboard::Handle)
-                      -> Option<Box<keyboard::Handler>> {
-        Some(Box::new(KeyboardManager))
-    }
+fn keyboard_added(_compositor_handle: compositor::Handle,
+                  _keyboard_handle: keyboard::Handle)
+                  -> Option<Box<keyboard::Handler>> {
+    Some(Box::new(KeyboardManager))
 }
 
 struct KeyboardManager;
@@ -164,8 +160,10 @@ fn main() {
     let rotation_transform = rotation_transform_from_str(&rotation_argument_string);
     let compositor_state = CompositorState::new(rotation_transform);
     let output_builder = output::ManagerBuilder::default().output_added(output_added);
+    let input_builder = input::ManagerBuilder::default()
+        .keyboard_added(keyboard_added);
     let mut compositor = compositor::Builder::new().gles2(true)
-                                                   .input_manager(Box::new(InputManager))
+                                                   .input_manager(input_builder)
                                                    .output_manager(output_builder)
                                                    .build_auto(compositor_state);
     {

--- a/examples/rotation.rs
+++ b/examples/rotation.rs
@@ -159,8 +159,8 @@ fn main() {
     let rotation_argument_string = args.nth(1).unwrap_or_else(|| "".to_string());
     let rotation_transform = rotation_transform_from_str(&rotation_argument_string);
     let compositor_state = CompositorState::new(rotation_transform);
-    let output_builder = output::ManagerBuilder::default().output_added(output_added);
-    let input_builder = input::ManagerBuilder::default()
+    let output_builder = output::manager::Builder::default().output_added(output_added);
+    let input_builder = input::manager::Builder::default()
         .keyboard_added(keyboard_added);
     let mut compositor = compositor::Builder::new().gles2(true)
                                                    .input_manager(input_builder)

--- a/examples/tablet.rs
+++ b/examples/tablet.rs
@@ -35,7 +35,6 @@ impl State {
     }
 }
 
-struct OutputManagerEx;
 struct InputManagerEx;
 struct OutputEx;
 struct KeyboardEx;
@@ -74,14 +73,11 @@ impl input::ManagerHandler for InputManagerEx {
     }
 }
 
-impl output::ManagerHandler for OutputManagerEx {
-    fn output_added<'output>(&mut self,
-                             _: compositor::Handle,
-                             builder: output::Builder<'output>)
-                             -> Option<output::BuilderResult<'output>> {
-        let result = builder.build_best_mode(OutputEx);
-        Some(result)
-    }
+fn output_added<'output>(_: compositor::Handle,
+                         builder: output::Builder<'output>)
+                         -> Option<output::BuilderResult<'output>> {
+    let result = builder.build_best_mode(OutputEx);
+    Some(result)
 }
 
 impl keyboard::Handler for KeyboardEx {
@@ -250,9 +246,10 @@ compositor_data!(State);
 
 fn main() {
     log::init_logging(log::WLR_DEBUG, None);
+    let output_builder = output::ManagerBuilder::default().output_added(output_added);
     compositor::Builder::new().gles2(true)
                             .input_manager(Box::new(InputManagerEx))
-                            .output_manager(Box::new(OutputManagerEx))
+                            .output_manager(output_builder)
                             .build_auto(State::new())
                             .run()
 }

--- a/examples/tablet.rs
+++ b/examples/tablet.rs
@@ -240,8 +240,8 @@ compositor_data!(State);
 
 fn main() {
     log::init_logging(log::WLR_DEBUG, None);
-    let output_builder = output::ManagerBuilder::default().output_added(output_added);
-    let input_builder = input::ManagerBuilder::default()
+    let output_builder = output::manager::Builder::default().output_added(output_added);
+    let input_builder = input::manager::Builder::default()
         .keyboard_added(keyboard_added)
         .tablet_tool_added(tablet_tool_added)
         .tablet_pad_added(tablet_pad_added);

--- a/examples/touch.rs
+++ b/examples/touch.rs
@@ -145,8 +145,8 @@ fn keyboard_added(_: compositor::Handle,
 
 fn main() {
     init_logging(WLR_DEBUG, None);
-    let output_builder = output::ManagerBuilder::default().output_added(output_added);
-    let input_builder = input::ManagerBuilder::default()
+    let output_builder = output::manager::Builder::default().output_added(output_added);
+    let input_builder = input::manager::Builder::default()
         .keyboard_added(keyboard_added)
         .touch_added(touch_added);
     let mut compositor = compositor::Builder::new().gles2(true)

--- a/examples/touch.rs
+++ b/examples/touch.rs
@@ -37,8 +37,6 @@ struct TouchHandlerEx;
 
 struct ExOutput;
 
-struct InputManager;
-
 struct ExKeyboardHandler;
 
 fn output_added<'output>(_: compositor::Handle,
@@ -135,24 +133,24 @@ impl touch::Handler for TouchHandlerEx {
     }
 }
 
-impl input::ManagerHandler for InputManager {
-    fn touch_added(&mut self, _: compositor::Handle, _: touch::Handle) -> Option<Box<touch::Handler>> {
-        Some(Box::new(TouchHandlerEx))
-    }
+fn touch_added(_: compositor::Handle, _: touch::Handle) -> Option<Box<touch::Handler>> {
+    Some(Box::new(TouchHandlerEx))
+}
 
-    fn keyboard_added(&mut self,
-                      _: compositor::Handle,
-                      _: keyboard::Handle)
-                      -> Option<Box<keyboard::Handler>> {
-        Some(Box::new(ExKeyboardHandler))
-    }
+fn keyboard_added(_: compositor::Handle,
+                  _: keyboard::Handle)
+                  -> Option<Box<keyboard::Handler>> {
+    Some(Box::new(ExKeyboardHandler))
 }
 
 fn main() {
     init_logging(WLR_DEBUG, None);
     let output_builder = output::ManagerBuilder::default().output_added(output_added);
+    let input_builder = input::ManagerBuilder::default()
+        .keyboard_added(keyboard_added)
+        .touch_added(touch_added);
     let mut compositor = compositor::Builder::new().gles2(true)
-                                                   .input_manager(Box::new(InputManager))
+                                                   .input_manager(input_builder)
                                                    .output_manager(output_builder)
                                                    .build_auto(State::new());
     {

--- a/examples/touch.rs
+++ b/examples/touch.rs
@@ -35,21 +35,16 @@ compositor_data!(State);
 
 struct TouchHandlerEx;
 
-struct OutputManager;
-
 struct ExOutput;
 
 struct InputManager;
 
 struct ExKeyboardHandler;
 
-impl output::ManagerHandler for OutputManager {
-    fn output_added<'output>(&mut self,
-                             _: compositor::Handle,
-                             builder: output::Builder<'output>)
-                             -> Option<output::BuilderResult<'output>> {
-        Some(builder.build_best_mode(ExOutput))
-    }
+fn output_added<'output>(_: compositor::Handle,
+                         builder: output::Builder<'output>)
+                         -> Option<output::BuilderResult<'output>> {
+    Some(builder.build_best_mode(ExOutput))
 }
 
 impl keyboard::Handler for ExKeyboardHandler {
@@ -155,9 +150,10 @@ impl input::ManagerHandler for InputManager {
 
 fn main() {
     init_logging(WLR_DEBUG, None);
+    let output_builder = output::ManagerBuilder::default().output_added(output_added);
     let mut compositor = compositor::Builder::new().gles2(true)
                                                    .input_manager(Box::new(InputManager))
-                                                   .output_manager(Box::new(OutputManager))
+                                                   .output_manager(output_builder)
                                                    .build_auto(State::new());
     {
         let gles2 = &mut compositor.renderer.as_mut().unwrap();

--- a/examples/xdg_shell_v6_test.rs
+++ b/examples/xdg_shell_v6_test.rs
@@ -260,11 +260,11 @@ fn main() {
         .unwrap();
     let layout = Layout::create(Box::new(OutputLayoutEx));
 
-    let output_builder = output::ManagerBuilder::default().output_added(output_added);
-    let input_builder = input::ManagerBuilder::default()
+    let output_builder = output::manager::Builder::default().output_added(output_added);
+    let input_builder = input::manager::Builder::default()
         .keyboard_added(keyboard_added)
         .pointer_added(pointer_added);
-    let xdg_shell_v6_builder = xdg_shell_v6::ManagerBuilder::default()
+    let xdg_shell_v6_builder = xdg_shell_v6::manager::Builder::default()
         .surface_added(new_surface);
     let mut compositor =
         compositor::Builder::new().gles2(true)

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -394,8 +394,7 @@ impl Builder {
 
         // Set up output manager, if the user provided it.
         let output_manager = self.output_manager_builder.map(|builder| {
-            output::Manager::build(builder);
-            let output_manager = &mut output::MANAGER;
+            let output_manager = output::Manager::build(builder);
             wl_signal_add(&mut (*backend.as_ptr()).events.new_output as *mut _ as _,
                           (&mut output_manager.add_listener) as *mut _ as _);
             output_manager

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -140,7 +140,7 @@ pub struct Builder {
     wayland_remote: Option<String>,
     x11_display: Option<String>,
     data_device_manager: bool,
-    xwayland: Option<Box<xwayland::ManagerHandler>>,
+    xwayland: Option<xwayland::ManagerBuilder>,
     user_terminate: Option<fn()>
 }
 
@@ -218,7 +218,7 @@ impl Builder {
     /// Add a handler for xwayland.
     ///
     /// If you do not provide a handler then the xwayland server does not run.
-    pub fn xwayland(mut self, xwayland: Box<xwayland::ManagerHandler>) -> Self {
+    pub fn xwayland(mut self, xwayland: xwayland::ManagerBuilder) -> Self {
         self.xwayland = Some(xwayland);
         self
     }
@@ -423,10 +423,10 @@ impl Builder {
         });
 
         // Set up the XWayland server, if the user wants it.
-        let xwayland = self.xwayland.and_then(|manager| {
+        let xwayland = self.xwayland.and_then(|builder| {
             Some(xwayland::Server::new(display as _,
                                        compositor,
-                                       manager,
+                                       builder,
                                        false))
         });
 

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -129,10 +129,10 @@ pub struct Compositor {
 #[derive(Default)]
 pub struct Builder {
     compositor_handler: Option<Box<Handler>>,
-    input_manager_builder: Option<input::ManagerBuilder>,
-    output_manager_builder: Option<output::ManagerBuilder>,
-    xdg_shell_manager_builder: Option<xdg_shell::ManagerBuilder>,
-    xdg_v6_shell_manager_builder: Option<xdg_shell_v6::ManagerBuilder>,
+    input_manager_builder: Option<input::manager::Builder>,
+    output_manager_builder: Option<output::manager::Builder>,
+    xdg_shell_manager_builder: Option<xdg_shell::manager::Builder>,
+    xdg_v6_shell_manager_builder: Option<xdg_shell_v6::manager::Builder>,
     wl_shm: bool,
     gles2: bool,
     render_setup_function: Option<UnsafeRenderSetupFunction>,
@@ -140,7 +140,7 @@ pub struct Builder {
     wayland_remote: Option<String>,
     x11_display: Option<String>,
     data_device_manager: bool,
-    xwayland: Option<xwayland::ManagerBuilder>,
+    xwayland: Option<xwayland::manager::Builder>,
     user_terminate: Option<fn()>
 }
 
@@ -159,19 +159,19 @@ impl Builder {
     }
 
     /// Set the handler for inputs.
-    pub fn input_manager(mut self, input_manager_builder: input::ManagerBuilder) -> Self {
+    pub fn input_manager(mut self, input_manager_builder: input::manager::Builder) -> Self {
         self.input_manager_builder = Some(input_manager_builder);
         self
     }
 
     /// Set the handler for outputs.
-    pub fn output_manager(mut self, output_manager_builder: output::ManagerBuilder) -> Self {
+    pub fn output_manager(mut self, output_manager_builder: output::manager::Builder) -> Self {
         self.output_manager_builder = Some(output_manager_builder);
         self
     }
 
     pub fn xdg_shell_manager(mut self,
-                             xdg_shell_manager_builder: xdg_shell::ManagerBuilder)
+                             xdg_shell_manager_builder: xdg_shell::manager::Builder)
                              -> Self {
         self.xdg_shell_manager_builder = Some(xdg_shell_manager_builder);
         self
@@ -179,7 +179,7 @@ impl Builder {
 
     /// Set the handler for xdg v6 shells.
     pub fn xdg_shell_v6_manager(mut self,
-                                xdg_v6_shell_manager_builder: xdg_shell_v6::ManagerBuilder)
+                                xdg_v6_shell_manager_builder: xdg_shell_v6::manager::Builder)
                                 -> Self {
         self.xdg_v6_shell_manager_builder = Some(xdg_v6_shell_manager_builder);
         self
@@ -218,7 +218,7 @@ impl Builder {
     /// Add a handler for xwayland.
     ///
     /// If you do not provide a handler then the xwayland server does not run.
-    pub fn xwayland(mut self, xwayland: xwayland::ManagerBuilder) -> Self {
+    pub fn xwayland(mut self, xwayland: xwayland::manager::Builder) -> Self {
         self.xwayland = Some(xwayland);
         self
     }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -211,6 +211,11 @@ macro_rules! wayland_listener_static {
         $(
             #[derive(Default)]
             #[allow(dead_code)]
+            /// A builder of static functions to manage and create resources.
+            ///
+            /// Implement the functions with the necessary signature, pass them
+            /// to the builder, and then give the builder to the necessary
+            /// structure in order to utilize them (usually it's `compositor::Builder`).
             pub struct $builder {
                 $($($callback: ::std::option::Option<$fn_type>,)*
                   $($($($extra_callback_name: ::std::option::Option<$extra_callback_type>,)*)*)*)*
@@ -218,11 +223,15 @@ macro_rules! wayland_listener_static {
 
             impl $builder {
                 $($(
+                    /// Uses the provided callback as the receiver for the
+                    /// event the type signature describes.
                     pub fn $builder_func(mut self, $callback: $fn_type) -> Self {
                         self.$callback = ::std::option::Option::Some($callback);
                         self
                     }
                     $($(
+                        /// Uses the provided callback as the receiver for the
+                        /// event the type signature describes.
                         pub fn $extra_callback_name(mut self, $extra_callback_name: $extra_callback_type) -> Self {
                             self.$extra_callback_name = ::std::option::Option::Some($extra_callback_name);
                             self

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -217,7 +217,7 @@ macro_rules! wayland_listener_static {
             /// to the builder, and then give the builder to the necessary
             /// structure in order to utilize them (usually it's `compositor::Builder`).
             pub struct $builder {
-                $($($callback: ::std::option::Option<$fn_type>,)*
+                $($(pub(crate) $callback: ::std::option::Option<$fn_type>,)*
                   $($($($extra_callback_name: ::std::option::Option<$extra_callback_type>,)*)*)*)*
             }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -212,7 +212,7 @@ macro_rules! wayland_listener_static {
             #[derive(Default)]
             #[allow(dead_code)]
             pub struct $builder {
-                $($($callback: ::std::option::Option<$fn_type>)*,
+                $($($callback: ::std::option::Option<$fn_type>,)*
                   $($($($extra_callback_name: ::std::option::Option<$extra_callback_type>,)*)*)*)*
             }
 
@@ -274,7 +274,7 @@ macro_rules! wayland_listener_static {
                             ffi_dispatch!(WAYLAND_SERVER_HANDLE,
                                           wl_list_init,
                                           &mut listener.link as *mut _ as _);
-                            ::std::ptr::write(&mut listener.notify, std::option::Option::Some(add_notify));
+                            ::std::ptr::write(&mut listener.notify, std::option::Option::Some($notify));
                             listener
                         };
                         $static_manager.$callback = builder.$callback;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -264,7 +264,7 @@ macro_rules! wayland_listener_static {
                 )*)*
             };
 
-            impl Manager {
+            impl $manager {
                 /// Sets the functions on the builder as the global manager functions.
                 ///
                 /// # Safety

--- a/src/manager/input_manager.rs
+++ b/src/manager/input_manager.rs
@@ -21,236 +21,231 @@ use {compositor,
              touch::{self, Touch, TouchWrapper}},
      utils::{Handleable, safe_as_cstring}};
 
-/// Handles input addition and removal.
-#[allow(unused_variables)]
-pub trait ManagerHandler {
-    /// Callback triggered when an input device is added.
-    ///
-    /// # Panics
-    /// Any panic in this function will cause the process to abort.
-    fn input_added(&mut self,
-                   compositor_handle: compositor::Handle,
-                   device: &mut input::Device) {}
+/// Callback triggered when an input device is added.
+///
+/// # Panics
+/// Any panic in this function will cause the process to abort.
+pub type InputAdded = fn(compositor_handle: compositor::Handle,
+                         device: &mut input::Device);
 
-    /// Callback triggered when a keyboard device is added.
-    ///
-    /// # Panics
-    /// Any panic in this function will cause the process to abort.
-    fn keyboard_added(&mut self,
-                      compositor_handle: compositor::Handle,
-                      keyboard_handle: keyboard::Handle)
-                      -> Option<Box<keyboard::Handler>> {
-        None
-    }
+/// Callback triggered when a keyboard device is added.
+///
+/// # Panics
+/// Any panic in this function will cause the process to abort.
+pub type KeyboardAdded = fn (compositor_handle: compositor::Handle,
+                             keyboard_handle: keyboard::Handle)
+                             -> Option<Box<keyboard::Handler>>;
 
-    /// Callback triggered when a pointer device is added.
-    ///
-    /// # Panics
-    /// Any panic in this function will cause the process to abort.
-    fn pointer_added(&mut self,
-                     compositor_handle: compositor::Handle,
-                     pointer_handle: pointer::Handle)
-                     -> Option<Box<pointer::Handler>> {
-        None
-    }
+/// Callback triggered when a pointer device is added.
+///
+/// # Panics
+/// Any panic in this function will cause the process to abort.
+pub type PointerAdded = fn (compositor_handle: compositor::Handle,
+                            pointer_handle: pointer::Handle)
+                            -> Option<Box<pointer::Handler>>;
 
-    /// Callback triggered when a touch device is added.
-    ///
-    /// # Panics
-    /// Any panic in this function will cause the process to abort.
-    fn touch_added(&mut self,
-                   compositor_handle: compositor::Handle,
-                   touch_handle: touch::Handle)
-                   -> Option<Box<touch::Handler>> {
-        None
-    }
+/// Callback triggered when a touch device is added.
+///
+/// # Panics
+/// Any panic in this function will cause the process to abort.
+pub type TouchAdded = fn(compositor_handle: compositor::Handle,
+                         touch_handle: touch::Handle)
+                         -> Option<Box<touch::Handler>>;
 
-    /// Callback triggered when a tablet tool is added.
-    ///
-    ///
-    /// # Panics
-    /// Any panic in this function will cause the process to abort.
-    fn tablet_tool_added(&mut self,
-                         compositor_handle: compositor::Handle,
-                         tablet_tool_handle: tablet_tool::Handle)
-                         -> Option<Box<tablet_tool::Handler>> {
-        None
-    }
+/// Callback triggered when a tablet tool is added.
+///
+///
+/// # Panics
+/// Any panic in this function will cause the process to abort.
+pub type TabletToolAdded = fn(compositor_handle: compositor::Handle,
+                              tablet_tool_handle: tablet_tool::Handle)
+                              -> Option<Box<tablet_tool::Handler>>;
 
-    /// Callback triggered when a tablet pad is added.
-    ///
-    ///
-    /// # Panics
-    /// Any panic in this function will cause the process to abort.
-    fn tablet_pad_added(&mut self,
-                        compositor_handle: compositor::Handle,
-                        tablet_pad_handle: tablet_pad::Handle)
-                        -> Option<Box<tablet_pad::Handler>> {
-        None
-    }
-}
+/// Callback triggered when a tablet pad is added.
+///
+///
+/// # Panics
+/// Any panic in this function will cause the process to abort.
+pub type TabletPadAdded = fn (compositor_handle: compositor::Handle,
+                              tablet_pad_handle: tablet_pad::Handle)
+                              -> Option<Box<tablet_pad::Handler>>;
 
-wayland_listener!(pub(crate) Manager, Box<ManagerHandler>, [
-    add_listener => add_notify: |this: &mut Manager, data: *mut libc::c_void,| unsafe {
-        let compositor = match compositor::handle() {
-            Some(handle) => handle,
-            None => return
-        };
-        let data = data as *mut wlr_input_device;
-        let ref mut manager = this.data;
-        use self::wlr_input_device_type::*;
-        let mut dev = input::Device::from_ptr(data);
-        let res = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-            match dev.dev_type() {
-                WLR_INPUT_DEVICE_KEYBOARD => {
-                    // Boring setup that we won't make the user do
-                    add_keyboard(&mut dev);
-                    let mut keyboard = match Keyboard::new_from_input_device(data) {
-                        Some(dev) => dev,
-                        None => {
-                            wlr_log!(WLR_ERROR, "Device {:#?} was not a keyboard!", dev);
-                            abort()
+wayland_listener_static! {
+    static mut MANAGER;
+    (Manager, ManagerBuilder): [
+        // NOTE
+        // This is a macro hack to add these as arguments to the builder.
+        // The callbacks will be storted in the manager, but they'll have no
+        // listener to wait for since this is the only event on this interface
+        // (and why we need this hack).
+        [
+            keyboard_added: KeyboardAdded,
+            pointer_added: PointerAdded,
+            touch_added: TouchAdded,
+            tablet_tool_added: TabletToolAdded,
+            tablet_pad_added: TabletPadAdded
+        ]
+        (InputAdded, add_listener, input_added) => (add_notify, input_added):
+        |manager: &mut Manager, data: *mut libc::c_void,| unsafe {
+            let compositor = match compositor::handle() {
+                Some(handle) => handle,
+                None => return
+            };
+            let data = data as *mut wlr_input_device;
+            use self::wlr_input_device_type::*;
+            let mut dev = input::Device::from_ptr(data);
+            let res = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+                match dev.dev_type() {
+                    WLR_INPUT_DEVICE_KEYBOARD => {
+                        // Boring setup that we won't make the user do
+                        add_keyboard(&mut dev);
+                        let mut keyboard = match Keyboard::new_from_input_device(data) {
+                            Some(dev) => dev,
+                            None => {
+                                wlr_log!(WLR_ERROR, "Device {:#?} was not a keyboard!", dev);
+                                abort()
+                            }
+                        };
+                        let keyboard_handle = keyboard.weak_reference();
+                        let res = manager.keyboard_added.and_then(|f| f(compositor.clone(), keyboard_handle));
+                        if let Some(keyboard_handler) = res {
+                            let mut keyboard = KeyboardWrapper::new((keyboard,
+                                                                     keyboard_handler));
+                            wl_signal_add(&mut (*dev.dev_union().keyboard).events.key as *mut _ as _,
+                                          keyboard.key_listener() as *mut _ as _);
+                            wl_signal_add(&mut (*dev.dev_union().keyboard).events.modifiers
+                                          as *mut _ as _,
+                                          keyboard.modifiers_listener() as *mut _ as _);
+                            wl_signal_add(&mut (*dev.dev_union().keyboard).events.keymap as *mut _ as _,
+                                          keyboard.keymap_listener() as *mut _ as _);
+                            wl_signal_add(&mut (*dev.dev_union().keyboard).events.repeat_info
+                                          as *mut _ as _,
+                                          keyboard.repeat_listener() as *mut _ as _);
+                            wl_signal_add(&mut (*dev.as_ptr()).events.destroy as *mut _ as _,
+                                          keyboard.on_destroy_listener() as _);
+                            (*data).data = Box::into_raw(keyboard) as _;
                         }
-                    };
-                    let keyboard_handle = keyboard.weak_reference();
-                    if let Some(keyboard_handler) = manager.keyboard_added(compositor.clone(),
-                                                                           keyboard_handle) {
-                        let mut keyboard = KeyboardWrapper::new((keyboard,
-                                                                 keyboard_handler));
-                        wl_signal_add(&mut (*dev.dev_union().keyboard).events.key as *mut _ as _,
-                                    keyboard.key_listener() as *mut _ as _);
-                        wl_signal_add(&mut (*dev.dev_union().keyboard).events.modifiers
-                                      as *mut _ as _,
-                                      keyboard.modifiers_listener() as *mut _ as _);
-                        wl_signal_add(&mut (*dev.dev_union().keyboard).events.keymap as *mut _ as _,
-                                      keyboard.keymap_listener() as *mut _ as _);
-                        wl_signal_add(&mut (*dev.dev_union().keyboard).events.repeat_info
-                                      as *mut _ as _,
-                                      keyboard.repeat_listener() as *mut _ as _);
-                        wl_signal_add(&mut (*dev.as_ptr()).events.destroy as *mut _ as _,
-                                      keyboard.on_destroy_listener() as _);
-                        (*data).data = Box::into_raw(keyboard) as _;
-                    }
-                },
-                WLR_INPUT_DEVICE_POINTER => {
-                    let pointer = match Pointer::new_from_input_device(data) {
-                        Some(dev) => dev,
-                        None => {
-                            wlr_log!(WLR_ERROR, "Device {:#?} was not a pointer!", dev);
-                            abort()
+                    },
+                    WLR_INPUT_DEVICE_POINTER => {
+                        let pointer = match Pointer::new_from_input_device(data) {
+                            Some(dev) => dev,
+                            None => {
+                                wlr_log!(WLR_ERROR, "Device {:#?} was not a pointer!", dev);
+                                abort()
+                            }
+                        };
+                        let pointer_handle = pointer.weak_reference();
+                        let res = manager.pointer_added.and_then(|f| f(compositor.clone(), pointer_handle));
+                        if let Some(pointer_handler) = res {
+                            let mut pointer = PointerWrapper::new((pointer, pointer_handler));
+                            wl_signal_add(&mut (*dev.dev_union().pointer).events.motion as *mut _ as _,
+                                          pointer.motion_listener() as *mut _ as _);
+                            wl_signal_add(&mut (*dev.dev_union().pointer)
+                                          .events.motion_absolute as *mut _ as _,
+                                          pointer.motion_absolute_listener() as *mut _ as _);
+                            wl_signal_add(&mut (*dev.dev_union().pointer).events.button as *mut _ as _,
+                                          pointer.button_listener() as *mut _ as _);
+                            wl_signal_add(&mut (*dev.dev_union().pointer).events.axis as *mut _ as _,
+                                          pointer.axis_listener() as *mut _ as _);
+                            wl_signal_add(&mut (*dev.as_ptr()).events.destroy as *mut _ as _,
+                                          pointer.on_destroy_listener() as _);
+                            (*data).data = Box::into_raw(pointer) as _;
                         }
-                    };
-                    let pointer_handle = pointer.weak_reference();
-                    if let Some(pointer_handler) = manager.pointer_added(compositor.clone(),
-                                                                         pointer_handle) {
-                        let mut pointer = PointerWrapper::new((pointer, pointer_handler));
-                        wl_signal_add(&mut (*dev.dev_union().pointer).events.motion as *mut _ as _,
-                                    pointer.motion_listener() as *mut _ as _);
-                        wl_signal_add(&mut (*dev.dev_union().pointer)
-                                      .events.motion_absolute as *mut _ as _,
-                                    pointer.motion_absolute_listener() as *mut _ as _);
-                        wl_signal_add(&mut (*dev.dev_union().pointer).events.button as *mut _ as _,
-                                    pointer.button_listener() as *mut _ as _);
-                        wl_signal_add(&mut (*dev.dev_union().pointer).events.axis as *mut _ as _,
-                                    pointer.axis_listener() as *mut _ as _);
-                        wl_signal_add(&mut (*dev.as_ptr()).events.destroy as *mut _ as _,
-                                      pointer.on_destroy_listener() as _);
-                        (*data).data = Box::into_raw(pointer) as _;
-                    }
-                },
-                WLR_INPUT_DEVICE_TOUCH => {
-                    let touch = match Touch::new_from_input_device(data) {
-                        Some(dev) => dev,
-                        None => {
-                            wlr_log!(WLR_ERROR, "Device {:#?} was not a touch", dev);
-                            abort()
+                    },
+                    WLR_INPUT_DEVICE_TOUCH => {
+                        let touch = match Touch::new_from_input_device(data) {
+                            Some(dev) => dev,
+                            None => {
+                                wlr_log!(WLR_ERROR, "Device {:#?} was not a touch", dev);
+                                abort()
+                            }
+                        };
+                        let touch_handle = touch.weak_reference();
+                        let res = manager.touch_added.and_then(|f| f(compositor.clone(), touch_handle));
+                        if let Some(touch_handler) = res {
+                            let mut touch = TouchWrapper::new((touch, touch_handler));
+                            wl_signal_add(&mut (*dev.dev_union().touch).events.down as *mut _ as _,
+                                          touch.down_listener() as *mut _ as _);
+                            wl_signal_add(&mut (*dev.dev_union().touch).events.up as *mut _ as _,
+                                          touch.up_listener() as *mut _ as _);
+                            wl_signal_add(&mut (*dev.dev_union().touch).events.motion as *mut _ as _,
+                                          touch.motion_listener() as *mut _ as _);
+                            wl_signal_add(&mut (*dev.dev_union().touch).events.cancel as *mut _ as _,
+                                          touch.cancel_listener() as *mut _ as _);
+                            wl_signal_add(&mut (*dev.as_ptr()).events.destroy as *mut _ as _,
+                                          touch.on_destroy_listener() as _);
+                            (*data).data = Box::into_raw(touch) as _;
                         }
-                    };
-                    let touch_handle = touch.weak_reference();
-                    if let Some(touch_handler) = manager.touch_added(compositor.clone(),
-                                                                     touch_handle) {
-                        let mut touch = TouchWrapper::new((touch, touch_handler));
-                        wl_signal_add(&mut (*dev.dev_union().touch).events.down as *mut _ as _,
-                                      touch.down_listener() as *mut _ as _);
-                        wl_signal_add(&mut (*dev.dev_union().touch).events.up as *mut _ as _,
-                                      touch.up_listener() as *mut _ as _);
-                        wl_signal_add(&mut (*dev.dev_union().touch).events.motion as *mut _ as _,
-                                      touch.motion_listener() as *mut _ as _);
-                        wl_signal_add(&mut (*dev.dev_union().touch).events.cancel as *mut _ as _,
-                                      touch.cancel_listener() as *mut _ as _);
-                        wl_signal_add(&mut (*dev.as_ptr()).events.destroy as *mut _ as _,
-                                      touch.on_destroy_listener() as _);
-                        (*data).data = Box::into_raw(touch) as _;
-                    }
-                },
-                WLR_INPUT_DEVICE_TABLET_TOOL => {
-                    let tablet_tool = match TabletTool::new_from_input_device(data) {
-                        Some(dev) => dev,
-                        None => {
-                            wlr_log!(WLR_ERROR, "Device {:#?}, was not a tablet tool", dev);
-                            abort()
+                    },
+                    WLR_INPUT_DEVICE_TABLET_TOOL => {
+                        let tablet_tool = match TabletTool::new_from_input_device(data) {
+                            Some(dev) => dev,
+                            None => {
+                                wlr_log!(WLR_ERROR, "Device {:#?}, was not a tablet tool", dev);
+                                abort()
+                            }
+                        };
+                        let tablet_tool_handle = tablet_tool.weak_reference();
+                        let res = manager.tablet_tool_added.and_then(|f| f(compositor.clone(), tablet_tool_handle));
+                        if let Some(tablet_tool_handler) = res {
+                            let mut tablet_tool = TabletToolWrapper::new((tablet_tool,
+                                                                          tablet_tool_handler));
+                            let tool_ptr = &mut (*dev.dev_union().tablet);
+                            wl_signal_add(&mut tool_ptr.events.axis as *mut _ as _,
+                                          tablet_tool.axis_listener() as *mut _ as _);
+                            wl_signal_add(&mut tool_ptr.events.proximity as *mut _ as _,
+                                          tablet_tool.proximity_listener() as *mut _ as _);
+                            wl_signal_add(&mut tool_ptr.events.tip as *mut _ as _,
+                                          tablet_tool.tip_listener() as *mut _ as _);
+                            wl_signal_add(&mut tool_ptr.events.button as *mut _ as _,
+                                          tablet_tool.button_listener() as *mut _ as _);
+                            wl_signal_add(&mut (*dev.as_ptr()).events.destroy as *mut _ as _,
+                                          tablet_tool.on_destroy_listener() as _);
+                            (*data).data = Box::into_raw(tablet_tool) as _;
                         }
-                    };
-                    let tablet_tool_handle = tablet_tool.weak_reference();
-                    if let Some(tablet_tool_handler) = manager.tablet_tool_added(compositor.clone(),
-                                                                         tablet_tool_handle) {
-                        let mut tablet_tool = TabletToolWrapper::new((tablet_tool,
-                                                                      tablet_tool_handler));
-                        let tool_ptr = &mut (*dev.dev_union().tablet);
-                        wl_signal_add(&mut tool_ptr.events.axis as *mut _ as _,
-                                      tablet_tool.axis_listener() as *mut _ as _);
-                        wl_signal_add(&mut tool_ptr.events.proximity as *mut _ as _,
-                                      tablet_tool.proximity_listener() as *mut _ as _);
-                        wl_signal_add(&mut tool_ptr.events.tip as *mut _ as _,
-                                      tablet_tool.tip_listener() as *mut _ as _);
-                        wl_signal_add(&mut tool_ptr.events.button as *mut _ as _,
-                                      tablet_tool.button_listener() as *mut _ as _);
-                        wl_signal_add(&mut (*dev.as_ptr()).events.destroy as *mut _ as _,
-                                      tablet_tool.on_destroy_listener() as _);
-                        (*data).data = Box::into_raw(tablet_tool) as _;
-                    }
-                },
-                WLR_INPUT_DEVICE_TABLET_PAD => {
-                    let tablet_pad = match TabletPad::new_from_input_device(data) {
-                        Some(dev) => dev,
-                        None => {
-                            wlr_log!(WLR_ERROR, "Device {:#?}, was not a tablet pad", dev);
-                            abort()
+                    },
+                    WLR_INPUT_DEVICE_TABLET_PAD => {
+                        let tablet_pad = match TabletPad::new_from_input_device(data) {
+                            Some(dev) => dev,
+                            None => {
+                                wlr_log!(WLR_ERROR, "Device {:#?}, was not a tablet pad", dev);
+                                abort()
+                            }
+                        };
+                        let tablet_pad_handle = tablet_pad.weak_reference();
+                        let res = manager.tablet_pad_added.and_then(|f| f(compositor.clone(), tablet_pad_handle));
+                        if let Some(tablet_pad_handler) = res {
+                            let mut tablet_pad = TabletPadWrapper::new((tablet_pad,
+                                                                        tablet_pad_handler));
+                            let pad_ptr = &mut (*dev.dev_union().tablet_pad);
+                            wl_signal_add(&mut pad_ptr.events.button as *mut _ as _,
+                                          tablet_pad.button_listener() as *mut _ as _);;
+                            wl_signal_add(&mut pad_ptr.events.ring as *mut _ as _,
+                                          tablet_pad.ring_listener() as *mut _ as _);;
+                            wl_signal_add(&mut pad_ptr.events.strip as *mut _ as _,
+                                          tablet_pad.strip_listener() as *mut _ as _);;
+                            wl_signal_add(&mut (*dev.as_ptr()).events.destroy as *mut _ as _,
+                                          tablet_pad.on_destroy_listener() as _);
+                            (*data).data = Box::into_raw(tablet_pad) as _;
                         }
-                    };
-                    let tablet_pad_handle = tablet_pad.weak_reference();
-                    if let Some(tablet_pad_handler) = manager.tablet_pad_added(compositor.clone(),
-                                                                       tablet_pad_handle) {
-                        let mut tablet_pad = TabletPadWrapper::new((tablet_pad,
-                                                                    tablet_pad_handler));
-                        let pad_ptr = &mut (*dev.dev_union().tablet_pad);
-                        wl_signal_add(&mut pad_ptr.events.button as *mut _ as _,
-                                      tablet_pad.button_listener() as *mut _ as _);;
-                        wl_signal_add(&mut pad_ptr.events.ring as *mut _ as _,
-                                      tablet_pad.ring_listener() as *mut _ as _);;
-                        wl_signal_add(&mut pad_ptr.events.strip as *mut _ as _,
-                                      tablet_pad.strip_listener() as *mut _ as _);;
-                        wl_signal_add(&mut (*dev.as_ptr()).events.destroy as *mut _ as _,
-                                      tablet_pad.on_destroy_listener() as _);
-                        (*data).data = Box::into_raw(tablet_pad) as _;
                     }
                 }
+                manager.input_added.map(|f| f(compositor, &mut dev))
+            }));
+            match res {
+                Ok(_) => {},
+                // NOTE
+                // Either Wayland or wlroots does not handle failure to set up input correctly.
+                // Calling wl_display_terminate does not work if input is incorrectly set up.
+                //
+                // Instead, execution keeps going with an eventual segfault (if lucky).
+                //
+                // To fix this, we abort the process if there was a panic in input setup.
+                Err(_) => abort()
             }
-            manager.input_added(compositor, &mut dev)
-        }));
-        match res {
-            Ok(_) => {},
-            // NOTE
-            // Either Wayland or wlroots does not handle failure to set up input correctly.
-            // Calling wl_display_terminate does not work if input is incorrectly set up.
-            //
-            // Instead, execution keeps going with an eventual segfault (if lucky).
-            //
-            // To fix this, we abort the process if there was a panic in input setup.
-            Err(_) => abort()
-        }
     };
-]);
+    ]
+}
 
 pub(crate) unsafe fn add_keyboard(dev: &mut input::Device) {
     // Set the XKB settings

--- a/src/manager/input_manager.rs
+++ b/src/manager/input_manager.rs
@@ -72,7 +72,7 @@ pub type TabletPadAdded = fn (compositor_handle: compositor::Handle,
 
 wayland_listener_static! {
     static mut MANAGER;
-    (Manager, ManagerBuilder): [
+    (Manager, Builder): [
         // NOTE
         // This is a macro hack to add these as arguments to the builder.
         // The callbacks will be storted in the manager, but they'll have no

--- a/src/manager/output_manager.rs
+++ b/src/manager/output_manager.rs
@@ -1,8 +1,6 @@
 //! Manager that is called when an output is created or destroyed.
-//! Pass a struct that implements this trait to the `Compositor` during
-//! initialization.
 
-use std::{marker::PhantomData, panic};
+use std::{marker::PhantomData, panic, ptr};
 
 use libc;
 use wayland_sys::server::signal::wl_signal_add;
@@ -10,7 +8,7 @@ use wlroots_sys::wlr_output;
 
 use {compositor,
      output::{self, Output, OutputState, UserOutput},
-     utils::Handleable};
+     utils::{self, Handleable}};
 
 
 /// Used to ensure the output sets the mode before doing any other
@@ -31,28 +29,6 @@ pub struct BuilderResult<'output> {
 /// Wrapper around Output destruction so that you can't call
 /// unsafe methods (e.g anything like setting the mode).
 pub struct Destroyed(output::Handle);
-
-/// Handles output addition and removal.
-#[allow(unused_variables)]
-pub trait ManagerHandler {
-    /// Called whenever an output is added.
-    ///
-    /// # Panics
-    /// Any panic in this function will cause the process to abort.
-    fn output_added<'output>(&mut self,
-                             compositor_handle: compositor::Handle,
-                             output_builder: Builder<'output>)
-                             -> Option<BuilderResult<'output>> {
-        None
-    }
-
-    /// Called whenever an output is removed.
-    fn output_removed(&mut self,
-                      compositor_handle: compositor::Handle,
-                      destroyed_output: Destroyed) {
-        // TODO
-    }
-}
 
 impl<'output> Builder<'output> {
     /// Build the output with the best mode.
@@ -75,59 +51,117 @@ impl Destroyed {
     // TODO Functions which are safe to use
 }
 
-wayland_listener!(pub(crate) Manager, Box<ManagerHandler>, [
-    add_listener => add_notify: |this: &mut Manager, data: *mut libc::c_void,| unsafe {
-        let ref mut manager = this.data;
-        let data = data as *mut wlr_output;
-        let output = Output::new(data as *mut wlr_output);
-        // NOTE
-        // This clone is required because we pass it mutably to the output builder,
-        // but due to lack of NLL there's no way to tell Rust it's safe to use it in
-        // in the if branch.
-        //
-        // Thus, we need to clone it here and then drop the original once at the end.
-        //
-        // This is not a real clone, but an pub(crate) unsafe one we added, so it doesn't
-        // break safety concerns in user code. Just an unfortunate hack we have to put here.
-        let output_clone = output.clone();
-        let builder = Builder { output: output.weak_reference(), phantom: PhantomData };
-        let compositor = match compositor::handle() {
-            Some(handle) => handle,
-            None => return
-        };
-        let res = panic::catch_unwind(
-            panic::AssertUnwindSafe(||manager.output_added(compositor, builder)));
-        let build_result = match res {
-            Ok(res) => res,
-            // NOTE
-            // Either Wayland or wlroots does not handle failure to set up output correctly.
-            // Calling wl_display_terminate does not work if output is incorrectly set up.
-            //
-            // Instead, execution keeps going with an eventual segfault (if lucky).
-            //
-            // To fix this, we abort the process if there was a panic in output setup.
-            Err(_) => ::std::process::abort()
-        };
-        if let Some(BuilderResult {result: output_ptr, .. }) = build_result {
-            let mut output = UserOutput::new((output_clone, output_ptr));
-            wl_signal_add(&mut (*data).events.frame as *mut _ as _,
-                          output.frame_listener() as _);
-            wl_signal_add(&mut (*data).events.mode as *mut _ as _,
-                          output.mode_listener() as _);
-            wl_signal_add(&mut (*data).events.enable as *mut _ as _,
-                          output.enable_listener() as _);
-            wl_signal_add(&mut (*data).events.scale as *mut _ as _,
-                          output.scale_listener() as _);
-            wl_signal_add(&mut (*data).events.transform as *mut _ as _,
-                          output.transform_listener() as _);
-            wl_signal_add(&mut (*data).events.swap_buffers as *mut _ as _,
-                          output.swap_buffers_listener() as _);
-            wl_signal_add(&mut (*data).events.needs_swap as *mut _ as _,
-                          output.need_swap_listener() as _);
-            wl_signal_add(&mut (*data).events.destroy as *mut _ as _,
-                          output.on_destroy_listener() as _);
-            let output_data = (*data).data as *mut OutputState;
-            (*output_data).output = Box::into_raw(output);
+#[derive(Default)]
+pub struct ManagerBuilder {
+    add_callback: Option<fn(compositor_handle: compositor::Handle,
+                            output_builder: Builder)
+                            -> Option<BuilderResult>>
+}
+
+impl ManagerBuilder {
+    pub fn output_added(mut self,
+                        add_callback: fn(compositor_handle: compositor::Handle,
+                                         output_builder: Builder)
+                                         -> Option<BuilderResult>) -> Self {
+        self.add_callback = Some(add_callback);
+        self
+    }
+}
+
+#[repr(C)]
+pub(crate) struct Manager {
+    pub(crate) add_listener: wlroots_sys::wl_listener,
+    add_callback: Option<fn(compositor_handle: compositor::Handle,
+                            output_builder: Builder)
+                            -> Option<BuilderResult>>
+}
+
+pub(crate) static mut MANAGER: Manager = Manager {
+    add_listener: wlroots_sys::wl_listener {
+        link: { wlroots_sys::wl_list { prev: ptr::null_mut(), next: ptr::null_mut()}},
+        notify: None },
+    add_callback: None
+};
+
+impl Manager {
+    /// Sets the functions on the builder as the global manager functions.
+    pub(crate) fn build(builder: ManagerBuilder) {
+        unsafe {
+            MANAGER.add_listener = {
+                // NOTE Rationale for zeroed memory:
+                // * Need to pass a pointer to wl_list_init
+                // * The list is initialized by Wayland, which doesn't "drop"
+                // * The listener is written to without dropping any of the data
+                let mut listener: wlroots_sys::wl_listener = ::std::mem::zeroed();
+                use wlroots_sys::server::WAYLAND_SERVER_HANDLE;
+                ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                              wl_list_init,
+                              &mut listener.link as *mut _ as _);
+                ::std::ptr::write(&mut listener.notify, Some(add_notify));
+                listener
+            };
+            MANAGER.add_callback = builder.add_callback;
         }
-    };
-]);
+    }
+}
+
+unsafe extern "C" fn add_notify(listener: *mut wlroots_sys::wl_listener, data: *mut libc::c_void) {
+    utils::handle_unwind(
+        panic::catch_unwind(
+            panic::AssertUnwindSafe(|| {
+                let manager = &mut *container_of!(listener, Manager, add_listener);
+                let data = data as *mut wlr_output;
+                let output = Output::new(data as *mut wlr_output);
+                // NOTE
+                // This clone is required because we pass it mutably to the output builder,
+                // but due to lack of NLL there's no way to tell Rust it's safe to use it in
+                // in the if branch.
+                //
+                // Thus, we need to clone it here and then drop the original once at the end.
+                //
+                // This is not a real clone, but an pub(crate) unsafe one we added, so it doesn't
+                // break safety concerns in user code. Just an unfortunate hack we have to put here.
+                let output_clone = output.clone();
+                let builder = Builder { output: output.weak_reference(), phantom: PhantomData };
+                let compositor = match compositor::handle() {
+                    Some(handle) => handle,
+                    None => return
+                };
+                let res = panic::catch_unwind(
+                    panic::AssertUnwindSafe(|| manager.add_callback
+                                            .map(|f| f(compositor, builder))
+                                            .unwrap_or(None)));
+                let build_result = match res {
+                    Ok(res) => res,
+                    // NOTE
+                    // Either Wayland or wlroots does not handle failure to set up output correctly.
+                    // Calling wl_display_terminate does not work if output is incorrectly set up.
+                    //
+                    // Instead, execution keeps going with an eventual segfault (if lucky).
+                    //
+                    // To fix this, we abort the process if there was a panic in output setup.
+                    Err(_) => ::std::process::abort()
+                };
+                if let Some(BuilderResult {result: output_ptr, .. }) = build_result {
+                    let mut output = UserOutput::new((output_clone, output_ptr));
+                    wl_signal_add(&mut (*data).events.frame as *mut _ as _,
+                                  output.frame_listener() as _);
+                    wl_signal_add(&mut (*data).events.mode as *mut _ as _,
+                                  output.mode_listener() as _);
+                    wl_signal_add(&mut (*data).events.enable as *mut _ as _,
+                                  output.enable_listener() as _);
+                    wl_signal_add(&mut (*data).events.scale as *mut _ as _,
+                                  output.scale_listener() as _);
+                    wl_signal_add(&mut (*data).events.transform as *mut _ as _,
+                                  output.transform_listener() as _);
+                    wl_signal_add(&mut (*data).events.swap_buffers as *mut _ as _,
+                                  output.swap_buffers_listener() as _);
+                    wl_signal_add(&mut (*data).events.needs_swap as *mut _ as _,
+                                  output.need_swap_listener() as _);
+                    wl_signal_add(&mut (*data).events.destroy as *mut _ as _,
+                                  output.on_destroy_listener() as _);
+                    let output_data = (*data).data as *mut OutputState;
+                    (*output_data).output = Box::into_raw(output);
+                }
+            })));
+}

--- a/src/manager/output_manager.rs
+++ b/src/manager/output_manager.rs
@@ -1,6 +1,6 @@
 //! Manager that is called when an output is created or destroyed.
 
-use std::{marker::PhantomData, panic, ptr};
+use std::{marker::PhantomData, panic};
 
 use libc;
 use wayland_sys::server::signal::wl_signal_add;
@@ -8,7 +8,7 @@ use wlroots_sys::wlr_output;
 
 use {compositor,
      output::{self, Output, OutputState, UserOutput},
-     utils::{self, Handleable}};
+     utils::Handleable};
 
 
 /// Used to ensure the output sets the mode before doing any other
@@ -51,117 +51,68 @@ impl Destroyed {
     // TODO Functions which are safe to use
 }
 
-#[derive(Default)]
-pub struct ManagerBuilder {
-    add_callback: Option<fn(compositor_handle: compositor::Handle,
-                            output_builder: Builder)
-                            -> Option<BuilderResult>>
-}
+pub type OutputAdded = fn(compositor_handle: compositor::Handle,
+                          output_builder: Builder)
+                          -> Option<BuilderResult>;
 
-impl ManagerBuilder {
-    pub fn output_added(mut self,
-                        add_callback: fn(compositor_handle: compositor::Handle,
-                                         output_builder: Builder)
-                                         -> Option<BuilderResult>) -> Self {
-        self.add_callback = Some(add_callback);
-        self
-    }
-}
-
-#[repr(C)]
-pub(crate) struct Manager {
-    pub(crate) add_listener: wlroots_sys::wl_listener,
-    add_callback: Option<fn(compositor_handle: compositor::Handle,
-                            output_builder: Builder)
-                            -> Option<BuilderResult>>
-}
-
-pub(crate) static mut MANAGER: Manager = Manager {
-    add_listener: wlroots_sys::wl_listener {
-        link: { wlroots_sys::wl_list { prev: ptr::null_mut(), next: ptr::null_mut()}},
-        notify: None },
-    add_callback: None
-};
-
-impl Manager {
-    /// Sets the functions on the builder as the global manager functions.
-    pub(crate) fn build(builder: ManagerBuilder) {
-        unsafe {
-            MANAGER.add_listener = {
-                // NOTE Rationale for zeroed memory:
-                // * Need to pass a pointer to wl_list_init
-                // * The list is initialized by Wayland, which doesn't "drop"
-                // * The listener is written to without dropping any of the data
-                let mut listener: wlroots_sys::wl_listener = ::std::mem::zeroed();
-                use wlroots_sys::server::WAYLAND_SERVER_HANDLE;
-                ffi_dispatch!(WAYLAND_SERVER_HANDLE,
-                              wl_list_init,
-                              &mut listener.link as *mut _ as _);
-                ::std::ptr::write(&mut listener.notify, Some(add_notify));
-                listener
+wayland_listener_static! {
+    static mut MANAGER;
+    (Manager, ManagerBuilder): [
+        (OutputAdded, add_listener, output_added) => (add_notify, add_callback):
+        |manager: &mut Manager, data: *mut libc::c_void,| unsafe {
+            let data = data as *mut wlr_output;
+            let output = Output::new(data as *mut wlr_output);
+            // NOTE
+            // This clone is required because we pass it mutably to the output builder,
+            // but due to lack of NLL there's no way to tell Rust it's safe to use it in
+            // in the if branch.
+            //
+            // Thus, we need to clone it here and then drop the original once at the end.
+            //
+            // This is not a real clone, but an pub(crate) unsafe one we added, so it doesn't
+            // break safety concerns in user code. Just an unfortunate hack we have to put here.
+            let output_clone = output.clone();
+            let builder = Builder { output: output.weak_reference(), phantom: PhantomData };
+            let compositor = match compositor::handle() {
+                Some(handle) => handle,
+                None => return
             };
-            MANAGER.add_callback = builder.add_callback;
-        }
-    }
-}
-
-unsafe extern "C" fn add_notify(listener: *mut wlroots_sys::wl_listener, data: *mut libc::c_void) {
-    utils::handle_unwind(
-        panic::catch_unwind(
-            panic::AssertUnwindSafe(|| {
-                let manager = &mut *container_of!(listener, Manager, add_listener);
-                let data = data as *mut wlr_output;
-                let output = Output::new(data as *mut wlr_output);
+            let res = panic::catch_unwind(
+                panic::AssertUnwindSafe(|| manager.add_callback
+                                        .map(|f| f(compositor, builder))
+                                        .unwrap_or(None)));
+            let build_result = match res {
+                Ok(res) => res,
                 // NOTE
-                // This clone is required because we pass it mutably to the output builder,
-                // but due to lack of NLL there's no way to tell Rust it's safe to use it in
-                // in the if branch.
+                // Either Wayland or wlroots does not handle failure to set up output correctly.
+                // Calling wl_display_terminate does not work if output is incorrectly set up.
                 //
-                // Thus, we need to clone it here and then drop the original once at the end.
+                // Instead, execution keeps going with an eventual segfault (if lucky).
                 //
-                // This is not a real clone, but an pub(crate) unsafe one we added, so it doesn't
-                // break safety concerns in user code. Just an unfortunate hack we have to put here.
-                let output_clone = output.clone();
-                let builder = Builder { output: output.weak_reference(), phantom: PhantomData };
-                let compositor = match compositor::handle() {
-                    Some(handle) => handle,
-                    None => return
-                };
-                let res = panic::catch_unwind(
-                    panic::AssertUnwindSafe(|| manager.add_callback
-                                            .map(|f| f(compositor, builder))
-                                            .unwrap_or(None)));
-                let build_result = match res {
-                    Ok(res) => res,
-                    // NOTE
-                    // Either Wayland or wlroots does not handle failure to set up output correctly.
-                    // Calling wl_display_terminate does not work if output is incorrectly set up.
-                    //
-                    // Instead, execution keeps going with an eventual segfault (if lucky).
-                    //
-                    // To fix this, we abort the process if there was a panic in output setup.
-                    Err(_) => ::std::process::abort()
-                };
-                if let Some(BuilderResult {result: output_ptr, .. }) = build_result {
-                    let mut output = UserOutput::new((output_clone, output_ptr));
-                    wl_signal_add(&mut (*data).events.frame as *mut _ as _,
-                                  output.frame_listener() as _);
-                    wl_signal_add(&mut (*data).events.mode as *mut _ as _,
-                                  output.mode_listener() as _);
-                    wl_signal_add(&mut (*data).events.enable as *mut _ as _,
-                                  output.enable_listener() as _);
-                    wl_signal_add(&mut (*data).events.scale as *mut _ as _,
-                                  output.scale_listener() as _);
-                    wl_signal_add(&mut (*data).events.transform as *mut _ as _,
-                                  output.transform_listener() as _);
-                    wl_signal_add(&mut (*data).events.swap_buffers as *mut _ as _,
-                                  output.swap_buffers_listener() as _);
-                    wl_signal_add(&mut (*data).events.needs_swap as *mut _ as _,
-                                  output.need_swap_listener() as _);
-                    wl_signal_add(&mut (*data).events.destroy as *mut _ as _,
-                                  output.on_destroy_listener() as _);
-                    let output_data = (*data).data as *mut OutputState;
-                    (*output_data).output = Box::into_raw(output);
-                }
-            })));
+                // To fix this, we abort the process if there was a panic in output setup.
+                Err(_) => ::std::process::abort()
+            };
+            if let Some(BuilderResult {result: output_ptr, .. }) = build_result {
+                let mut output = UserOutput::new((output_clone, output_ptr));
+                wl_signal_add(&mut (*data).events.frame as *mut _ as _,
+                              output.frame_listener() as _);
+                wl_signal_add(&mut (*data).events.mode as *mut _ as _,
+                              output.mode_listener() as _);
+                wl_signal_add(&mut (*data).events.enable as *mut _ as _,
+                              output.enable_listener() as _);
+                wl_signal_add(&mut (*data).events.scale as *mut _ as _,
+                              output.scale_listener() as _);
+                wl_signal_add(&mut (*data).events.transform as *mut _ as _,
+                              output.transform_listener() as _);
+                wl_signal_add(&mut (*data).events.swap_buffers as *mut _ as _,
+                              output.swap_buffers_listener() as _);
+                wl_signal_add(&mut (*data).events.needs_swap as *mut _ as _,
+                              output.need_swap_listener() as _);
+                wl_signal_add(&mut (*data).events.destroy as *mut _ as _,
+                              output.on_destroy_listener() as _);
+                let output_data = (*data).data as *mut OutputState;
+                (*output_data).output = Box::into_raw(output);
+            }
+        };
+    ]
 }

--- a/src/manager/xdg_shell_manager.rs
+++ b/src/manager/xdg_shell_manager.rs
@@ -12,12 +12,12 @@ use super::xdg_shell_handler::XdgShell;
 
 /// Callback that is triggered when a new stable XDG shell surface appears.
 pub type NewSurface = fn(compositor_handle: compositor::Handle,
-                            xdg_shell_handle: xdg_shell::Handle)
-                            -> (Option<Box<xdg_shell::Handler>>, Option<Box<surface::Handler>>);
+                         xdg_shell_handle: xdg_shell::Handle)
+                         -> (Option<Box<xdg_shell::Handler>>, Option<Box<surface::Handler>>);
 
 wayland_listener_static! {
     static mut MANAGER;
-    (Manager, ManagerBuilder): [
+    (Manager, Builder): [
         (NewSurface, add_listener, surface_added) => (add_notify, surface_added):
         |manager: &mut Manager, data: *mut libc::c_void,|
         unsafe {

--- a/src/manager/xdg_shell_manager.rs
+++ b/src/manager/xdg_shell_manager.rs
@@ -10,82 +10,84 @@ use {compositor,
      utils::Handleable};
 use super::xdg_shell_handler::XdgShell;
 
-#[allow(unused_variables)]
-pub trait ManagerHandler {
-    /// Callback that is triggered when a new stable XDG shell surface appears.
-    fn new_surface(&mut self,
-                   compositor_handle: compositor::Handle,
-                   xdg_shell_handle: xdg_shell::Handle)
-                   -> (Option<Box<xdg_shell::Handler>>, Option<Box<surface::Handler>>);
+/// Callback that is triggered when a new stable XDG shell surface appears.
+pub type NewSurface = fn(compositor_handle: compositor::Handle,
+                            xdg_shell_handle: xdg_shell::Handle)
+                            -> (Option<Box<xdg_shell::Handler>>, Option<Box<surface::Handler>>);
+
+wayland_listener_static! {
+    static mut MANAGER;
+    (Manager, ManagerBuilder): [
+        (NewSurface, add_listener, surface_added) => (add_notify, surface_added):
+        |manager: &mut Manager, data: *mut libc::c_void,|
+        unsafe {
+            let data = data as *mut wlr_xdg_surface;
+            let compositor = match compositor::handle() {
+                Some(handle) => handle,
+                None => return
+            };
+            wlr_log!(WLR_DEBUG, "New xdg_shell_surface request {:p}", data);
+            let state = unsafe {
+                match (*data).role {
+                    WLR_XDG_SURFACE_ROLE_NONE => None,
+                    WLR_XDG_SURFACE_ROLE_TOPLEVEL => {
+                        let toplevel = (*data).__bindgen_anon_1.toplevel;
+                        Some(ShellState::TopLevel(xdg_shell::TopLevel::from_shell(data, toplevel)))
+                    }
+                    WLR_XDG_SURFACE_ROLE_POPUP => {
+                        let popup = (*data).__bindgen_anon_1.popup;
+                        Some(ShellState::Popup(xdg_shell::Popup::from_shell(data, popup)))
+                    }
+                }
+            };
+            let shell_surface = xdg_shell::Surface::new(data, state);
+
+            let (shell_surface_manager, surface_handler) =
+                match manager.surface_added {
+                    None => (None, None),
+                    Some(f) => f(compositor, shell_surface.weak_reference())
+                };
+
+            let mut shell_surface = XdgShell::new((shell_surface, shell_surface_manager));
+            let surface_state = (*(*data).surface).data as *mut surface::InternalState;
+            if let Some(surface_handler) = surface_handler {
+                (*(*surface_state).surface).data().1 = surface_handler;
+            }
+
+            wl_signal_add(&mut (*data).events.destroy as *mut _ as _,
+                          shell_surface.destroy_listener() as _);
+            wl_signal_add(&mut (*(*data).surface).events.commit as *mut _ as _,
+                          shell_surface.commit_listener() as _);
+            wl_signal_add(&mut (*data).events.ping_timeout as *mut _ as _,
+                          shell_surface.ping_timeout_listener() as _);
+            wl_signal_add(&mut (*data).events.new_popup as *mut _ as _,
+                          shell_surface.new_popup_listener() as _);
+            wl_signal_add(&mut (*data).events.map as *mut _ as _,
+                          shell_surface.map_listener() as _);
+            wl_signal_add(&mut (*data).events.unmap as *mut _ as _,
+                          shell_surface.unmap_listener() as _);
+            let events = with_handles!([(shell_surface: {shell_surface.surface_mut()})] => {
+                match shell_surface.state() {
+                    None | Some(&mut ShellState::Popup(_)) => None,
+                    Some(&mut ShellState::TopLevel(ref mut toplevel)) => Some((*toplevel.as_ptr()).events)
+                }
+            }).expect("Cannot borrow xdg shell surface");
+            if let Some(mut events) = events {
+                wl_signal_add(&mut events.request_maximize as *mut _ as _,
+                              shell_surface.maximize_listener() as _);
+                wl_signal_add(&mut events.request_fullscreen as *mut _ as _,
+                              shell_surface.fullscreen_listener() as _);
+                wl_signal_add(&mut events.request_minimize as *mut _ as _,
+                              shell_surface.minimize_listener() as _);
+                wl_signal_add(&mut events.request_move as *mut _ as _,
+                              shell_surface.move_listener() as _);
+                wl_signal_add(&mut events.request_resize as *mut _ as _,
+                              shell_surface.resize_listener() as _);
+                wl_signal_add(&mut events.request_show_window_menu as *mut _ as _,
+                              shell_surface.show_window_menu_listener() as _);
+            }
+            let shell_data = (*data).data as *mut xdg_shell::SurfaceState;
+            (*shell_data).shell = Box::into_raw(shell_surface);
+        };
+    ]
 }
-
-wayland_listener!(pub(crate) Manager, Box<ManagerHandler>, [
-    add_listener => add_notify: |this: &mut Manager, data: *mut libc::c_void,|
-    unsafe {
-        let manager = &mut this.data;
-        let data = data as *mut wlr_xdg_surface;
-        let compositor = match compositor::handle() {
-            Some(handle) => handle,
-            None => return
-        };
-        wlr_log!(WLR_DEBUG, "New xdg_shell_surface request {:p}", data);
-        let state = unsafe {
-            match (*data).role {
-                WLR_XDG_SURFACE_ROLE_NONE => None,
-                WLR_XDG_SURFACE_ROLE_TOPLEVEL => {
-                    let toplevel = (*data).__bindgen_anon_1.toplevel;
-                    Some(ShellState::TopLevel(xdg_shell::TopLevel::from_shell(data, toplevel)))
-                }
-                WLR_XDG_SURFACE_ROLE_POPUP => {
-                    let popup = (*data).__bindgen_anon_1.popup;
-                    Some(ShellState::Popup(xdg_shell::Popup::from_shell(data, popup)))
-                }
-            }
-        };
-        let shell_surface = xdg_shell::Surface::new(data, state);
-
-        let (shell_surface_manager, surface_handler) =
-            manager.new_surface(compositor, shell_surface.weak_reference());
-
-        let mut shell_surface = XdgShell::new((shell_surface, shell_surface_manager));
-        let surface_state = (*(*data).surface).data as *mut surface::InternalState;
-        if let Some(surface_handler) = surface_handler {
-            (*(*surface_state).surface).data().1 = surface_handler;
-        }
-
-        wl_signal_add(&mut (*data).events.destroy as *mut _ as _,
-                        shell_surface.destroy_listener() as _);
-        wl_signal_add(&mut (*(*data).surface).events.commit as *mut _ as _,
-                        shell_surface.commit_listener() as _);
-        wl_signal_add(&mut (*data).events.ping_timeout as *mut _ as _,
-                        shell_surface.ping_timeout_listener() as _);
-        wl_signal_add(&mut (*data).events.new_popup as *mut _ as _,
-                        shell_surface.new_popup_listener() as _);
-        wl_signal_add(&mut (*data).events.map as *mut _ as _,
-                        shell_surface.map_listener() as _);
-        wl_signal_add(&mut (*data).events.unmap as *mut _ as _,
-                        shell_surface.unmap_listener() as _);
-        let events = with_handles!([(shell_surface: {shell_surface.surface_mut()})] => {
-            match shell_surface.state() {
-                None | Some(&mut ShellState::Popup(_)) => None,
-                Some(&mut ShellState::TopLevel(ref mut toplevel)) => Some((*toplevel.as_ptr()).events)
-            }
-        }).expect("Cannot borrow xdg shell surface");
-        if let Some(mut events) = events {
-            wl_signal_add(&mut events.request_maximize as *mut _ as _,
-                            shell_surface.maximize_listener() as _);
-            wl_signal_add(&mut events.request_fullscreen as *mut _ as _,
-                            shell_surface.fullscreen_listener() as _);
-            wl_signal_add(&mut events.request_minimize as *mut _ as _,
-                            shell_surface.minimize_listener() as _);
-            wl_signal_add(&mut events.request_move as *mut _ as _,
-                            shell_surface.move_listener() as _);
-            wl_signal_add(&mut events.request_resize as *mut _ as _,
-                            shell_surface.resize_listener() as _);
-            wl_signal_add(&mut events.request_show_window_menu as *mut _ as _,
-                            shell_surface.show_window_menu_listener() as _);
-        }
-        let shell_data = (*data).data as *mut xdg_shell::SurfaceState;
-        (*shell_data).shell = Box::into_raw(shell_surface);
-    };
-]);

--- a/src/manager/xdg_shell_v6_manager.rs
+++ b/src/manager/xdg_shell_v6_manager.rs
@@ -10,82 +10,84 @@ use {compositor,
      utils::Handleable};
 use super::xdg_shell_v6_handler::XdgShellV6;
 
-pub trait ManagerHandler {
-    /// Callback that is triggered when a new XDG shell v6 surface appears.
-    fn new_surface(&mut self,
-                   compositor_handle: compositor::Handle,
-                   xdg_shell_v6_handle: xdg_shell_v6::Handle)
-                   -> (Option<Box<xdg_shell_v6::Handler>>, Option<Box<surface::Handler>>);
+/// Callback that is triggered when a new XDG shell v6 surface appears.
+pub type NewSurface = fn(compositor_handle: compositor::Handle,
+                         xdg_shell_v6_handle: xdg_shell_v6::Handle)
+                         -> (Option<Box<xdg_shell_v6::Handler>>, Option<Box<surface::Handler>>);
+
+wayland_listener_static! {
+    static mut MANAGER;
+    (Manager, ManagerBuilder): [
+        (NewSurface, add_listener, surface_added) => (add_notify, surface_added):
+        |manager: &mut Manager, data: *mut libc::c_void,| unsafe {
+            let data = data as *mut wlr_xdg_surface_v6;
+            let compositor = match compositor::handle() {
+                Some(handle) => handle,
+                None => return
+            };
+            wlr_log!(WLR_DEBUG, "New xdg_shell_v6_surface request {:p}", data);
+            let state = unsafe {
+                match (*data).role {
+                    WLR_XDG_SURFACE_V6_ROLE_NONE => None,
+                    WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL => {
+                        let toplevel = (*data).__bindgen_anon_1.toplevel;
+                        Some(ShellState::TopLevel(xdg_shell_v6::TopLevel::from_shell(data, toplevel)))
+                    }
+                    WLR_XDG_SURFACE_V6_ROLE_POPUP => {
+                        let popup = (*data).__bindgen_anon_1.popup;
+                        Some(ShellState::Popup(xdg_shell_v6::Popup::from_shell(data, popup)))
+                    }
+                }
+            };
+            let shell_surface = xdg_shell_v6::Surface::new(data, state);
+
+            let (shell_surface_handler, surface_handler) =
+                match manager.surface_added {
+                    None => (None, None),
+                    Some(f) => f(compositor, shell_surface.weak_reference())
+                };
+
+            let mut shell_surface = XdgShellV6::new((shell_surface, shell_surface_handler));
+            let surface_state = (*(*data).surface).data as *mut surface::InternalState;
+            if let Some(surface_handler) = surface_handler {
+                (*(*surface_state).surface).data().1 = surface_handler;
+            }
+
+            wl_signal_add(&mut (*data).events.destroy as *mut _ as _,
+                          shell_surface.destroy_listener() as _);
+            wl_signal_add(&mut (*(*data).surface).events.commit as *mut _ as _,
+                          shell_surface.commit_listener() as _);
+            wl_signal_add(&mut (*data).events.ping_timeout as *mut _ as _,
+                          shell_surface.ping_timeout_listener() as _);
+            wl_signal_add(&mut (*data).events.new_popup as *mut _ as _,
+                          shell_surface.new_popup_listener() as _);
+            wl_signal_add(&mut (*data).events.map as *mut _ as _,
+                          shell_surface.map_listener() as _);
+            wl_signal_add(&mut (*data).events.unmap as *mut _ as _,
+                          shell_surface.unmap_listener() as _);
+            let events = with_handles!([(shell_surface: {shell_surface.surface_mut()})] => {
+                match shell_surface.state() {
+                    None | Some(&mut ShellState::Popup(_)) => None,
+                    Some(&mut ShellState::TopLevel(ref mut toplevel)) => Some((*toplevel.as_ptr()).events)
+                }
+            }).expect("Cannot borrow xdg shell surface");
+            if let Some(mut events) = events {
+                wl_signal_add(&mut events.request_maximize as *mut _ as _,
+                              shell_surface.maximize_listener() as _);
+                wl_signal_add(&mut events.request_fullscreen as *mut _ as _,
+                              shell_surface.fullscreen_listener() as _);
+                wl_signal_add(&mut events.request_minimize as *mut _ as _,
+                              shell_surface.minimize_listener() as _);
+                wl_signal_add(&mut events.request_move as *mut _ as _,
+                              shell_surface.move_listener() as _);
+                wl_signal_add(&mut events.request_resize as *mut _ as _,
+                              shell_surface.resize_listener() as _);
+                wl_signal_add(&mut events.request_show_window_menu as *mut _ as _,
+                              shell_surface.show_window_menu_listener() as _);
+            }
+
+            let shell_data = (*data).data as *mut xdg_shell_v6::SurfaceState;
+            (*shell_data).shell = Box::into_raw(shell_surface);
+        };
+    ]
 }
-
-wayland_listener!(pub(crate) Manager, Box<ManagerHandler>, [
-    add_listener => add_notify: |this: &mut Manager, data: *mut libc::c_void,|
-    unsafe {
-        let ref mut manager = this.data;
-        let data = data as *mut wlr_xdg_surface_v6;
-        let compositor = match compositor::handle() {
-            Some(handle) => handle,
-            None => return
-        };
-        wlr_log!(WLR_DEBUG, "New xdg_shell_v6_surface request {:p}", data);
-        let state = unsafe {
-            match (*data).role {
-                WLR_XDG_SURFACE_V6_ROLE_NONE => None,
-                WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL => {
-                    let toplevel = (*data).__bindgen_anon_1.toplevel;
-                    Some(ShellState::TopLevel(xdg_shell_v6::TopLevel::from_shell(data, toplevel)))
-                }
-                WLR_XDG_SURFACE_V6_ROLE_POPUP => {
-                    let popup = (*data).__bindgen_anon_1.popup;
-                    Some(ShellState::Popup(xdg_shell_v6::Popup::from_shell(data, popup)))
-                }
-            }
-        };
-        let shell_surface = xdg_shell_v6::Surface::new(data, state);
-
-        let (shell_surface_handler, surface_handler) =
-            manager.new_surface(compositor, shell_surface.weak_reference());
-
-        let mut shell_surface = XdgShellV6::new((shell_surface, shell_surface_handler));
-        let surface_state = (*(*data).surface).data as *mut surface::InternalState;
-        if let Some(surface_handler) = surface_handler {
-            (*(*surface_state).surface).data().1 = surface_handler;
-        }
-
-        wl_signal_add(&mut (*data).events.destroy as *mut _ as _,
-                        shell_surface.destroy_listener() as _);
-        wl_signal_add(&mut (*(*data).surface).events.commit as *mut _ as _,
-                        shell_surface.commit_listener() as _);
-        wl_signal_add(&mut (*data).events.ping_timeout as *mut _ as _,
-                        shell_surface.ping_timeout_listener() as _);
-        wl_signal_add(&mut (*data).events.new_popup as *mut _ as _,
-                        shell_surface.new_popup_listener() as _);
-        wl_signal_add(&mut (*data).events.map as *mut _ as _,
-                        shell_surface.map_listener() as _);
-        wl_signal_add(&mut (*data).events.unmap as *mut _ as _,
-                        shell_surface.unmap_listener() as _);
-        let events = with_handles!([(shell_surface: {shell_surface.surface_mut()})] => {
-            match shell_surface.state() {
-                None | Some(&mut ShellState::Popup(_)) => None,
-                Some(&mut ShellState::TopLevel(ref mut toplevel)) => Some((*toplevel.as_ptr()).events)
-            }
-        }).expect("Cannot borrow xdg shell surface");
-        if let Some(mut events) = events {
-            wl_signal_add(&mut events.request_maximize as *mut _ as _,
-                            shell_surface.maximize_listener() as _);
-            wl_signal_add(&mut events.request_fullscreen as *mut _ as _,
-                            shell_surface.fullscreen_listener() as _);
-            wl_signal_add(&mut events.request_minimize as *mut _ as _,
-                            shell_surface.minimize_listener() as _);
-            wl_signal_add(&mut events.request_move as *mut _ as _,
-                            shell_surface.move_listener() as _);
-            wl_signal_add(&mut events.request_resize as *mut _ as _,
-                            shell_surface.resize_listener() as _);
-            wl_signal_add(&mut events.request_show_window_menu as *mut _ as _,
-                            shell_surface.show_window_menu_listener() as _);
-        }
-
-        let shell_data = (*data).data as *mut xdg_shell_v6::SurfaceState;
-        (*shell_data).shell = Box::into_raw(shell_surface);
-    };
-]);

--- a/src/manager/xdg_shell_v6_manager.rs
+++ b/src/manager/xdg_shell_v6_manager.rs
@@ -17,7 +17,7 @@ pub type NewSurface = fn(compositor_handle: compositor::Handle,
 
 wayland_listener_static! {
     static mut MANAGER;
-    (Manager, ManagerBuilder): [
+    (Manager, Builder): [
         (NewSurface, add_listener, surface_added) => (add_notify, surface_added):
         |manager: &mut Manager, data: *mut libc::c_void,| unsafe {
             let data = data as *mut wlr_xdg_surface_v6;

--- a/src/types/input/input_device.rs
+++ b/src/types/input/input_device.rs
@@ -6,7 +6,7 @@ use wlroots_sys::{wlr_input_device, wlr_input_device_pointer, wlr_input_device_t
 
 use {input::{keyboard, pointer, touch, tablet_pad, tablet_tool},
      utils::c_to_rust_string};
-pub use manager::input_manager::*;
+pub(crate) use manager::input_manager::Manager;
 
 /// A handle to an input device.
 pub enum Handle {

--- a/src/types/input/mod.rs
+++ b/src/types/input/mod.rs
@@ -6,3 +6,15 @@ pub mod tablet_tool;
 pub mod tablet_pad;
 
 pub use self::input_device::*;
+
+pub mod manager {
+    //! Input resources are managed by the input resource manager.
+    //!
+    //! To manage a particular type of input resource implement a function
+    //! with the signature of its corresponding name. For example, to manage
+    //! keyboards implement [`KeyboardAdded`](./type.KeyboardAdded.html).
+    //!
+    //! Pass those functions to an [`input::Builder`](./struct.Builder.html)
+    //! which is then given to a `compositor::Builder`.
+    pub use manager::input_manager::*;
+}

--- a/src/types/output/mod.rs
+++ b/src/types/output/mod.rs
@@ -8,3 +8,12 @@ pub use self::cursor::*;
 pub use self::damage::*;
 pub use self::output::*;
 pub use self::mode::*;
+
+pub mod manager {
+    //! Output resources are managed by the output resource manager.
+    //!
+    //! Using the [`OutputBuilder`](./struct.OutputBuilder.html) a [`BuilderResult`](./struct.BuilderResult.html) is constructed in a function
+    //! conforming to the [`OutputAdded`](./type.OutputAdded.html) type signature. That function is passed
+    //! to the [`output::Builder`](./struct.Builder.html) which is then given to the `compositor::Builder`.
+    pub use manager::output_manager::*;
+}

--- a/src/types/output/output.rs
+++ b/src/types/output/output.rs
@@ -17,7 +17,9 @@ use {area::{Origin, Size},
      utils::{self, HandleErr, HandleResult, Handleable, c_to_rust_string},
      output::{self, layout},
      render::PixmanRegion};
-pub use manager::{output_manager::*, output_handler::*};
+pub use manager::output_handler::*;
+pub use manager::output_manager::{OutputBuilder as Builder, BuilderResult};
+pub(crate) use manager::output_manager::Manager;
 
 pub type Subpixel = wl_output_subpixel;
 pub type Transform = wl_output_transform;

--- a/src/types/shell/xdg_shell.rs
+++ b/src/types/shell/xdg_shell.rs
@@ -16,8 +16,20 @@ use {area::Area,
      seat,
      surface,
      utils::{self, HandleErr, HandleResult, Handleable, c_to_rust_string}};
-pub use manager::{xdg_shell_manager::*, xdg_shell_handler::*};
+pub use manager::xdg_shell_handler::*;
+pub(crate) use manager::xdg_shell_manager::Manager;
 pub use events::xdg_shell_events as event;
+
+pub mod manager {
+    //! XDG shell resources are managed by the XDG shell resource manager.
+    //!
+    //! To manage XDG shells from clients implement a function with
+    //! [`NewSurface`](./type.NewSurface.html) as the signature.
+    //!
+    //! Pass that function to the [`xdg_shell::Builder`](./struct.Builder.html)
+    //! which is then passed to the `compositor::Builder`.
+    pub use manager::xdg_shell_manager::*;
+}
 
 pub type Handle = utils::Handle<OptionalShellState, wlr_xdg_surface, Surface>;
 

--- a/src/types/shell/xdg_shell_v6.rs
+++ b/src/types/shell/xdg_shell_v6.rs
@@ -15,8 +15,20 @@ use {area::Area,
      seat,
      surface,
      utils::{self, HandleErr, HandleResult, Handleable, c_to_rust_string}};
-pub use manager::{xdg_shell_v6_manager::*, xdg_shell_v6_handler::*};
+pub use manager::xdg_shell_v6_handler::*;
+pub(crate) use manager::xdg_shell_v6_manager::Manager;
 pub use events::xdg_shell_v6_events as event;
+
+pub mod manager {
+    //! XDG shell v6 resources are managed by the XDG shell v6 resource manager.
+    //!
+    //! To manage XDG shells v6 from clients implement a function with
+    //! [`NewSurface`](./type.NewSurface.html) as the signature.
+    //!
+    //! Pass that function to the [`xdg_shell_v6::Builder`](./struct.Builder.html)
+    //! which is then passed to the `compositor::Builder`.
+    pub use manager::xdg_shell_v6_manager::*;
+}
 
 pub type Handle = utils::Handle<OptionalShellState,
                                 wlr_xdg_surface_v6,

--- a/src/xwayland/manager.rs
+++ b/src/xwayland/manager.rs
@@ -1,4 +1,11 @@
-//! Global manager for the XWayland server.
+//! XWayland client resources are managed by the XWayland resource manager
+//! and server.
+//!
+//! To manage XWayland clients (and run an XServer) implement a function
+//! with [`NewSurface`](./type.NewSurface.html) as the signature.
+//!
+//! Pass that function to the [`xwayland::Builder`](./struct.Builder.html)
+//! which is then passed to the `compositor::Builder`.
 
 use libc;
 use wayland_sys::server::signal::wl_signal_add;
@@ -17,7 +24,7 @@ pub type NewSurface = fn(compositor_handle: compositor::Handle,
 
 wayland_listener_static! {
     static mut MANAGER;
-    (Manager, ManagerBuilder): [
+    (Manager, Builder): [
         (OnReady, on_ready_listener, xwayland_ready) => (ready_notify, xwayland_ready):
         |manager: &mut Manager, _data: *mut libc::c_void,|
         unsafe {

--- a/src/xwayland/manager.rs
+++ b/src/xwayland/manager.rs
@@ -6,72 +6,73 @@ use wlroots_sys::wlr_xwayland_surface;
 
 use {compositor, xwayland, utils::Handleable};
 
-pub trait ManagerHandler {
-    /// Callback that's triggered when the XWayland library is ready.
-    fn on_ready(&mut self, compositor::Handle) {}
+/// Callback that's triggered when the XWayland library is ready.
+pub type OnReady = fn(compositor::Handle);
 
-    /// Callback that's triggered when a new surface is presented to the X
-    /// server.
-    fn new_surface(&mut self,
-                   compositor_handle: compositor::Handle,
-                   xwayland_surface: xwayland::surface::Handle)
-                   -> Option<Box<xwayland::surface::Handler>>;
+/// Callback that's triggered when a new surface is presented to the X
+/// server.
+pub type NewSurface = fn(compositor_handle: compositor::Handle,
+                            xwayland_surface: xwayland::surface::Handle)
+                            -> Option<Box<xwayland::surface::Handler>>;
+
+wayland_listener_static! {
+    static mut MANAGER;
+    (Manager, ManagerBuilder): [
+        (OnReady, on_ready_listener, xwayland_ready) => (ready_notify, xwayland_ready):
+        |manager: &mut Manager, _data: *mut libc::c_void,|
+        unsafe {
+            let compositor = match compositor::handle() {
+                Some(handle) => handle,
+                None => return
+            };
+
+            manager.xwayland_ready.map(|f| f(compositor));
+        };
+
+        (NewSurface, new_surface_listener, surface_added) => (add_notify, surface_added):
+        |manager: &mut Manager, data: *mut libc::c_void,|
+        unsafe {
+            let surface_ptr = data as *mut wlr_xwayland_surface;
+            let compositor = match compositor::handle() {
+                Some(handle) => handle,
+                None => return
+            };
+            let shell_surface = xwayland::surface::Surface::new(surface_ptr);
+            let xwayland_handler = manager.surface_added
+                .and_then(|f| f(compositor, shell_surface.weak_reference()));
+            let mut shell = xwayland::surface::Shell::new((shell_surface, xwayland_handler));
+
+            wl_signal_add(&mut (*surface_ptr).events.destroy as *mut _ as _,
+                          shell.destroy_listener() as *mut _ as _);
+            wl_signal_add(&mut (*surface_ptr).events.request_configure as *mut _ as _,
+                          shell.request_configure_listener() as *mut _ as _);
+            wl_signal_add(&mut (*surface_ptr).events.request_move as *mut _ as _,
+                          shell.request_move_listener() as *mut _ as _);
+            wl_signal_add(&mut (*surface_ptr).events.request_resize as *mut _ as _,
+                          shell.request_resize_listener() as *mut _ as _);
+            wl_signal_add(&mut (*surface_ptr).events.request_maximize as *mut _ as _,
+                          shell.request_maximize_listener() as *mut _ as _);
+            wl_signal_add(&mut (*surface_ptr).events.request_fullscreen as *mut _ as _,
+                          shell.request_fullscreen_listener() as *mut _ as _);
+            wl_signal_add(&mut (*surface_ptr).events.map as *mut _ as _,
+                          shell.map_listener() as *mut _ as _);
+            wl_signal_add(&mut (*surface_ptr).events.unmap as *mut _ as _,
+                          shell.unmap_listener() as *mut _ as _);
+            wl_signal_add(&mut (*surface_ptr).events.set_title as *mut _ as _,
+                          shell.set_title_listener() as *mut _ as _);
+            wl_signal_add(&mut (*surface_ptr).events.set_class as *mut _ as _,
+                          shell.set_class_listener() as *mut _ as _);
+            wl_signal_add(&mut (*surface_ptr).events.set_parent as *mut _ as _,
+                          shell.set_parent_listener() as *mut _ as _);
+            wl_signal_add(&mut (*surface_ptr).events.set_pid as *mut _ as _,
+                          shell.set_pid_listener() as *mut _ as _);
+            wl_signal_add(&mut (*surface_ptr).events.set_window_type as *mut _ as _,
+                          shell.set_window_type_listener() as *mut _ as _);
+            wl_signal_add(&mut (*surface_ptr).events.ping_timeout as *mut _ as _,
+                          shell.ping_timeout_listener() as *mut _ as _);
+            let shell_data = (*surface_ptr).data as *mut xwayland::surface::State;
+            (*shell_data).shell = Box::into_raw(shell);
+            // TODO Pass in the new surface from the data
+        };
+    ]
 }
-
-wayland_listener!(pub(crate) Manager, Box<ManagerHandler>, [
-    on_ready_listener => on_ready_notify: |this: &mut Manager, _data: *mut libc::c_void,|
-    unsafe {
-        let ref mut manager = this.data;
-        let compositor = match compositor::handle() {
-            Some(handle) => handle,
-            None => return
-        };
-
-        manager.on_ready(compositor);
-    };
-    new_surface_listener => new_surface_notify: |this: &mut Manager,
-                                                 data: *mut libc::c_void,|
-    unsafe {
-        let ref mut manager = this.data;
-        let surface_ptr = data as *mut wlr_xwayland_surface;
-        let compositor = match compositor::handle() {
-            Some(handle) => handle,
-            None => return
-        };
-        let shell_surface = xwayland::surface::Surface::new(surface_ptr);
-        let xwayland_handler = manager.new_surface(compositor, shell_surface.weak_reference());
-        let mut shell = xwayland::surface::Shell::new((shell_surface, xwayland_handler));
-
-        wl_signal_add(&mut (*surface_ptr).events.destroy as *mut _ as _,
-                        shell.destroy_listener() as *mut _ as _);
-        wl_signal_add(&mut (*surface_ptr).events.request_configure as *mut _ as _,
-                        shell.request_configure_listener() as *mut _ as _);
-        wl_signal_add(&mut (*surface_ptr).events.request_move as *mut _ as _,
-                        shell.request_move_listener() as *mut _ as _);
-        wl_signal_add(&mut (*surface_ptr).events.request_resize as *mut _ as _,
-                        shell.request_resize_listener() as *mut _ as _);
-        wl_signal_add(&mut (*surface_ptr).events.request_maximize as *mut _ as _,
-                        shell.request_maximize_listener() as *mut _ as _);
-        wl_signal_add(&mut (*surface_ptr).events.request_fullscreen as *mut _ as _,
-                        shell.request_fullscreen_listener() as *mut _ as _);
-        wl_signal_add(&mut (*surface_ptr).events.map as *mut _ as _,
-                        shell.map_listener() as *mut _ as _);
-        wl_signal_add(&mut (*surface_ptr).events.unmap as *mut _ as _,
-                        shell.unmap_listener() as *mut _ as _);
-        wl_signal_add(&mut (*surface_ptr).events.set_title as *mut _ as _,
-                        shell.set_title_listener() as *mut _ as _);
-        wl_signal_add(&mut (*surface_ptr).events.set_class as *mut _ as _,
-                        shell.set_class_listener() as *mut _ as _);
-        wl_signal_add(&mut (*surface_ptr).events.set_parent as *mut _ as _,
-                        shell.set_parent_listener() as *mut _ as _);
-        wl_signal_add(&mut (*surface_ptr).events.set_pid as *mut _ as _,
-                        shell.set_pid_listener() as *mut _ as _);
-        wl_signal_add(&mut (*surface_ptr).events.set_window_type as *mut _ as _,
-                        shell.set_window_type_listener() as *mut _ as _);
-        wl_signal_add(&mut (*surface_ptr).events.ping_timeout as *mut _ as _,
-                        shell.ping_timeout_listener() as *mut _ as _);
-        let shell_data = (*surface_ptr).data as *mut xwayland::surface::State;
-        (*shell_data).shell = Box::into_raw(shell);
-        // TODO Pass in the new surface from the data
-    };
-]);

--- a/src/xwayland/mod.rs
+++ b/src/xwayland/mod.rs
@@ -1,8 +1,7 @@
 pub(crate) mod hints;
-mod manager;
+pub mod manager;
 mod server;
 pub mod surface;
 
 pub use events::xwayland_events as event;
-pub use self::manager::*;
 pub use self::server::*;

--- a/src/xwayland/server.rs
+++ b/src/xwayland/server.rs
@@ -8,24 +8,24 @@ use xwayland;
 #[allow(dead_code)]
 pub struct Server {
     xwayland: *mut wlr_xwayland,
-    manager: Box<xwayland::Manager>
+    manager: &'static mut xwayland::Manager
 }
 
 impl Server {
     pub(crate) unsafe fn new(display: *mut wl_display,
                              compositor: *mut wlr_compositor,
-                             manager: Box<xwayland::ManagerHandler>,
+                             builder: xwayland::ManagerBuilder,
                              lazy: bool)
                              -> Self {
         let xwayland = wlr_xwayland_create(display, compositor, lazy);
         if xwayland.is_null() {
             panic!("Could not start XWayland server")
         }
-        let mut manager = xwayland::Manager::new(manager);
+        let manager = xwayland::Manager::build(builder);
         wl_signal_add(&mut (*xwayland).events.ready as *mut _ as _,
-                      manager.on_ready_listener() as *mut _ as _);
+                      (&mut manager.on_ready_listener) as *mut _ as _);
         wl_signal_add(&mut (*xwayland).events.new_surface as *mut _ as _,
-                      manager.new_surface_listener() as *mut _ as _);
+                      (&mut manager.new_surface_listener) as *mut _ as _);
         Server { xwayland, manager }
     }
 

--- a/src/xwayland/server.rs
+++ b/src/xwayland/server.rs
@@ -8,20 +8,20 @@ use xwayland;
 #[allow(dead_code)]
 pub struct Server {
     xwayland: *mut wlr_xwayland,
-    manager: &'static mut xwayland::Manager
+    manager: &'static mut xwayland::manager::Manager
 }
 
 impl Server {
     pub(crate) unsafe fn new(display: *mut wl_display,
                              compositor: *mut wlr_compositor,
-                             builder: xwayland::ManagerBuilder,
+                             builder: xwayland::manager::Builder,
                              lazy: bool)
                              -> Self {
         let xwayland = wlr_xwayland_create(display, compositor, lazy);
         if xwayland.is_null() {
             panic!("Could not start XWayland server")
         }
-        let manager = xwayland::Manager::build(builder);
+        let manager = xwayland::manager::Manager::build(builder);
         wl_signal_add(&mut (*xwayland).events.ready as *mut _ as _,
                       (&mut manager.on_ready_listener) as *mut _ as _);
         wl_signal_add(&mut (*xwayland).events.new_surface as *mut _ as _,


### PR DESCRIPTION
All the managers are now static functions that are built using builders that refer to static functions.

It never made sense to pay for the overhead of a trait object since:

1) There's only one manager per resource, so the vtable always is the same.
2) There's no way to swap them out, so the ability to refer to a different vtable is pointless.
3) In practice there was no manager specific state that the compositors writers had to keep that didn't end up having to be in the global compositor state (to share with the other resource managers).

This re-organizes a lot of things, including changing how the managers work so this is a **breaking change**.

Fixes #239 