### PR TITLE
Added log wrapper for wlr_log

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ wlroots-dehandle = { path = "wlroots-dehandle", version = "1.0" }
 xkbcommon = "0.3"
 bitflags = "1.0"
 vsprintf = "1.0.1"
+log = "0.4"
 
 [features]
 default = ["libcap", "systemd", "elogind", "xwayland", "x11_backend"]

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -4,6 +4,6 @@ extern crate wlroots;
 use log::LevelFilter;
 
 fn main() {
-    wlroots::utils::log::Logger::init(LevelFilter::Debug);
+    wlroots::utils::log::Logger::init(LevelFilter::Debug, None);
     wlroots::compositor::Builder::new().build_auto(()).run()
 }

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -1,6 +1,9 @@
+extern crate log;
 extern crate wlroots;
 
+use log::LevelFilter;
+
 fn main() {
-    wlroots::utils::log::init_logging(wlroots::utils::log::WLR_DEBUG, None);
+    wlroots::utils::log::Logger::init(LevelFilter::Debug);
     wlroots::compositor::Builder::new().build_auto(()).run()
 }

--- a/examples/pointer.rs
+++ b/examples/pointer.rs
@@ -189,7 +189,7 @@ fn load_xcursor() -> (xcursor::Manager, cursor::Handle) {
 }
 
 fn main() {
-    Logger::init(LevelFilter::Debug);    
+    Logger::init(LevelFilter::Debug, None);
     let (xcursor_manager, cursor_handle) = load_xcursor();
     let layout_handle = output::layout::Layout::create(Box::new(ExOutputLayout));
 

--- a/examples/pointer.rs
+++ b/examples/pointer.rs
@@ -1,10 +1,12 @@
 #[macro_use]
 extern crate wlroots;
+extern crate log;
 
+use log::LevelFilter;
 use wlroots::{compositor,
               cursor::{self, Cursor, xcursor},
               input::{self, pointer, keyboard},
-              utils::log::{init_logging, WLR_DEBUG},
+              utils::log::Logger,
               output};
 use wlroots::wlroots_sys::wlr_button_state::WLR_BUTTON_RELEASED;
 use wlroots::xkbcommon::xkb::keysyms;
@@ -187,7 +189,7 @@ fn load_xcursor() -> (xcursor::Manager, cursor::Handle) {
 }
 
 fn main() {
-    init_logging(WLR_DEBUG, None);
+    Logger::init(LevelFilter::Debug);    
     let (xcursor_manager, cursor_handle) = load_xcursor();
     let layout_handle = output::layout::Layout::create(Box::new(ExOutputLayout));
 

--- a/examples/rotation.rs
+++ b/examples/rotation.rs
@@ -1,13 +1,16 @@
+extern crate log;
 #[macro_use]
 extern crate wlroots;
 
 use std::{env, time::Instant};
 
+use log::LevelFilter;
+
 use wlroots::{compositor,
               input::{self, keyboard},
               output,
               render::{Texture, TextureFormat},
-              utils::log::{init_logging, WLR_DEBUG}};
+              utils::log::Logger};
 use wlroots::wlroots_sys::wl_output_transform;
 use wlroots::xkbcommon::xkb::keysyms;
 
@@ -152,7 +155,7 @@ fn rotation_transform_from_str(rotation_str: &str) -> wl_output_transform {
 }
 
 fn main() {
-    init_logging(WLR_DEBUG, None);
+    Logger::init(LevelFilter::Debug);    
     let mut args = env::args();
     let rotation_argument_string = args.nth(1).unwrap_or_else(|| "".to_string());
     let rotation_transform = rotation_transform_from_str(&rotation_argument_string);

--- a/examples/rotation.rs
+++ b/examples/rotation.rs
@@ -155,7 +155,7 @@ fn rotation_transform_from_str(rotation_str: &str) -> wl_output_transform {
 }
 
 fn main() {
-    Logger::init(LevelFilter::Debug);    
+    Logger::init(LevelFilter::Debug, None);
     let mut args = env::args();
     let rotation_argument_string = args.nth(1).unwrap_or_else(|| "".to_string());
     let rotation_transform = rotation_transform_from_str(&rotation_argument_string);

--- a/examples/tablet.rs
+++ b/examples/tablet.rs
@@ -1,7 +1,10 @@
+extern crate log;
 #[macro_use]
 extern crate wlroots;
 
 use std::f64::consts::PI;
+
+use log::LevelFilter;
 
 use wlroots::{area::{Area, Size, Origin}, compositor,
               input::{self, keyboard, tablet_tool, tablet_pad},
@@ -9,7 +12,7 @@ use wlroots::{area::{Area, Size, Origin}, compositor,
               wlroots_sys::wl_output_transform::WL_OUTPUT_TRANSFORM_NORMAL,
               wlr_tablet_tool_proximity_state::*,
               wlr_button_state::*,
-              utils::log,
+              utils::log::Logger,
               xkbcommon::xkb::KEY_Escape};
 
 #[derive(Debug, Default)]
@@ -237,7 +240,7 @@ impl output::Handler for OutputEx {
 }
 
 fn main() {
-    log::init_logging(log::WLR_DEBUG, None);
+    Logger::init(LevelFilter::Debug);
     let output_builder = output::manager::Builder::default().output_added(output_added);
     let input_builder = input::manager::Builder::default()
         .keyboard_added(keyboard_added)

--- a/examples/tablet.rs
+++ b/examples/tablet.rs
@@ -240,7 +240,7 @@ impl output::Handler for OutputEx {
 }
 
 fn main() {
-    Logger::init(LevelFilter::Debug);
+    Logger::init(LevelFilter::Debug, None);
     let output_builder = output::manager::Builder::default().output_added(output_added);
     let input_builder = input::manager::Builder::default()
         .keyboard_added(keyboard_added)

--- a/examples/touch.rs
+++ b/examples/touch.rs
@@ -144,7 +144,7 @@ fn keyboard_added(_: compositor::Handle,
 }
 
 fn main() {
-    Logger::init(LevelFilter::Debug);
+    Logger::init(LevelFilter::Debug, None);
     let output_builder = output::manager::Builder::default().output_added(output_added);
     let input_builder = input::manager::Builder::default()
         .keyboard_added(keyboard_added)

--- a/examples/touch.rs
+++ b/examples/touch.rs
@@ -1,11 +1,13 @@
+extern crate log;
 #[macro_use]
 extern crate wlroots;
 
+use log::LevelFilter;
 use wlroots::{compositor,
               input::{self, keyboard, touch},
               output,
               render::{Texture, TextureFormat}};
-use wlroots::utils::log::{init_logging, WLR_DEBUG};
+use wlroots::utils::log::Logger;
 use wlroots::xkbcommon::xkb::keysyms::KEY_Escape;
 
 const CAT_WIDTH: u32 = 128;
@@ -142,7 +144,7 @@ fn keyboard_added(_: compositor::Handle,
 }
 
 fn main() {
-    init_logging(WLR_DEBUG, None);
+    Logger::init(LevelFilter::Debug);
     let output_builder = output::manager::Builder::default().output_added(output_added);
     let input_builder = input::manager::Builder::default()
         .keyboard_added(keyboard_added)

--- a/examples/xdg_shell_v6_test.rs
+++ b/examples/xdg_shell_v6_test.rs
@@ -1,8 +1,10 @@
+extern crate log;
 #[macro_use]
 extern crate wlroots;
 
 use std::{thread, process::Command};
 
+use log::LevelFilter;
 use wlroots::{area::{Area, Origin, Size},
               compositor,
               cursor::{self, Cursor, xcursor},
@@ -12,7 +14,7 @@ use wlroots::{area::{Area, Origin, Size},
               seat::{self, Seat},
               shell::xdg_shell_v6,
               surface,
-              utils::{Handleable, log::{init_logging, WLR_DEBUG}, current_time}};
+              utils::{Handleable, log::Logger, current_time}};
 use wlroots::wlroots_sys::wlr_key_state::WLR_KEY_PRESSED;
 use wlroots::xkbcommon::xkb::keysyms::{KEY_Escape, KEY_F1};
 use wlroots::wlroots_dehandle;
@@ -248,7 +250,7 @@ fn keyboard_added(compositor: compositor::Handle,
 }
 
 fn main() {
-    init_logging(WLR_DEBUG, None);
+    Logger::init(LevelFilter::Debug);
     let cursor = Cursor::create(Box::new(CursorEx));
     let mut xcursor_manager =
         xcursor::Manager::create("default".to_string(), 24).expect("Could not create xcursor \

--- a/examples/xdg_shell_v6_test.rs
+++ b/examples/xdg_shell_v6_test.rs
@@ -250,7 +250,7 @@ fn keyboard_added(compositor: compositor::Handle,
 }
 
 fn main() {
-    Logger::init(LevelFilter::Debug);
+    Logger::init(LevelFilter::Debug, None);
     let cursor = Cursor::create(Box::new(CursorEx));
     let mut xcursor_manager =
         xcursor::Manager::create("default".to_string(), 24).expect("Could not create xcursor \

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 #![allow(unused_unsafe)]
 #[macro_use]
 extern crate bitflags;
+extern crate log;
 extern crate vsprintf;
 #[macro_use]
 pub extern crate wlroots_sys;

--- a/src/utils/log.rs
+++ b/src/utils/log.rs
@@ -6,10 +6,13 @@
 //! To log using this system please utilize the [`wlr_log!`](../../macro.wlr_log.html) macro.
 
 use libc::c_char;
-use wlroots_sys::{wlr_log_importance, __va_list_tag, wlr_log_init};
+use log::{info, max_level, set_boxed_logger, set_max_level, Level, LevelFilter, Metadata, Record};
 use vsprintf::vsprintf;
+use wlroots_sys::{wlr_log_importance, __va_list_tag, wlr_log_init, _wlr_log};
 
 use utils::c_to_rust_string;
+
+use std::ffi::CString;
 
 // Export these so it can be used in `wlr_log!`.
 pub use self::wlr_log_importance::{WLR_SILENT, WLR_ERROR, WLR_INFO,
@@ -57,4 +60,57 @@ unsafe extern "C" fn log_callback(importance: wlr_log_importance,
         c_to_rust_string(fmt).unwrap_or_else(|| "".into())
     });
     RUST_LOGGING_FN(importance, message);
+}
+
+pub struct Logger;
+
+impl Logger {
+    pub fn init(level: LevelFilter) {
+        init_logging(
+            match level {
+                LevelFilter::Off => WLR_SILENT,
+                LevelFilter::Warn | LevelFilter::Error => WLR_ERROR,
+                LevelFilter::Info => WLR_INFO,
+                LevelFilter::Debug | LevelFilter::Trace => WLR_DEBUG,
+            },
+            None,
+        );
+
+        let _ = set_boxed_logger(Box::new(Logger)).map(|_| set_max_level(level));
+
+        info!("Logger initialized!");
+    }
+}
+
+impl log::Log for Logger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        metadata.level() <= max_level()
+    }
+
+    fn log(&self, record: &Record) {
+        if self.enabled(record.metadata()) {
+            let wlr_level = match record.level() {
+                Level::Warn | Level::Error => WLR_ERROR,
+                Level::Info => WLR_INFO,
+                Level::Debug | Level::Trace => WLR_DEBUG,
+            };
+
+            let msg = CString::new(if let Some(file) = record.file() {
+                if let Some(line) = record.line() {
+                    format!("[{}:{}] {}", file, line, record.args())
+                } else {
+                    format!("[{}] {}", file, record.args())
+                }
+            } else {
+                format!("{}", record.args())
+            })
+            .expect("Could not convert log message to CString");
+
+            unsafe {
+                _wlr_log(wlr_level, msg.as_ptr());
+            }
+        }
+    }
+
+    fn flush(&self) {}
 }


### PR DESCRIPTION
Added a small Logger around `_wlr_log`. At the moment you'd have to use an external logger like env_logger, and maintain both verbosity levels, so that wlroots logs at the correct verbosity.

This allows it for the user to do what's currently possible with the `wlr_log!` macro, while allowing the user to use the standarized interface provided by the `log` crate.

Please check the mappings from the more detailed `FilterLevel`s `log` provides to the `enum wlr_log_importance`s.