### PR TITLE
Compositor writer manually sets WAYLAND_DISPLAY

### DIFF
--- a/examples/xdg_shell_v6_test.rs
+++ b/examples/xdg_shell_v6_test.rs
@@ -2,7 +2,7 @@ extern crate log;
 #[macro_use]
 extern crate wlroots;
 
-use std::{thread, process::Command};
+use std::{env, thread, process::Command};
 
 use log::LevelFilter;
 use wlroots::{area::{Area, Origin, Size},
@@ -271,6 +271,7 @@ fn main() {
         let state: &mut State = compositor.downcast();
         state.seat_handle = Some(seat_handle);
     }
+    env::set_var("WAYLAND_DISPLAY", compositor.socket_name());
     compositor.run();
 }
 

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -616,7 +616,7 @@ impl Compositor {
     /// Before starting the compositor the `WAYLAND_DISPLAY` environment
     /// variable should be set to this so clients can connect to the compositor:
     ///
-    /// ```rust
+    /// ```rust,no_run,ignore
     /// env::set_var("WAYLAND_DISPLAY", compositor.socket_name());
     /// ```
     pub fn socket_name(&self) -> &str {

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -545,9 +545,6 @@ impl Builder {
             panic!("Unable to open wayland socket");
         }
         let socket_name = CStr::from_ptr(socket).to_string_lossy().into_owned();
-        wlr_log!(WLR_DEBUG,
-                 "Running compositor on wayland display {}",
-                 socket_name);
         env::set_var("_WAYLAND_DISPLAY", socket_name.clone());
         let compositor = Compositor { data: Box::new(data),
                                       compositor_handler,
@@ -614,6 +611,18 @@ impl Compositor {
         Handle { handle }
     }
 
+    /// Get the name of the socket to Wayland.
+    ///
+    /// Before starting the compositor the `WAYLAND_DISPLAY` environment
+    /// variable should be set to this so clients can connect to the compositor:
+    ///
+    /// ```rust
+    /// env::set_var("WAYLAND_DISPLAY", compositor.socket_name());
+    /// ```
+    pub fn socket_name(&self) -> &str {
+        self.socket_name.as_str()
+    }
+
     /// Enters the wayland event loop. Won't return until the compositor is
     /// shut off.
     pub fn run(self) {
@@ -630,6 +639,9 @@ impl Compositor {
     pub fn run_with<F>(self, runner: F)
         where F: FnOnce(&Compositor)
     {
+        wlr_log!(WLR_DEBUG,
+                 "Running compositor on wayland display {}",
+                 self.socket_name);
         unsafe {
             self.set_lock(false);
             let compositor = UnsafeCell::new(self);
@@ -649,7 +661,6 @@ impl Compositor {
                 //   if you auto create it's assumed you can't recover.
                 panic!("Failed to start backend");
             }
-            env::set_var("WAYLAND_DISPLAY", (*COMPOSITOR_PTR).socket_name.clone());
             runner(&*COMPOSITOR_PTR);
             match (*compositor.get()).panic_error.take() {
                 None => {}


### PR DESCRIPTION
This is done to increase flexibility for three reasons:
1) If you want to spawn programs at startup you would need to set this
already, and setting it twice seems silly. So lets make it easier and
let that happen.
2) You may want to deny clients from connecting, though this is less a
security measure and more of a "lets lock this down or maybe forward it
to another compositor" use case. It's a small edge caset tbf.
3) It's trivial to do, so you don't lose much by having to do it
yourself.

Later on I might also make starting the backend a manual thing you must
do, but I need to ensure it's safe (the problem is I keep the Compositor
in a global `UnsafeCell` once I start the event loop, and I don't want
it to be possible to call the backedn start more than once so I'll need
to make it an affine type which is more rewriting than I'm willing to do
right now. Also we should probably make it return a result so the
backend failure can be dealt with)