### PR TITLE
link to wlr_gamma instead of orbital gamma

### DIFF
--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -114,7 +114,7 @@ pub struct Compositor {
     /// Optional decoration manager extension.
     pub server_decoration_manager: Option<server_decoration::Manager>,
     /// Optional gamma manager extension.
-    pub gamma_control_manager: Option<gamma_control::Manager>,
+    pub gamma_control_manager: Option<gamma_control::ZManagerV1>,
     /// Optional idle manager extension.
     pub idle_manager: Option<idle::Manager>,
     /// Optional GTK primary selection manager
@@ -440,7 +440,7 @@ impl Builder {
             None
         };
         let gamma_control_manager = if self.gamma_control_manager {
-            gamma_control::Manager::new(display)
+            gamma_control::ZManagerV1::new(display)
         } else {
             None
         };

--- a/src/extensions/gamma_control.rs
+++ b/src/extensions/gamma_control.rs
@@ -1,4 +1,7 @@
 //! Support for the wlroots Gamma Control Protocol
+//!
+//! Warning: This protocol is unstable and can change in the future
+//! Current Protocol: https://github.com/swaywm/wlroots/blob/master/protocol/wlr-gamma-control-unstable-v1.xml
 
 use wayland_sys::server::wl_display as wl_server_display;
 use wlroots_sys::{wl_display, wlr_gamma_control_manager_v1, wlr_gamma_control_manager_v1_create, 
@@ -6,16 +9,16 @@ use wlroots_sys::{wl_display, wlr_gamma_control_manager_v1, wlr_gamma_control_ma
 
 #[derive(Debug)]
 /// Manager that can adjust gamma controls for an output
-pub struct Manager {
+pub struct ZManagerV1 {
     manager: *mut wlr_gamma_control_manager_v1
 }
 
-impl Manager {
+impl ZManagerV1 {
     pub(crate) unsafe fn new(display: *mut wl_server_display) -> Option<Self> {
         let manager_raw = wlr_gamma_control_manager_v1_create(display as *mut wl_display);
 
         if !manager_raw.is_null() {
-            Some(Manager { manager: manager_raw })
+            Some(ZManagerV1 { manager: manager_raw })
         } else {
             None
         }
@@ -23,7 +26,7 @@ impl Manager {
 
 }
 
-impl Drop for Manager {
+impl Drop for ZManagerV1 {
     fn drop(&mut self) {
         unsafe { wlr_gamma_control_manager_v1_destroy(self.manager) }
     }

--- a/src/extensions/gamma_control.rs
+++ b/src/extensions/gamma_control.rs
@@ -1,18 +1,18 @@
 //! Support for the wlroots Gamma Control Protocol
 
 use wayland_sys::server::wl_display as wl_server_display;
-use wlroots_sys::{wl_display, wlr_gamma_control_manager, wlr_gamma_control_manager_create, 
-    wlr_gamma_control_manager_destroy};
+use wlroots_sys::{wl_display, wlr_gamma_control_manager_v1, wlr_gamma_control_manager_v1_create, 
+    wlr_gamma_control_manager_v1_destroy};
 
 #[derive(Debug)]
 /// Manager that can adjust gamma controls for an output
 pub struct Manager {
-    manager: *mut wlr_gamma_control_manager
+    manager: *mut wlr_gamma_control_manager_v1
 }
 
 impl Manager {
     pub(crate) unsafe fn new(display: *mut wl_server_display) -> Option<Self> {
-        let manager_raw = wlr_gamma_control_manager_create(display as *mut wl_display);
+        let manager_raw = wlr_gamma_control_manager_v1_create(display as *mut wl_display);
 
         if !manager_raw.is_null() {
             Some(Manager { manager: manager_raw })
@@ -25,6 +25,6 @@ impl Manager {
 
 impl Drop for Manager {
     fn drop(&mut self) {
-        unsafe { wlr_gamma_control_manager_destroy(self.manager) }
+        unsafe { wlr_gamma_control_manager_v1_destroy(self.manager) }
     }
 }

--- a/wlroots-sys/src/wlroots.h
+++ b/wlroots-sys/src/wlroots.h
@@ -35,7 +35,7 @@
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_data_device.h>
 #include <wlr/types/wlr_gtk_primary_selection.h>
-#include <wlr/types/wlr_gamma_control.h>
+#include <wlr/types/wlr_gamma_control_v1.h>
 #include <wlr/types/wlr_idle.h>
 #include <wlr/types/wlr_input_device.h>
 #include <wlr/types/wlr_keyboard.h>


### PR DESCRIPTION
Fixed the Gamma Control extension to link to the wlroots protocol instead of the orbital protocol

Fixes #268 