### PR TITLE
wlroots_dehandle 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ autoexamples = true
 
 [dependencies]
 wlroots-sys = { path = "wlroots-sys", default-features = false, version = "0.2.1" }
-wlroots-dehandle = { path = "wlroots-dehandle", version = "1.0" }
+wlroots-dehandle = { path = "wlroots-dehandle", version = "2.0" }
 xkbcommon = "0.3"
 bitflags = "1.0"
 vsprintf = "1.0.1"

--- a/examples/xdg_shell_v6_test.rs
+++ b/examples/xdg_shell_v6_test.rs
@@ -183,9 +183,6 @@ impl pointer::Handler for ExPointer {
                  _: &pointer::event::Button) {
         #[dehandle] let compositor = compositor;
         let state: &mut State = compositor.downcast();
-        let seat = state.seat_handle.clone().unwrap();
-        let keyboard = state.keyboard.clone().unwrap();
-        let shell_handle = &state.shells[0];
         #[dehandle] let shell = &state.shells[0];
         match shell.state() {
             Some(&mut xdg_shell_v6::ShellState::TopLevel(ref mut toplevel)) => {

--- a/wlroots-dehandle/Cargo.toml
+++ b/wlroots-dehandle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wlroots-dehandle"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Timidger <APragmaticPlace@gmail.com>"]
 description = "Procedural macro to upgrade wlroots handles without callback hell"
 license = "MIT"

--- a/wlroots-dehandle/src/lib.rs
+++ b/wlroots-dehandle/src/lib.rs
@@ -73,19 +73,18 @@ impl Args {
 ///
 /// ```rust,ignore
 /// impl InputManagerHandler for InputManager {
-///     #[wlroots_dehandle(compositor, keyboard, seat)]
+///     #[wlroots_dehandle]
 ///     fn keyboard_added(&mut self,
 ///                       compositor_handle: CompositorHandle,
 ///                       keyboard: KeyboardHandle)
 ///                       -> Option<Box<Keyboard Handler>> {
 ///         {
-///             use compositor_handle as compositor;
-///             use keyboard as keyboard;
+///             #[dehandle] let compositor = compositor_handle;
+///             #[dehandle] let keyboard = keyboard;
 ///             let server: &mut ::Server = compositor.into();
 ///             server.keyboards.push(keyboard.weak_reference());
 ///             // Now that we have at least one keyboard, update the seat capabilities.
-///             let server_seat = &server.seat.seat;
-///             use server_seat as seat;
+///             #[dehandle] let seat = &server.seat.seat;
 ///             let mut capabilities = seat.capabilities();
 ///             capabilities.insert(Capability::Keyboard);
 ///             seat.set_capabilities(capabilities);

--- a/wlroots-dehandle/src/lib.rs
+++ b/wlroots-dehandle/src/lib.rs
@@ -104,8 +104,9 @@ fn build_block(mut input: std::slice::Iter<Stmt>, args: &mut Args) -> Block {
                         _ => {}
                     }
                 };
-                // Check if this is prefaced with #[dehandle]
-                match (dehandle, local.pats.first().map(Pair::into_value).cloned(), local.init.clone()) {
+                let left_side = local.pats.first().map(Pair::into_value).cloned();
+                let right_side = local.init.clone();
+                match (dehandle, left_side, right_side) {
                     (true,
                      Some(Pat::Ident(dehandle_name)),
                      Some((_, body))) => {
@@ -120,7 +121,7 @@ fn build_block(mut input: std::slice::Iter<Stmt>, args: &mut Args) -> Block {
                         local.init.as_mut().unwrap().1 = Box::new(body);
                         output.push(Stmt::Local(local))
                     },
-                    _ => {}
+                    _ => output.push(Stmt::Local(local))
                 }
             },
             Stmt::Expr(expr) => {

--- a/wlroots-dehandle/src/lib.rs
+++ b/wlroots-dehandle/src/lib.rs
@@ -28,20 +28,18 @@ impl Fold for Args {
 /// Attribute to automatically call the `run` method on handles with the
 /// remaining block of code.
 ///
-/// The name of the variable you want to use as the upgraded handle should be
-/// provided as an argument to the attribute. It does not need to be the same
-/// as the handle variable.
+/// The syntax in the code to denote a handle being accessed is
+/// `#[dehandle] let $upgraded_handle = $handle`.
 ///
-/// The syntax in the code should be `use $handle as $upgraded_handle`.
-/// E.g the variable in the code that stores the handle should go on the
-/// **left** and the variable you used in the attribute declaration should
-/// go on the **right**.
 ///
 /// # Panics
-/// If the handle is invalid (e.g. default constructed, or is a dangling
-/// handle) then your code will `panic!`.
+/// If the handle is invalid (e.g. default constructed, borrowed multiple times,
+/// or it is a dangling handle) then your code will `panic!`.
 ///
-/// If this is undesirable, please use the non-proc macro `with_handles!`.
+/// If this is undesirable, please append `?` to the end like so:
+/// `#[dehandle] let $upgraded_handle = $handle?`. This will make it behave
+/// as you expect (i.e. the `Err` is returned early and the return type of the
+/// function should be `HandleResult<T>`)
 ///
 /// # Example
 ///


### PR DESCRIPTION
The use syntax is a little gross, so I've decided to make it a bit clearer what the heck is going on by using a nested attribute to denote handle upgrades. Note that v1.0 is still valid, this is just easier to use (and also I threw `Span` in all the right places, so the errors will be much, much better now).

It also allows you to use `?` error handling, so it's strictly better than `with_handles` (though that will stick around).

The syntax before:

```rust
impl InputManagerHandler for InputManager {
    #[wlroots_dehandle(compositor, keyboard, seat)]
    fn keyboard_added(&mut self,
                      compositor_handle: CompositorHandle,
                      keyboard: KeyboardHandle)
                      -> Option<Box<Keyboard Handler>> {
        {
            use compositor_handle as compositor;
            use keyboard as keyboard;
            let server: &mut ::Server = compositor.into();
            server.keyboards.push(keyboard.weak_reference());
            // Now that we have at least one keyboard, update the seat capabilities.
            let server_seat = &server.seat.seat;
            use server_seat as seat;
            let mut capabilities = seat.capabilities();
            capabilities.insert(Capability::Keyboard);
            seat.set_capabilities(capabilities);
            seat.set_keyboard(keyboard.input_device());
        }
        // Due to some weird closure inference rules, this has to be outside
        // of the above block.
        Some(Box::new(::Keyboard))
    }
}
```

The syntax now:

```rust
impl InputManagerHandler for InputManager {
    #[wlroots_dehandle]
    fn keyboard_added(&mut self,
                      compositor_handle: CompositorHandle,
                      keyboard: KeyboardHandle)
                      -> Option<Box<Keyboard Handler>> {
        {
            #[dehandle] let compositor = compositor_handle;
            #[dehandle] let keyboard = keyboard;
            let server: &mut ::Server = compositor.into();
            server.keyboards.push(keyboard.weak_reference());
            // Now that we have at least one keyboard, update the seat capabilities.
            #[dehandle] let seat = &server.seat.seat;
            let mut capabilities = seat.capabilities();
            capabilities.insert(Capability::Keyboard);
            seat.set_capabilities(capabilities);
            seat.set_keyboard(keyboard.input_device());
        }
        // Due to some weird closure inference rules, this has to be outside
        // of the above block.
        Some(Box::new(::Keyboard))
    }
}
```

# TODO
- [x] Update docs to include `#[dehandle] .. ?`
- [ ] ~Move all the examples over to this proc macro.~ Better I document the other ways in the less complicated examples.
- [x] Test way-cooler and how-to-make-a-wayland-compositor with new syntax
