### PR TITLE
Removed bogus destroyed subsurface listener

### DIFF
--- a/src/types/surface/subsurface.rs
+++ b/src/types/surface/subsurface.rs
@@ -59,10 +59,6 @@ impl Subsurface {
                      liveliness }
     }
 
-    pub(crate) unsafe fn as_ptr(&self) -> *mut wlr_subsurface {
-        self.subsurface
-    }
-
     /// Get a handle to the surface for this sub surface.
     pub fn surface(&self) -> surface::Handle {
         unsafe { surface::Handle::from_ptr((*self.subsurface).surface) }

--- a/src/types/surface/subsurface_manager.rs
+++ b/src/types/surface/subsurface_manager.rs
@@ -9,7 +9,6 @@
 use std::fmt;
 
 use libc;
-use wayland_sys::server::signal::wl_signal_add;
 use wlroots_sys::wlr_subsurface;
 
 use {surface::subsurface::{self, Subsurface}, utils::Handleable};
@@ -18,20 +17,9 @@ wayland_listener!(pub SubsurfaceManager, Vec<Subsurface>, [
     subsurface_created_listener => subsurface_created_notify:
                                    |this: &mut SubsurfaceManager, data: *mut libc::c_void,|
     unsafe {
-        wl_signal_add(&mut (*(data as *mut wlr_subsurface)).events.destroy as *mut _ as _,
-                      this.subsurface_destroyed_listener() as _);
         let subsurfaces = &mut this.data;
         let subsurface = Subsurface::new(data as *mut wlr_subsurface);
         subsurfaces.push(subsurface)
-    };
-    subsurface_destroyed_listener => subsurface_destroyed_listner:
-                                     |this: &mut SubsurfaceManager, data: *mut libc::c_void,|
-    unsafe {
-        let subsurfaces = &mut this.data;
-        let subsurface = data as *mut wlr_subsurface;
-        if let Some(index) = subsurfaces.iter().position(|cur| cur.as_ptr() == subsurface) {
-            subsurfaces.remove(index);
-        }
     };
 ]);
 

--- a/src/types/surface/surface.rs
+++ b/src/types/surface/surface.rs
@@ -160,10 +160,6 @@ impl Surface {
                                   subsurfaces.push(Subsurface::new(subsurface))
                               });
             let mut manager = SubsurfaceManager::new(subsurfaces);
-            for sub_surface in &mut manager.subsurfaces() {
-                wl_signal_add(&mut (*sub_surface.as_ptr()).events.destroy as *mut _ as _,
-                              manager.subsurface_destroyed_listener() as _);
-            }
             wl_signal_add(&mut (*surface).events.new_subsurface as *mut _ as _,
                           manager.subsurface_created_listener() as _);
             manager


### PR DESCRIPTION
This was being overridden for each subsurface and would cause a segfault when the surface was inevitably cleaned up.

This only happens for complex clients, so I didn't find it out until alacritty was being tested for the book.