### PR TITLE
Fix xdg surface use-after-free by switching to NonNull

### DIFF
--- a/src/backend/headless.rs
+++ b/src/backend/headless.rs
@@ -1,3 +1,5 @@
+use std::ptr::NonNull;
+
 use libc;
 use wlroots_sys::{wlr_backend, wlr_headless_backend_create, wlr_headless_add_output,
                   wlr_headless_add_input_device, wlr_input_device_is_headless,
@@ -54,11 +56,8 @@ impl Headless {
     pub fn add_input_device(&self, input_type: wlr_input_device_type) -> Option<input::Handle> {
         unsafe {
             let device = wlr_headless_add_input_device(self.backend, input_type);
-            if device.is_null() {
-                None
-            } else {
-                Some(input::Device { device }.device())
-            }
+            let device = NonNull::new(device)?;
+            Some(input::Device { device }.device())
         }
     }
 

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -1,7 +1,7 @@
 //! Main entry point to the library.
 //! See examples for documentation on how to use this struct.
 
-use std::{env, panic, ptr, any::Any, cell::{Cell, UnsafeCell},
+use std::{env, panic, ptr::{self, NonNull}, any::Any, cell::{Cell, UnsafeCell},
           ffi::CStr, rc::{Rc, Weak}, sync::atomic::{AtomicBool, Ordering}};
 
 use libc;
@@ -58,7 +58,7 @@ wayland_listener_static!{
             wl_signal_add(&mut (*surface_ptr).events.destroy as *mut _ as _,
                           internal_surface.on_destroy_listener() as _);
             let surface_data = (*surface_ptr).data as *mut surface::InternalState;
-            (*surface_data).surface = Box::into_raw(internal_surface);
+            (*surface_data).surface = NonNull::new(Box::into_raw(internal_surface));
         };
 
         (OnShutdown, shutdown_listener, on_shutdown) => (shutdown_notify, on_shutdown):

--- a/src/manager/output_handler.rs
+++ b/src/manager/output_handler.rs
@@ -99,7 +99,9 @@ wayland_listener!(pub(crate) UserOutput, (Output, Box<Handler>), [
                       wl_list_remove,
                       &mut (*this.need_swap_listener()).link as *mut _ as _);
         let output_data = (*output_ptr).data as *mut OutputState;
-        Box::from_raw((*output_data).output as *mut UserOutput);
+        if let Some(output_ptr) = (*output_data).output {
+            Box::from_raw(output_ptr.as_ptr());
+        }
     };
     frame_listener => frame_notify: |this: &mut UserOutput, _output: *mut libc::c_void,| unsafe {
         let (ref output, ref mut manager) = this.data;

--- a/src/manager/output_manager.rs
+++ b/src/manager/output_manager.rs
@@ -1,6 +1,6 @@
 //! Manager that is called when an output is created or destroyed.
 
-use std::{marker::PhantomData, panic};
+use std::{marker::PhantomData, panic, ptr::NonNull};
 
 use libc;
 use wayland_sys::server::signal::wl_signal_add;
@@ -111,7 +111,7 @@ wayland_listener_static! {
                 wl_signal_add(&mut (*data).events.destroy as *mut _ as _,
                               output.on_destroy_listener() as _);
                 let output_data = (*data).data as *mut OutputState;
-                (*output_data).output = Box::into_raw(output);
+                (*output_data).output = NonNull::new(Box::into_raw(output));
             }
         };
     ]

--- a/src/manager/xdg_shell_handler.rs
+++ b/src/manager/xdg_shell_handler.rs
@@ -108,7 +108,9 @@ wayland_listener!(pub(crate) XdgShell, (xdg_shell::Surface, Option<Box<Handler>>
         }
         let surface_ptr = data as *mut wlr_xdg_surface;
         let shell_state_ptr = (*surface_ptr).data as *mut SurfaceState;
-        Box::from_raw((*shell_state_ptr).shell);
+        if let Some(shell_ptr) = (*shell_state_ptr).shell {
+            Box::from_raw(shell_ptr.as_ptr());
+        }
     };
     commit_listener => commit_notify: |this: &mut XdgShell, _data: *mut libc::c_void,| unsafe {
         let (ref mut shell_surface, ref mut manager) = match &mut this.data {

--- a/src/manager/xdg_shell_manager.rs
+++ b/src/manager/xdg_shell_manager.rs
@@ -1,5 +1,7 @@
 //! Manager for stable XDG shell client.
 
+use std::ptr::NonNull;
+
 use libc;
 use wayland_sys::server::signal::wl_signal_add;
 use wlroots_sys::{wlr_xdg_surface, wlr_xdg_surface_role::*};
@@ -21,26 +23,30 @@ wayland_listener_static! {
         (NewSurface, add_listener, surface_added) => (add_notify, surface_added):
         |manager: &mut Manager, data: *mut libc::c_void,|
         unsafe {
-            let data = data as *mut wlr_xdg_surface;
+            let xdg_surface = NonNull::new(data as *mut wlr_xdg_surface)
+                .expect("Xdg shell surface was null");
+            let xdg_surface_ptr = xdg_surface.as_ptr();
             let compositor = match compositor::handle() {
                 Some(handle) => handle,
                 None => return
             };
-            wlr_log!(WLR_DEBUG, "New xdg_shell_surface request {:p}", data);
+            wlr_log!(WLR_DEBUG, "New xdg_shell_surface request {:p}", xdg_surface_ptr);
             let state = unsafe {
-                match (*data).role {
+                match (*xdg_surface_ptr).role {
                     WLR_XDG_SURFACE_ROLE_NONE => None,
                     WLR_XDG_SURFACE_ROLE_TOPLEVEL => {
-                        let toplevel = (*data).__bindgen_anon_1.toplevel;
-                        Some(ShellState::TopLevel(xdg_shell::TopLevel::from_shell(data, toplevel)))
+                        let toplevel = NonNull::new((*xdg_surface_ptr).__bindgen_anon_1.toplevel)
+                            .expect("XDG Toplevel pointer was null");
+                        Some(ShellState::TopLevel(xdg_shell::TopLevel::from_shell(xdg_surface, toplevel)))
                     }
                     WLR_XDG_SURFACE_ROLE_POPUP => {
-                        let popup = (*data).__bindgen_anon_1.popup;
-                        Some(ShellState::Popup(xdg_shell::Popup::from_shell(data, popup)))
+                        let popup = NonNull::new((*xdg_surface_ptr).__bindgen_anon_1.popup)
+                            .expect("XDG Popup pointer was null");
+                        Some(ShellState::Popup(xdg_shell::Popup::from_shell(xdg_surface, popup)))
                     }
                 }
             };
-            let shell_surface = xdg_shell::Surface::new(data, state);
+            let shell_surface = xdg_shell::Surface::new(xdg_surface, state);
 
             let (shell_surface_manager, surface_handler) =
                 match manager.surface_added {
@@ -49,22 +55,22 @@ wayland_listener_static! {
                 };
 
             let mut shell_surface = XdgShell::new((shell_surface, shell_surface_manager));
-            let surface_state = (*(*data).surface).data as *mut surface::InternalState;
+            let surface_state = (*(*xdg_surface_ptr).surface).data as *mut surface::InternalState;
             if let Some(surface_handler) = surface_handler {
-                (*(*surface_state).surface).data().1 = surface_handler;
+                (*(*surface_state).surface.unwrap().as_ptr()).data().1 = surface_handler;
             }
 
-            wl_signal_add(&mut (*data).events.destroy as *mut _ as _,
+            wl_signal_add(&mut (*xdg_surface_ptr).events.destroy as *mut _ as _,
                           shell_surface.destroy_listener() as _);
-            wl_signal_add(&mut (*(*data).surface).events.commit as *mut _ as _,
+            wl_signal_add(&mut (*(*xdg_surface_ptr).surface).events.commit as *mut _ as _,
                           shell_surface.commit_listener() as _);
-            wl_signal_add(&mut (*data).events.ping_timeout as *mut _ as _,
+            wl_signal_add(&mut (*xdg_surface_ptr).events.ping_timeout as *mut _ as _,
                           shell_surface.ping_timeout_listener() as _);
-            wl_signal_add(&mut (*data).events.new_popup as *mut _ as _,
+            wl_signal_add(&mut (*xdg_surface_ptr).events.new_popup as *mut _ as _,
                           shell_surface.new_popup_listener() as _);
-            wl_signal_add(&mut (*data).events.map as *mut _ as _,
+            wl_signal_add(&mut (*xdg_surface_ptr).events.map as *mut _ as _,
                           shell_surface.map_listener() as _);
-            wl_signal_add(&mut (*data).events.unmap as *mut _ as _,
+            wl_signal_add(&mut (*xdg_surface_ptr).events.unmap as *mut _ as _,
                           shell_surface.unmap_listener() as _);
             let events = with_handles!([(shell_surface: {shell_surface.surface_mut()})] => {
                 match shell_surface.state() {
@@ -86,8 +92,8 @@ wayland_listener_static! {
                 wl_signal_add(&mut events.request_show_window_menu as *mut _ as _,
                               shell_surface.show_window_menu_listener() as _);
             }
-            let shell_data = (*data).data as *mut xdg_shell::SurfaceState;
-            (*shell_data).shell = Box::into_raw(shell_surface);
+            let shell_data = (*xdg_surface_ptr).data as *mut xdg_shell::SurfaceState;
+            (*shell_data).shell = NonNull::new(Box::into_raw(shell_surface));
         };
     ]
 }

--- a/src/manager/xdg_shell_v6_handler.rs
+++ b/src/manager/xdg_shell_v6_handler.rs
@@ -112,7 +112,9 @@ wayland_listener!(pub(crate) XdgShellV6, (xdg_shell_v6::Surface, Option<Box<Hand
         manager.destroyed(compositor, shell_surface.weak_reference());
         let surface_ptr = data as *mut wlr_xdg_surface_v6;
         let shell_state_ptr = (*surface_ptr).data as *mut SurfaceState;
-        Box::from_raw((*shell_state_ptr).shell);
+        if let Some(shell_ptr) = (*shell_state_ptr).shell {
+            Box::from_raw(shell_ptr.as_ptr());
+        }
     };
     commit_listener => commit_notify: |this: &mut XdgShellV6, _data: *mut libc::c_void,| unsafe {
         let (ref mut shell_surface, ref mut manager) = match &mut this.data {

--- a/src/manager/xdg_shell_v6_manager.rs
+++ b/src/manager/xdg_shell_v6_manager.rs
@@ -1,5 +1,7 @@
 //! Manager for XDG shell v6 client.
 
+use std::ptr::NonNull;
+
 use libc;
 use wayland_sys::server::signal::wl_signal_add;
 use wlroots_sys::{wlr_xdg_surface_v6, wlr_xdg_surface_v6_role::*};
@@ -20,26 +22,30 @@ wayland_listener_static! {
     (Manager, Builder): [
         (NewSurface, add_listener, surface_added) => (add_notify, surface_added):
         |manager: &mut Manager, data: *mut libc::c_void,| unsafe {
-            let data = data as *mut wlr_xdg_surface_v6;
+            let xdg_v6_surface = NonNull::new(data as *mut wlr_xdg_surface_v6)
+                .expect("XDGv6 Surface was null");
+            let xdg_v6_surface_ptr = xdg_v6_surface.as_ptr();
             let compositor = match compositor::handle() {
                 Some(handle) => handle,
                 None => return
             };
-            wlr_log!(WLR_DEBUG, "New xdg_shell_v6_surface request {:p}", data);
+            wlr_log!(WLR_DEBUG, "New xdg_shell_v6_surface request {:p}", xdg_v6_surface_ptr);
             let state = unsafe {
-                match (*data).role {
+                match (*xdg_v6_surface_ptr).role {
                     WLR_XDG_SURFACE_V6_ROLE_NONE => None,
                     WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL => {
-                        let toplevel = (*data).__bindgen_anon_1.toplevel;
-                        Some(ShellState::TopLevel(xdg_shell_v6::TopLevel::from_shell(data, toplevel)))
+                        let toplevel = NonNull::new((*xdg_v6_surface_ptr).__bindgen_anon_1.toplevel)
+                            .expect("XDGv6 Toplevel was null");
+                        Some(ShellState::TopLevel(xdg_shell_v6::TopLevel::from_shell(xdg_v6_surface, toplevel)))
                     }
                     WLR_XDG_SURFACE_V6_ROLE_POPUP => {
-                        let popup = (*data).__bindgen_anon_1.popup;
-                        Some(ShellState::Popup(xdg_shell_v6::Popup::from_shell(data, popup)))
+                        let popup = NonNull::new((*xdg_v6_surface_ptr).__bindgen_anon_1.popup)
+                            .expect("XDGv6 Popup was null");
+                        Some(ShellState::Popup(xdg_shell_v6::Popup::from_shell(xdg_v6_surface, popup)))
                     }
                 }
             };
-            let shell_surface = xdg_shell_v6::Surface::new(data, state);
+            let shell_surface = xdg_shell_v6::Surface::new(xdg_v6_surface, state);
 
             let (shell_surface_handler, surface_handler) =
                 match manager.surface_added {
@@ -48,22 +54,22 @@ wayland_listener_static! {
                 };
 
             let mut shell_surface = XdgShellV6::new((shell_surface, shell_surface_handler));
-            let surface_state = (*(*data).surface).data as *mut surface::InternalState;
+            let surface_state = (*(*xdg_v6_surface_ptr).surface).data as *mut surface::InternalState;
             if let Some(surface_handler) = surface_handler {
-                (*(*surface_state).surface).data().1 = surface_handler;
+                (*(*surface_state).surface.unwrap().as_ptr()).data().1 = surface_handler;
             }
 
-            wl_signal_add(&mut (*data).events.destroy as *mut _ as _,
+            wl_signal_add(&mut (*xdg_v6_surface_ptr).events.destroy as *mut _ as _,
                           shell_surface.destroy_listener() as _);
-            wl_signal_add(&mut (*(*data).surface).events.commit as *mut _ as _,
+            wl_signal_add(&mut (*(*xdg_v6_surface_ptr).surface).events.commit as *mut _ as _,
                           shell_surface.commit_listener() as _);
-            wl_signal_add(&mut (*data).events.ping_timeout as *mut _ as _,
+            wl_signal_add(&mut (*xdg_v6_surface_ptr).events.ping_timeout as *mut _ as _,
                           shell_surface.ping_timeout_listener() as _);
-            wl_signal_add(&mut (*data).events.new_popup as *mut _ as _,
+            wl_signal_add(&mut (*xdg_v6_surface_ptr).events.new_popup as *mut _ as _,
                           shell_surface.new_popup_listener() as _);
-            wl_signal_add(&mut (*data).events.map as *mut _ as _,
+            wl_signal_add(&mut (*xdg_v6_surface_ptr).events.map as *mut _ as _,
                           shell_surface.map_listener() as _);
-            wl_signal_add(&mut (*data).events.unmap as *mut _ as _,
+            wl_signal_add(&mut (*xdg_v6_surface_ptr).events.unmap as *mut _ as _,
                           shell_surface.unmap_listener() as _);
             let events = with_handles!([(shell_surface: {shell_surface.surface_mut()})] => {
                 match shell_surface.state() {
@@ -86,8 +92,8 @@ wayland_listener_static! {
                               shell_surface.show_window_menu_listener() as _);
             }
 
-            let shell_data = (*data).data as *mut xdg_shell_v6::SurfaceState;
-            (*shell_data).shell = Box::into_raw(shell_surface);
+            let shell_data = (*xdg_v6_surface_ptr).data as *mut xdg_shell_v6::SurfaceState;
+            (*shell_data).shell = NonNull::new(Box::into_raw(shell_surface));
         };
     ]
 }

--- a/src/types/input/input_device.rs
+++ b/src/types/input/input_device.rs
@@ -1,4 +1,4 @@
-use std::{cell::Cell, rc::Weak};
+use std::{cell::Cell, ptr::NonNull, rc::Weak};
 
 use libc::{c_double, c_uint};
 use wlroots_sys::{wlr_input_device, wlr_input_device_pointer, wlr_input_device_type,
@@ -26,7 +26,7 @@ pub(crate) struct InputState {
 /// Wrapper for wlr_input_device
 #[derive(Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Device {
-    pub(crate) device: *mut wlr_input_device
+    pub(crate) device: NonNull<wlr_input_device>
 }
 
 impl Device {
@@ -44,31 +44,31 @@ impl Device {
     }
 
     pub fn vendor(&self) -> c_uint {
-        unsafe { (*self.device).vendor }
+        unsafe { self.device.as_ref().vendor }
     }
 
     pub fn product(&self) -> c_uint {
-        unsafe { (*self.device).product }
+        unsafe { self.device.as_ref().product }
     }
 
     pub fn name(&self) -> Option<String> {
-        unsafe { c_to_rust_string((*self.device).name) }
+        unsafe { c_to_rust_string(self.device.as_ref().name) }
     }
 
     pub fn output_name(&self) -> Option<String> {
-        unsafe { c_to_rust_string((*self.device).output_name) }
+        unsafe { c_to_rust_string(self.device.as_ref().output_name) }
     }
 
     /// Get the size in (width_mm, height_mm) format.
     ///
     /// These values will be 0 if it's not supported.
     pub fn size(&self) -> (c_double, c_double) {
-        unsafe { ((*self.device).width_mm, (*self.device).height_mm) }
+        unsafe { (self.device.as_ref().width_mm, self.device.as_ref().height_mm) }
     }
 
     /// Get the type of the device
     pub fn dev_type(&self) -> wlr_input_device_type {
-        unsafe { (*self.device).type_ }
+        unsafe { self.device.as_ref().type_ }
     }
 
     /// Get a handle to the backing input device.
@@ -76,27 +76,27 @@ impl Device {
         unsafe {
             match self.dev_type() {
                 WLR_INPUT_DEVICE_KEYBOARD => {
-                    let keyboard_ptr = (*self.device).__bindgen_anon_1.keyboard;
+                    let keyboard_ptr = self.device.as_ref().__bindgen_anon_1.keyboard;
                     Handle::Keyboard(keyboard::Handle::from_ptr(keyboard_ptr))
                 },
                 WLR_INPUT_DEVICE_POINTER => {
-                    let pointer_ptr = (*self.device).__bindgen_anon_1.pointer;
+                    let pointer_ptr = self.device.as_ref().__bindgen_anon_1.pointer;
                     Handle::Pointer(pointer::Handle::from_ptr(pointer_ptr))
                 },
                 WLR_INPUT_DEVICE_TOUCH => {
-                    let touch_ptr = (*self.device).__bindgen_anon_1.touch;
+                    let touch_ptr = self.device.as_ref().__bindgen_anon_1.touch;
                     Handle::Touch(touch::Handle::from_ptr(touch_ptr))
                 },
                 WLR_INPUT_DEVICE_TABLET_TOOL => {
-                    let tablet_tool_ptr = (*self.device).__bindgen_anon_1.tablet;
+                    let tablet_tool_ptr = self.device.as_ref().__bindgen_anon_1.tablet;
                     Handle::TabletTool(tablet_tool::Handle::from_ptr(tablet_tool_ptr))
                 },
                 WLR_INPUT_DEVICE_TABLET_PAD => {
-                    let tablet_pad_ptr = (*self.device).__bindgen_anon_1.tablet_pad;
+                    let tablet_pad_ptr = self.device.as_ref().__bindgen_anon_1.tablet_pad;
                     Handle::TabletPad(tablet_pad::Handle::from_ptr(tablet_pad_ptr))
                 },
                 WLR_INPUT_DEVICE_SWITCH => {
-                    let switch_ptr = (*self.device).__bindgen_anon_1.lid_switch;
+                    let switch_ptr = self.device.as_ref().__bindgen_anon_1.lid_switch;
                     Handle::Switch(switch::Handle::from_ptr(switch_ptr))
                 }
             }
@@ -104,14 +104,19 @@ impl Device {
     }
 
     pub(crate) unsafe fn dev_union(&self) -> wlr_input_device_pointer {
-        (*self.device).__bindgen_anon_1
+        self.device.as_ref().__bindgen_anon_1
     }
 
     pub(crate) unsafe fn from_ptr(device: *mut wlr_input_device) -> Self {
-        Device { device: device }
+        let device = NonNull::new(device).expect("Device was null");
+        Device { device }
+    }
+
+    pub(crate) unsafe fn as_non_null(&self) -> NonNull<wlr_input_device> {
+        self.device
     }
 
     pub(crate) unsafe fn as_ptr(&self) -> *mut wlr_input_device {
-        self.device
+        self.device.as_ptr()
     }
 }

--- a/src/types/input/switch.rs
+++ b/src/types/input/switch.rs
@@ -1,6 +1,6 @@
 //! TODO Documentation
 
-use std::{cell::Cell, rc::Rc};
+use std::{cell::Cell, ptr::NonNull, rc::Rc};
 
 use {
     input::{self, InputState},
@@ -9,7 +9,7 @@ use wlroots_sys::{wlr_input_device, wlr_switch};
 pub use manager::switch_handler::*;
 pub use events::switch_events as event;
 
-pub type Handle = utils::Handle<*mut wlr_input_device, wlr_switch, Switch>;
+pub type Handle = utils::Handle<NonNull<wlr_input_device>, wlr_switch, Switch>;
 
 #[derive(Debug)]
 pub struct Switch {
@@ -26,7 +26,7 @@ pub struct Switch {
     /// The device that refers to this pointer.
     device: input::Device,
     /// The underlying switch data.
-    switch: *mut wlr_switch
+    switch: NonNull<wlr_switch>
 }
 
 impl Switch {
@@ -41,12 +41,13 @@ impl Switch {
         use wlroots_sys::wlr_input_device_type::*;
         match (*device).type_ {
             WLR_INPUT_DEVICE_SWITCH => {
-                let switch = (*device).__bindgen_anon_1.lid_switch;
+                let switch = NonNull::new((*device).__bindgen_anon_1.lid_switch)
+                    .expect("Switch pointer was null");
                 let liveliness = Rc::new(Cell::new(false));
                 let handle = Rc::downgrade(&liveliness);
                 let state = Box::new(InputState { handle,
                                                   device: input::Device::from_ptr(device) });
-                (*switch).data = Box::into_raw(state) as *mut _;
+                (*switch.as_ptr()).data = Box::into_raw(state) as *mut _;
                 Some(Switch { liveliness,
                               device: input::Device::from_ptr(device),
                               switch })
@@ -64,31 +65,29 @@ impl Switch {
 impl Drop for Switch {
     fn drop(&mut self) {
         if Rc::strong_count(&self.liveliness) == 1 {
-            wlr_log!(WLR_DEBUG, "Dropped Switch {:p}", self.switch);
+            wlr_log!(WLR_DEBUG, "Dropped Switch {:p}", self.switch.as_ptr());
             unsafe {
-                let _ = Box::from_raw((*self.switch).data as *mut InputState);
+                let _ = Box::from_raw((*self.switch.as_ptr()).data as *mut InputState);
             }
             let weak_count = Rc::weak_count(&self.liveliness);
             if weak_count > 0 {
                 wlr_log!(WLR_DEBUG,
                          "Still {} weak pointers to Switch {:p}",
                          weak_count,
-                         self.switch);
+                         self.switch.as_ptr());
             }
         }
     }
 }
 
-impl Handleable<*mut wlr_input_device, wlr_switch> for Switch {
+impl Handleable<NonNull<wlr_input_device>, wlr_switch> for Switch {
     #[doc(hidden)]
     unsafe fn from_ptr(switch: *mut wlr_switch) -> Option<Self> {
-        if (*switch).data.is_null() {
-            return None
-        }
-        let data = Box::from_raw((*switch).data as *mut InputState);
+        let switch = NonNull::new(switch)?;
+        let data = Box::from_raw((*switch.as_ptr()).data as *mut InputState);
         let handle = data.handle.clone();
         let device = data.device.clone();
-        (*switch).data = Box::into_raw(data) as *mut _;
+        (*switch.as_ptr()).data = Box::into_raw(data) as *mut _;
         Some(Switch { liveliness: handle.upgrade().unwrap(),
                       device,
                       switch })
@@ -96,7 +95,7 @@ impl Handleable<*mut wlr_input_device, wlr_switch> for Switch {
 
     #[doc(hidden)]
     unsafe fn as_ptr(&self) -> *mut wlr_switch {
-        self.switch
+        self.switch.as_ptr()
     }
 
     #[doc(hidden)]
@@ -109,7 +108,7 @@ impl Handleable<*mut wlr_input_device, wlr_switch> for Switch {
                     // NOTE Rationale for cloning:
                     // If we already dropped we don't reach this point.
                     device: input::Device { device },
-                    switch: handle.as_ptr()
+                    switch: handle.as_non_null()
         })
     }
 
@@ -119,7 +118,7 @@ impl Handleable<*mut wlr_input_device, wlr_switch> for Switch {
                  // NOTE Rationale for cloning:
                  // Since we have a strong reference already,
                  // the input must still be alive.
-                 data: unsafe { Some(self.device.as_ptr()) },
+                 data: unsafe { Some(self.device.as_non_null()) },
                  _marker: std::marker::PhantomData
         }
     }

--- a/src/types/input/tablet_tool.rs
+++ b/src/types/input/tablet_tool.rs
@@ -98,14 +98,17 @@ impl Drop for TabletTool {
 
 impl Handleable<*mut wlr_input_device, wlr_tablet> for TabletTool {
     #[doc(hidden)]
-    unsafe fn from_ptr(tool: *mut wlr_tablet) -> Self {
+    unsafe fn from_ptr(tool: *mut wlr_tablet) -> Option<Self> {
+        if (*tool).data.is_null() {
+            return None
+        }
         let data = Box::from_raw((*tool).data as *mut InputState);
         let handle = data.handle.clone();
         let device = data.device.clone();
         (*tool).data = Box::into_raw(data) as *mut _;
-        TabletTool { liveliness: handle.upgrade().unwrap(),
-                     device,
-                     tool }
+        Some(TabletTool { liveliness: handle.upgrade().unwrap(),
+                          device,
+                          tool })
     }
 
     #[doc(hidden)]
@@ -118,10 +121,11 @@ impl Handleable<*mut wlr_input_device, wlr_tablet> for TabletTool {
         let liveliness = handle.handle
             .upgrade()
             .ok_or(HandleErr::AlreadyDropped)?;
+        let device = handle.data.ok_or(HandleErr::AlreadyDropped)?;
         Ok(TabletTool { liveliness,
                         // NOTE Rationale for cloning:
                         // If we already dropped we don't reach this point.
-                        device: input::Device { device: handle.data },
+                        device: input::Device { device },
                         tool: handle.as_ptr()
         })
     }
@@ -132,7 +136,7 @@ impl Handleable<*mut wlr_input_device, wlr_tablet> for TabletTool {
                  // NOTE Rationale for cloning:
                  // Since we have a strong reference already,
                  // the input must still be alive.
-                 data: unsafe { self.device.as_ptr() },
+                 data: unsafe { Some(self.device.as_ptr()) },
                  _marker: std::marker::PhantomData
         }
     }

--- a/src/types/output/output.rs
+++ b/src/types/output/output.rs
@@ -26,7 +26,7 @@ pub type Subpixel = wl_output_subpixel;
 pub type Transform = wl_output_transform;
 
 pub(crate) struct OutputState {
-    pub(crate) output: *mut UserOutput,
+    pub(crate) output: Option<NonNull<UserOutput>>,
     handle: Weak<Cell<bool>>,
     damage: NonNull<wlr_output_damage>,
     layout_handle: Option<layout::Handle>
@@ -80,7 +80,7 @@ impl Output {
         let handle = Rc::downgrade(&liveliness);
         let damage = ManuallyDrop::new(output::Damage::new(output.as_ptr()));
         let damage_ptr = NonNull::new(damage.as_ptr()).unwrap();
-        let state = Box::new(OutputState { output: ptr::null_mut(),
+        let state = Box::new(OutputState { output: None,
                                            handle,
                                            damage: damage_ptr,
                                            layout_handle: None });

--- a/src/types/output/output.rs
+++ b/src/types/output/output.rs
@@ -1,7 +1,7 @@
 //! TODO Documentation
 
-use std::{cell::Cell, ffi::CStr, mem::ManuallyDrop, rc::{Rc, Weak},
-          time::Duration, panic, ptr};
+use std::{cell::Cell, ffi::CStr, mem::ManuallyDrop, ptr::NonNull,
+          rc::{Rc, Weak}, time::Duration, panic, ptr};
 
 use libc::{c_float, c_int, clock_t};
 use wayland_sys::server::WAYLAND_SERVER_HANDLE;
@@ -28,7 +28,7 @@ pub type Transform = wl_output_transform;
 pub(crate) struct OutputState {
     pub(crate) output: *mut UserOutput,
     handle: Weak<Cell<bool>>,
-    damage: *mut wlr_output_damage,
+    damage: NonNull<wlr_output_damage>,
     layout_handle: Option<layout::Handle>
 }
 
@@ -47,10 +47,10 @@ pub struct Output {
     /// The tracker for damage on the output.
     damage: ManuallyDrop<output::Damage>,
     /// The output ptr that refers to this `Output`
-    output: *mut wlr_output
+    output: NonNull<wlr_output>
 }
 
-pub type Handle = utils::Handle<*mut wlr_output_damage, wlr_output, Output>;
+pub type Handle = utils::Handle<NonNull<wlr_output_damage>, wlr_output, Output>;
 
 impl Output {
     /// Just like `std::clone::Clone`, but unsafe.
@@ -73,15 +73,18 @@ impl Output {
     /// This creates a totally new Output (e.g with its own reference count)
     /// so only do this once per `wlr_output`!
     pub(crate) unsafe fn new(output: *mut wlr_output) -> Self {
-        (*output).data = ptr::null_mut();
+        let output = NonNull::new(output)
+            .expect("Output pointer was null");
+        (*output.as_ptr()).data = ptr::null_mut();
         let liveliness = Rc::new(Cell::new(false));
         let handle = Rc::downgrade(&liveliness);
-        let damage = ManuallyDrop::new(output::Damage::new(output));
+        let damage = ManuallyDrop::new(output::Damage::new(output.as_ptr()));
+        let damage_ptr = NonNull::new(damage.as_ptr()).unwrap();
         let state = Box::new(OutputState { output: ptr::null_mut(),
                                            handle,
-                                           damage: damage.as_ptr(),
+                                           damage: damage_ptr,
                                            layout_handle: None });
-        (*output).data = Box::into_raw(state) as *mut _;
+        (*output.as_ptr()).data = Box::into_raw(state) as *mut _;
         Output { liveliness,
                  damage,
                  output }
@@ -97,11 +100,11 @@ impl Output {
         }
         let mut data = Box::from_raw(user_data);
         data.layout_handle = layout_handle.into();
-        (*self.output).data = Box::into_raw(data) as *mut _;
+        (*self.output.as_ptr()).data = Box::into_raw(data) as *mut _;
     }
 
     unsafe fn user_data(&mut self) -> *mut OutputState {
-        (*self.output).data as *mut _
+        (*self.output.as_ptr()).data as *mut _
     }
 
     /// Used to clear the pointer to an OutputLayout when the OutputLayout
@@ -113,7 +116,7 @@ impl Output {
         }
         let mut data = Box::from_raw(user_data);
         data.layout_handle = None;
-        (*self.output).data = Box::into_raw(data) as *mut _;
+        (*self.output.as_ptr()).data = Box::into_raw(data) as *mut _;
     }
 
     /// Remove this Output from an OutputLayout, if it is part of an
@@ -158,7 +161,7 @@ impl Output {
     /// action in the output destruction callback.
     pub fn choose_best_mode(&mut self) {
         unsafe {
-            let modes = &mut (*self.output).modes as *mut wl_list;
+            let modes = &mut (*self.output.as_ptr()).modes as *mut wl_list;
             let length = ffi_dispatch!(WAYLAND_SERVER_HANDLE, wl_list_length, modes as _);
             if length > 0 {
                 // TODO Better logging
@@ -176,18 +179,18 @@ impl Output {
 
     /// Set this to be the current mode for the Output.
     pub fn set_mode(&mut self, mode: output::Mode) -> bool {
-        unsafe { wlr_output_set_mode(self.output, mode.as_ptr()) }
+        unsafe { wlr_output_set_mode(self.output.as_ptr(), mode.as_ptr()) }
     }
 
     /// Set a custom mode for this output.
     pub fn set_custom_mode(&mut self, size: Size, refresh: i32) -> bool {
-        unsafe { wlr_output_set_custom_mode(self.output, size.width, size.height, refresh) }
+        unsafe { wlr_output_set_custom_mode(self.output.as_ptr(), size.width, size.height, refresh) }
     }
 
     /// Gets the name of the output in UTF-8.
     pub fn name(&self) -> String {
         unsafe {
-            CStr::from_ptr((*self.output).name.as_ptr()).to_string_lossy()
+            CStr::from_ptr((*self.output.as_ptr()).name.as_ptr()).to_string_lossy()
                                                         .into_owned()
         }
     }
@@ -195,68 +198,68 @@ impl Output {
     /// Gets the make of the output in UTF-8.
     pub fn make(&self) -> String {
         unsafe {
-            c_to_rust_string((*self.output).make.as_ptr()).expect("Could not parse make as UTF-8")
+            c_to_rust_string((*self.output.as_ptr()).make.as_ptr()).expect("Could not parse make as UTF-8")
         }
     }
 
     /// Gets the model of the output in UTF-8.
     pub fn model(&self) -> String {
         unsafe {
-            c_to_rust_string((*self.output).model.as_ptr()).expect("Could not parse model as UTF-8")
+            c_to_rust_string((*self.output.as_ptr()).model.as_ptr()).expect("Could not parse model as UTF-8")
         }
     }
 
     /// Gets the serial of the output in UTF-8.
     pub fn serial(&self) -> String {
         unsafe {
-            c_to_rust_string((*self.output).serial.as_ptr()).expect("Could not parse serial as \
+            c_to_rust_string((*self.output.as_ptr()).serial.as_ptr()).expect("Could not parse serial as \
                                                                      UTF-8")
         }
     }
 
     /// Determines if the output is enabled or not.
     pub fn enabled(&self) -> bool {
-        unsafe { (*self.output).enabled }
+        unsafe { (*self.output.as_ptr()).enabled }
     }
 
     /// Get the scale of the output
     pub fn scale(&self) -> c_float {
-        unsafe { (*self.output).scale }
+        unsafe { (*self.output.as_ptr()).scale }
     }
 
     /// Determines if the output should have its buffers swapped or not.
     pub fn needs_swap(&self) -> bool {
-        unsafe { (*self.output).needs_swap }
+        unsafe { (*self.output.as_ptr()).needs_swap }
     }
 
     /// Get the refresh rate of the output.
     pub fn refresh_rate(&self) -> i32 {
-        unsafe { (*self.output).refresh }
+        unsafe { (*self.output.as_ptr()).refresh }
     }
 
     pub fn current_mode<'output>(&'output self) -> Option<output::Mode<'output>> {
         unsafe {
-            if (*self.output).current_mode.is_null() {
+            if (*self.output.as_ptr()).current_mode.is_null() {
                 None
             } else {
-                Some(output::Mode::new((*self.output).current_mode))
+                Some(output::Mode::new((*self.output.as_ptr()).current_mode))
             }
         }
     }
 
     /// Gets the output position in layout space reported to clients.
     pub fn layout_space_pos(&self) -> (i32, i32) {
-        unsafe { ((*self.output).lx, (*self.output).ly) }
+        unsafe { ((*self.output.as_ptr()).lx, (*self.output.as_ptr()).ly) }
     }
 
     /// Get subpixel information about the output.
     pub fn subpixel(&self) -> Subpixel {
-        unsafe { (*self.output).subpixel }
+        unsafe { (*self.output.as_ptr()).subpixel }
     }
 
     /// Get the transform information about the output.
     pub fn get_transform(&self) -> Transform {
-        unsafe { (*self.output).transform }
+        unsafe { (*self.output.as_ptr()).transform }
     }
 
     /// Renders software cursors. This is a utility function that can be called when
@@ -272,7 +275,7 @@ impl Output {
                 Some(ref mut region) => &mut region.region as *mut _,
                 None => ptr::null_mut()
             };
-            wlr_output_render_software_cursors(self.output, damage)
+            wlr_output_render_software_cursors(self.output.as_ptr(), damage)
         }
     }
 
@@ -280,7 +283,7 @@ impl Output {
     ///
     /// If a `frame` event is already pending, it is a no-op.
     pub fn schedule_frame(&mut self) {
-        unsafe { wlr_output_schedule_frame(self.output) }
+        unsafe { wlr_output_schedule_frame(self.output.as_ptr()) }
     }
 
     /// Make this output the current output.
@@ -296,7 +299,7 @@ impl Output {
     /// or None if unknown. This is useful for damage tracking.
     pub unsafe fn make_current(&mut self) -> (bool, Option<c_int>) {
         let mut buffer_age = -1;
-        let res = wlr_output_make_current(self.output, &mut buffer_age);
+        let res = wlr_output_make_current(self.output.as_ptr(), &mut buffer_age);
         let buffer_age = if buffer_age == -1 {
             None
         } else {
@@ -332,29 +335,29 @@ impl Output {
             Some(region) => &mut region.region as *mut _,
             None => ptr::null_mut()
         };
-        wlr_output_swap_buffers(self.output, when_ptr, damage)
+        wlr_output_swap_buffers(self.output.as_ptr(), when_ptr, damage)
     }
 
     /// Determines if a frame is pending or not.
     pub fn frame_pending(&self) -> bool {
-        unsafe { (*self.output).frame_pending }
+        unsafe { (*self.output.as_ptr()).frame_pending }
     }
 
     /// Get the dimensions of the output as (width, height).
     pub fn size(&self) -> (i32, i32) {
-        unsafe { ((*self.output).width, (*self.output).height) }
+        unsafe { ((*self.output.as_ptr()).width, (*self.output.as_ptr()).height) }
     }
 
     /// Get the physical dimensions of the output as (width, height).
     pub fn physical_size(&self) -> (i32, i32) {
-        unsafe { ((*self.output).phys_width, (*self.output).phys_height) }
+        unsafe { ((*self.output.as_ptr()).phys_width, (*self.output.as_ptr()).phys_height) }
     }
 
     /// Computes the transformed output resolution
     pub fn transformed_resolution(&self) -> (c_int, c_int) {
         unsafe {
             let (mut x, mut y) = (0, 0);
-            wlr_output_transformed_resolution(self.output, &mut x, &mut y);
+            wlr_output_transformed_resolution(self.output.as_ptr(), &mut x, &mut y);
             (x, y)
         }
     }
@@ -363,18 +366,18 @@ impl Output {
     pub fn effective_resolution(&self) -> (c_int, c_int) {
         unsafe {
             let (mut x, mut y) = (0, 0);
-            wlr_output_effective_resolution(self.output, &mut x, &mut y);
+            wlr_output_effective_resolution(self.output.as_ptr(), &mut x, &mut y);
             (x, y)
         }
     }
 
     pub fn transform_matrix(&self) -> [c_float; 9] {
-        unsafe { (*self.output).transform_matrix }
+        unsafe { (*self.output.as_ptr()).transform_matrix }
     }
 
     pub fn transform(&mut self, transform: Transform) {
         unsafe {
-            wlr_output_set_transform(self.output, transform);
+            wlr_output_set_transform(self.output.as_ptr(), transform);
         }
     }
 
@@ -384,7 +387,7 @@ impl Output {
     pub fn modes<'output>(&'output self) -> Vec<output::Mode<'output>> {
         unsafe {
             let mut result = vec![];
-            wl_list_for_each!((*self.output).modes, link, (mode: wlr_output_mode) => {
+            wl_list_for_each!((*self.output.as_ptr()).modes, link, (mode: wlr_output_mode) => {
                 result.push(output::Mode::new(mode))
             });
             result
@@ -393,27 +396,27 @@ impl Output {
 
     /// Enables or disables an output.
     pub fn enable(&mut self, enable: bool) -> bool {
-        unsafe { wlr_output_enable(self.output, enable) }
+        unsafe { wlr_output_enable(self.output.as_ptr(), enable) }
     }
 
     /// Sets the gamma based on the size.
     pub fn set_gamma(&mut self, size: usize, mut r: u16, mut g: u16, mut b: u16) -> bool {
-        unsafe { wlr_output_set_gamma(self.output, size, &mut r, &mut g, &mut b) }
+        unsafe { wlr_output_set_gamma(self.output.as_ptr(), size, &mut r, &mut g, &mut b) }
     }
 
     /// Get the gamma size.
     pub fn get_gamma_size(&self) -> usize {
-        unsafe { wlr_output_get_gamma_size(self.output) }
+        unsafe { wlr_output_get_gamma_size(self.output.as_ptr()) }
     }
 
     /// Sets the position of this output.
     pub fn set_position(&mut self, origin: Origin) {
-        unsafe { wlr_output_set_position(self.output, origin.x, origin.y) }
+        unsafe { wlr_output_set_position(self.output.as_ptr(), origin.x, origin.y) }
     }
 
     /// Set the scale applied to this output.
     pub fn set_scale(&mut self, scale: c_float) {
-        unsafe { wlr_output_set_scale(self.output, scale) }
+        unsafe { wlr_output_set_scale(self.output.as_ptr(), scale) }
     }
 
     pub fn damage(&mut self) -> &mut output::Damage {
@@ -431,13 +434,13 @@ impl Drop for Output {
         // We do _not_ need to call wlr_output_damage_destroy for the output,
         // that is handled automatically by the listeners in wlroots.
         if Rc::strong_count(&self.liveliness) == 1 {
-            wlr_log!(WLR_DEBUG, "Dropped output {:p}", self.output);
+            wlr_log!(WLR_DEBUG, "Dropped output {:p}", self.output.as_ptr());
             let weak_count = Rc::weak_count(&self.liveliness);
             if weak_count > 0 {
                 wlr_log!(WLR_DEBUG,
                          "Still {} weak pointers to Output {:p}",
                          weak_count,
-                         self.output);
+                         self.output.as_ptr());
             }
         } else {
             return
@@ -445,30 +448,29 @@ impl Drop for Output {
         // TODO Move back up in the some after NLL is a thing.
         unsafe {
             self.remove_from_output_layout();
-            let _ = Box::from_raw((*self.output).data as *mut OutputState);
+            let _ = Box::from_raw((*self.output.as_ptr()).data as *mut OutputState);
         }
     }
 }
 
-impl Handleable<*mut wlr_output_damage, wlr_output> for Output {
+impl Handleable<NonNull<wlr_output_damage>, wlr_output> for Output {
     #[doc(hidden)]
-    unsafe fn from_ptr(ptr: *mut wlr_output) -> Option<Self> {
-        if (*ptr).data.is_null() {
-            return None
-        }
-        let data = Box::from_raw((*ptr).data as *mut OutputState);
+    unsafe fn from_ptr(output: *mut wlr_output) -> Option<Self> {
+        let output = NonNull::new(output)?;
+        let data = Box::from_raw((*output.as_ptr()).data as *mut OutputState);
         let handle = data.handle.clone();
         let damage = data.damage;
-        (*ptr).data = Box::into_raw(data) as *mut _;
+        let damage = ManuallyDrop::new(output::Damage::from_ptr(damage.as_ptr()));
+        (*output.as_ptr()).data = Box::into_raw(data) as *mut _;
         Some(Output { liveliness: handle.upgrade().unwrap(),
-                      damage: ManuallyDrop::new(output::Damage::from_ptr(damage)),
-                      output: ptr})
+                      damage,
+                      output })
 
     }
 
     #[doc(hidden)]
     unsafe fn as_ptr(&self) -> *mut wlr_output {
-        self.output
+        self.output.as_ptr()
     }
 
     #[doc(hidden)]
@@ -477,15 +479,16 @@ impl Handleable<*mut wlr_output_damage, wlr_output> for Output {
             .upgrade()
             .ok_or_else(|| HandleErr::AlreadyDropped)?;
         let damage_ptr = handle.data.ok_or(HandleErr::AlreadyDropped)?;
+        let damage = ManuallyDrop::new(output::Damage::from_ptr(damage_ptr.as_ptr()));
         Ok(Output { liveliness,
-                    damage: ManuallyDrop::new(output::Damage::from_ptr(damage_ptr)),
-                    output: handle.as_ptr() })
+                    damage,
+                    output: handle.as_non_null() })
     }
 
     fn weak_reference(&self) -> Handle {
         Handle { ptr: self.output,
                  handle: Rc::downgrade(&self.liveliness),
-                 data: unsafe { Some(self.damage.as_ptr()) },
+                 data: unsafe { Some(NonNull::new(self.damage.as_ptr()).unwrap()) },
                  _marker: std::marker::PhantomData }
     }
 }

--- a/src/types/seat/seat.rs
+++ b/src/types/seat/seat.rs
@@ -290,7 +290,7 @@ wayland_listener!(pub Seat, (*mut wlr_seat, Box<Handler>), [
 
         if let Some(surface_handler) = surface_handler {
             let surface_state = (*(*data).surface).data as *mut surface::InternalState;
-            (*(*surface_state).surface).data().1 = surface_handler;
+            (*(*surface_state).surface.unwrap().as_ptr()).data().1 = surface_handler;
         }
 
         if let Some(drag_icon_handler) = drag_icon_handler {

--- a/src/types/shell/xdg_shell_v6.rs
+++ b/src/types/shell/xdg_shell_v6.rs
@@ -113,6 +113,11 @@ impl Surface {
             if surface.is_null() {
                 panic!("xdg shell had a null surface!")
             }
+            if (*surface).data.is_null()  {
+                let mut handle =  surface::Handle::default();
+                handle.ptr = surface;
+                return handle
+            }
             surface::Handle::from_ptr(surface)
         }
     }

--- a/src/types/shell/xdg_shell_v6.rs
+++ b/src/types/shell/xdg_shell_v6.rs
@@ -113,11 +113,6 @@ impl Surface {
             if surface.is_null() {
                 panic!("xdg shell had a null surface!")
             }
-            if (*surface).data.is_null()  {
-                let mut handle =  surface::Handle::default();
-                handle.ptr = surface;
-                return handle
-            }
             surface::Handle::from_ptr(surface)
         }
     }
@@ -228,16 +223,19 @@ impl Drop for Surface {
 
 impl Handleable<OptionalShellState, wlr_xdg_surface_v6> for Surface {
     #[doc(hidden)]
-    unsafe fn from_ptr(shell_surface: *mut wlr_xdg_surface_v6) -> Self {
+    unsafe fn from_ptr(shell_surface: *mut wlr_xdg_surface_v6) -> Option<Self> {
+        if (*shell_surface).data.is_null() {
+            return None
+        }
         let data = &mut *((*shell_surface).data as *mut SurfaceState);
         let state = match data.shell_state {
             None => None,
             Some(ref state) => Some(state.clone())
         };
         let liveliness = data.handle.upgrade().unwrap();
-        Surface { liveliness,
-                  state,
-                  shell_surface }
+        Some(Surface { liveliness,
+                       state,
+                       shell_surface })
     }
 
     #[doc(hidden)]
@@ -252,16 +250,16 @@ impl Handleable<OptionalShellState, wlr_xdg_surface_v6> for Surface {
             .ok_or_else(|| HandleErr::AlreadyDropped)?;
         Ok(Surface { liveliness,
                      shell_surface: handle.ptr,
-                     state: handle.data.clone().0 })
+                     state: handle.data.clone().and_then(|d| d.0) })
     }
 
     fn weak_reference(&self) -> Handle {
         Handle { ptr: self.shell_surface,
                  handle: Rc::downgrade(&self.liveliness),
-                 data: OptionalShellState(match self.state {
+                 data: Some(OptionalShellState(match self.state {
                      None => None,
                      Some(ref state) => Some(unsafe { state.clone() })
-                 }),
+                 })),
                  _marker: std::marker::PhantomData }
     }
 }

--- a/src/types/shell/xdg_shell_v6.rs
+++ b/src/types/shell/xdg_shell_v6.rs
@@ -1,6 +1,6 @@
 //! TODO Documentation
 
-use std::{cell::Cell, rc::{Rc, Weak}, panic, ptr};
+use std::{cell::Cell, rc::{Rc, Weak}, panic, ptr::NonNull};
 
 use libc::c_void;
 use wlroots_sys::{wlr_xdg_popup_v6, wlr_xdg_surface_v6, wlr_xdg_surface_v6_ping,
@@ -53,21 +53,21 @@ impl Clone for OptionalShellState {
 
 /// Used internally to reclaim a handle from just a *mut wlr_xdg_surface_v6.
 pub(crate) struct SurfaceState {
-    pub(crate) shell: *mut XdgShellV6,
+    pub(crate) shell: Option<NonNull<XdgShellV6>>,
     handle: Weak<Cell<bool>>,
     shell_state: Option<ShellState>
 }
 
 #[derive(Debug, Eq, PartialEq, Hash)]
 pub struct TopLevel {
-    shell_surface: *mut wlr_xdg_surface_v6,
-    toplevel: *mut wlr_xdg_toplevel_v6
+    shell_surface: NonNull<wlr_xdg_surface_v6>,
+    toplevel: NonNull<wlr_xdg_toplevel_v6>
 }
 
 #[derive(Debug, Eq, PartialEq, Hash)]
 pub struct Popup {
-    shell_surface: *mut wlr_xdg_surface_v6,
-    popup: *mut wlr_xdg_popup_v6
+    shell_surface: NonNull<wlr_xdg_surface_v6>,
+    popup: NonNull<wlr_xdg_popup_v6>
 }
 
 /// A tagged enum of the different roles used by the xdg shell.
@@ -83,33 +83,35 @@ pub enum ShellState {
 pub struct Surface {
     liveliness: Rc<Cell<bool>>,
     state: Option<ShellState>,
-    shell_surface: *mut wlr_xdg_surface_v6
+    shell_surface: NonNull<wlr_xdg_surface_v6>
 }
 
 impl Surface {
-    pub(crate) unsafe fn new<T>(shell_surface: *mut wlr_xdg_surface_v6, state: T) -> Self
+    pub(crate) unsafe fn new<T>(shell_surface: NonNull<wlr_xdg_surface_v6>, state: T) -> Self
         where T: Into<Option<ShellState>>
     {
+        if !(*shell_surface.as_ptr()).data.is_null() {
+            panic!("XDGv6 shell surface has already been initialized");
+        }
         let state = state.into();
-        (*shell_surface).data = ptr::null_mut();
         let liveliness = Rc::new(Cell::new(false));
         let shell_state =
-            Box::new(SurfaceState { shell: ptr::null_mut(),
-                                              handle: Rc::downgrade(&liveliness),
-                                              shell_state: match state {
-                                                  None => None,
-                                                  Some(ref state) => Some(state.clone())
-                                              } });
-        (*shell_surface).data = Box::into_raw(shell_state) as *mut _;
+            Box::new(SurfaceState { shell: None,
+                                    handle: Rc::downgrade(&liveliness),
+                                    shell_state: match state {
+                                        None => None,
+                                        Some(ref state) => Some(state.clone())
+                                    } });
+        (*shell_surface.as_ptr()).data = Box::into_raw(shell_state) as *mut _;
         Surface { liveliness,
-                            state: state,
-                            shell_surface }
+                  state: state,
+                  shell_surface }
     }
 
     /// Gets the surface used by this XDG shell.
     pub fn surface(&mut self) -> surface::Handle {
         unsafe {
-            let surface = (*self.shell_surface).surface;
+            let surface = (*self.shell_surface.as_ptr()).surface;
             if surface.is_null() {
                 panic!("xdg shell had a null surface!")
             }
@@ -119,7 +121,7 @@ impl Surface {
 
     /// Get the role of this XDG surface.
     pub fn role(&self) -> wlr_xdg_surface_v6_role {
-        unsafe { (*self.shell_surface).role }
+        unsafe { (*self.shell_surface.as_ptr()).role }
     }
 
     pub fn state(&mut self) -> Option<&mut ShellState> {
@@ -128,31 +130,31 @@ impl Surface {
 
     /// Determines if this XDG shell surface has been configured or not.
     pub fn configured(&self) -> bool {
-        unsafe { (*self.shell_surface).configured }
+        unsafe { (*self.shell_surface.as_ptr()).configured }
     }
 
     pub fn added(&self) -> bool {
-        unsafe { (*self.shell_surface).added }
+        unsafe { (*self.shell_surface.as_ptr()).added }
     }
 
     pub fn configure_serial(&self) -> u32 {
-        unsafe { (*self.shell_surface).configure_serial }
+        unsafe { (*self.shell_surface.as_ptr()).configure_serial }
     }
 
     pub fn configure_next_serial(&self) -> u32 {
-        unsafe { (*self.shell_surface).configure_next_serial }
+        unsafe { (*self.shell_surface.as_ptr()).configure_next_serial }
     }
 
     pub fn has_next_geometry(&self) -> bool {
-        unsafe { (*self.shell_surface).has_next_geometry }
+        unsafe { (*self.shell_surface.as_ptr()).has_next_geometry }
     }
 
     pub fn next_geometry(&self) -> Area {
-        unsafe { Area::from_box((*self.shell_surface).next_geometry) }
+        unsafe { Area::from_box((*self.shell_surface.as_ptr()).next_geometry) }
     }
 
     pub fn geometry(&self) -> Area {
-        unsafe { Area::from_box((*self.shell_surface).geometry) }
+        unsafe { Area::from_box((*self.shell_surface.as_ptr()).geometry) }
     }
 
     /// Send a ping to the surface.
@@ -161,7 +163,7 @@ impl Surface {
     /// the ping timeout event will be emitted.
     pub fn ping(&mut self) {
         unsafe {
-            wlr_xdg_surface_v6_ping(self.shell_surface);
+            wlr_xdg_surface_v6_ping(self.shell_surface.as_ptr());
         }
     }
 
@@ -177,7 +179,7 @@ impl Surface {
                       -> Option<surface::Handle> {
         unsafe {
             let sub_surface =
-                wlr_xdg_surface_v6_surface_at(self.shell_surface, sx, sy, sub_sx, sub_sy);
+                wlr_xdg_surface_v6_surface_at(self.shell_surface.as_ptr(), sx, sy, sub_sx, sub_sy);
             if sub_surface.is_null() {
                 None
             } else {
@@ -196,7 +198,7 @@ impl Surface {
                 iterator_fn(surface, sx, sy);
             }
             let iterator_ptr: *mut c_void = &mut iterator_ref as *mut _ as *mut c_void;
-            wlr_xdg_surface_v6_for_each_surface(self.shell_surface, Some(c_iterator), iterator_ptr);
+            wlr_xdg_surface_v6_for_each_surface(self.shell_surface.as_ptr(), Some(c_iterator), iterator_ptr);
         }
     }
 }
@@ -204,19 +206,19 @@ impl Surface {
 impl Drop for Surface {
     fn drop(&mut self) {
         if Rc::strong_count(&self.liveliness) == 1 {
-            wlr_log!(WLR_DEBUG, "Dropped xdg v6 shell {:p}", self.shell_surface);
+            wlr_log!(WLR_DEBUG, "Dropped xdg v6 shell {:p}", self.shell_surface.as_ptr());
             let weak_count = Rc::weak_count(&self.liveliness);
             if weak_count > 0 {
                 wlr_log!(WLR_DEBUG,
                          "Still {} weak pointers to xdg v6 shell {:p}",
                          weak_count,
-                         self.shell_surface);
+                         self.shell_surface.as_ptr());
             }
         } else {
             return
         }
         unsafe {
-            let _ = Box::from_raw((*self.shell_surface).data as *mut SurfaceState);
+            let _ = Box::from_raw((*self.shell_surface.as_ptr()).data as *mut SurfaceState);
         }
     }
 }
@@ -224,10 +226,8 @@ impl Drop for Surface {
 impl Handleable<OptionalShellState, wlr_xdg_surface_v6> for Surface {
     #[doc(hidden)]
     unsafe fn from_ptr(shell_surface: *mut wlr_xdg_surface_v6) -> Option<Self> {
-        if (*shell_surface).data.is_null() {
-            return None
-        }
-        let data = &mut *((*shell_surface).data as *mut SurfaceState);
+        let shell_surface = NonNull::new(shell_surface)?;
+        let data = &mut *((*shell_surface.as_ptr()).data as *mut SurfaceState);
         let state = match data.shell_state {
             None => None,
             Some(ref state) => Some(state.clone())
@@ -240,7 +240,7 @@ impl Handleable<OptionalShellState, wlr_xdg_surface_v6> for Surface {
 
     #[doc(hidden)]
     unsafe fn as_ptr(&self) -> *mut wlr_xdg_surface_v6 {
-        self.shell_surface
+        self.shell_surface.as_ptr()
     }
 
     #[doc(hidden)]
@@ -265,59 +265,59 @@ impl Handleable<OptionalShellState, wlr_xdg_surface_v6> for Surface {
 }
 
 impl TopLevel {
-    pub(crate) unsafe fn from_shell(shell_surface: *mut wlr_xdg_surface_v6,
-                                    toplevel: *mut wlr_xdg_toplevel_v6)
-                                    -> TopLevel {
+        pub(crate) unsafe fn from_shell(shell_surface: NonNull<wlr_xdg_surface_v6>,
+                                        toplevel: NonNull<wlr_xdg_toplevel_v6>)
+                                        -> TopLevel {
         TopLevel { shell_surface,
-                        toplevel }
+                   toplevel }
     }
 
     /// Get the title associated with this XDG shell toplevel.
     pub fn title(&self) -> String {
-        unsafe { c_to_rust_string((*self.toplevel).title).expect("Could not parse class as UTF-8") }
+        unsafe { c_to_rust_string((*self.toplevel.as_ptr()).title).expect("Could not parse class as UTF-8") }
     }
 
     /// Get the app id associated with this XDG shell toplevel.
     pub fn app_id(&self) -> String {
         unsafe {
-            c_to_rust_string((*self.toplevel).app_id).expect("Could not parse class as UTF-8")
+            c_to_rust_string((*self.toplevel.as_ptr()).app_id).expect("Could not parse class as UTF-8")
         }
     }
 
     /// Get a handle to the base surface of the xdg tree.
     pub fn base(&self) -> Handle {
-        unsafe { Handle::from_ptr((*self.toplevel).base) }
+        unsafe { Handle::from_ptr((*self.toplevel.as_ptr()).base) }
     }
 
     /// Get a handle to the parent surface of the xdg tree.
     pub fn parent(&self) -> Handle {
-        unsafe { Handle::from_ptr((*self.toplevel).parent) }
+        unsafe { Handle::from_ptr((*self.toplevel.as_ptr()).parent) }
     }
 
     pub fn added(&self) -> bool {
-        unsafe { (*self.toplevel).added }
+        unsafe { (*self.toplevel.as_ptr()).added }
     }
 
     /// Get the pending client state.
     pub fn client_pending_state(&self) -> wlr_xdg_toplevel_v6_state {
-        unsafe { (*self.toplevel).client_pending }
+        unsafe { (*self.toplevel.as_ptr()).client_pending }
     }
 
     /// Get the pending server state.
     pub fn server_pending_state(&self) -> wlr_xdg_toplevel_v6_state {
-        unsafe { (*self.toplevel).server_pending }
+        unsafe { (*self.toplevel.as_ptr()).server_pending }
     }
 
     /// Get the current configure state.
     pub fn current_state(&self) -> wlr_xdg_toplevel_v6_state {
-        unsafe { (*self.toplevel).current }
+        unsafe { (*self.toplevel.as_ptr()).current }
     }
 
     /// Request that this toplevel surface be the given size.
     ///
     /// Returns the associated configure serial.
     pub fn set_size(&mut self, width: u32, height: u32) -> u32 {
-        unsafe { wlr_xdg_toplevel_v6_set_size(self.shell_surface, width, height) }
+        unsafe { wlr_xdg_toplevel_v6_set_size(self.shell_surface.as_ptr(), width, height) }
     }
 
     /// Request that this toplevel surface show itself in an activated or deactivated
@@ -325,7 +325,7 @@ impl TopLevel {
     ///
     /// Returns the associated configure serial.
     pub fn set_activated(&mut self, activated: bool) -> u32 {
-        unsafe { wlr_xdg_toplevel_v6_set_activated(self.shell_surface, activated) }
+        unsafe { wlr_xdg_toplevel_v6_set_activated(self.shell_surface.as_ptr(), activated) }
     }
 
     /// Request that this toplevel surface consider itself maximized or not
@@ -333,7 +333,7 @@ impl TopLevel {
     ///
     /// Returns the associated configure serial.
     pub fn set_maximized(&mut self, maximized: bool) -> u32 {
-        unsafe { wlr_xdg_toplevel_v6_set_maximized(self.shell_surface, maximized) }
+        unsafe { wlr_xdg_toplevel_v6_set_maximized(self.shell_surface.as_ptr(), maximized) }
     }
 
     /// Request that this toplevel surface consider itself fullscreen or not
@@ -341,7 +341,7 @@ impl TopLevel {
     ///
     /// Returns the associated configure serial.
     pub fn set_fullscreen(&mut self, fullscreen: bool) -> u32 {
-        unsafe { wlr_xdg_toplevel_v6_set_fullscreen(self.shell_surface, fullscreen) }
+        unsafe { wlr_xdg_toplevel_v6_set_fullscreen(self.shell_surface.as_ptr(), fullscreen) }
     }
 
     /// Request that this toplevel surface consider itself to be resizing or not
@@ -349,45 +349,45 @@ impl TopLevel {
     ///
     /// Returns the associated configure serial.
     pub fn set_resizing(&mut self, resizing: bool) -> u32 {
-        unsafe { wlr_xdg_toplevel_v6_set_resizing(self.shell_surface, resizing) }
+        unsafe { wlr_xdg_toplevel_v6_set_resizing(self.shell_surface.as_ptr(), resizing) }
     }
 
     /// Request that this toplevel surface closes.
     pub fn close(&mut self) {
-        unsafe { wlr_xdg_surface_v6_send_close(self.shell_surface) }
+        unsafe { wlr_xdg_surface_v6_send_close(self.shell_surface.as_ptr()) }
     }
 
     pub(crate) unsafe fn as_ptr(&self) -> *mut wlr_xdg_toplevel_v6 {
-        self.toplevel
+        self.toplevel.as_ptr()
     }
 }
 
 impl Popup {
-    pub(crate) unsafe fn from_shell(shell_surface: *mut wlr_xdg_surface_v6,
-                                    popup: *mut wlr_xdg_popup_v6)
+    pub(crate) unsafe fn from_shell(shell_surface: NonNull<wlr_xdg_surface_v6>,
+                                    popup: NonNull<wlr_xdg_popup_v6>)
                                     -> Popup {
         Popup { shell_surface,
-                     popup }
+                popup }
     }
 
     /// Get a handle to the base surface of the xdg tree.
     pub fn base(&self) -> Handle {
-        unsafe { Handle::from_ptr((*self.popup).base) }
+        unsafe { Handle::from_ptr((*self.popup.as_ptr()).base) }
     }
 
     /// Get a handle to the parent surface of the xdg tree.
     pub fn parent(&self) -> Handle {
-        unsafe { Handle::from_ptr((*self.popup).parent) }
+        unsafe { Handle::from_ptr((*self.popup.as_ptr()).parent) }
     }
 
     pub fn committed(&self) -> bool {
-        unsafe { (*self.popup).committed }
+        unsafe { (*self.popup.as_ptr()).committed }
     }
 
     /// Get a handle to the seat associated with this popup.
     pub fn seat_handle(&self) -> Option<seat::Handle> {
         unsafe {
-            let seat = (*self.popup).seat;
+            let seat = (*self.popup.as_ptr()).seat;
             if seat.is_null() {
                 None
             } else {
@@ -397,7 +397,7 @@ impl Popup {
     }
 
     pub fn geometry(&self) -> Area {
-        unsafe { Area::from_box((*self.popup).geometry) }
+        unsafe { Area::from_box((*self.popup.as_ptr()).geometry) }
     }
 }
 

--- a/src/types/surface/subsurface.rs
+++ b/src/types/surface/subsurface.rs
@@ -96,12 +96,14 @@ impl Subsurface {
 
 impl Handleable<(), wlr_subsurface> for Subsurface {
     #[doc(hidden)]
-    unsafe fn from_ptr(subsurface: *mut wlr_subsurface) -> Self {
-        let data = (*subsurface).data as *mut InternalSubsurface;
-        Subsurface {
-            liveliness: (*data).data.0.liveliness.clone(),
-            subsurface
+    unsafe fn from_ptr(subsurface: *mut wlr_subsurface) -> Option<Self> {
+        if (*subsurface).data.is_null() {
+            return None
         }
+        let data = (*subsurface).data as *mut InternalSubsurface;
+        Some(Subsurface {liveliness: (*data).data.0.liveliness.clone(),
+                         subsurface
+        })
     }
 
     #[doc(hidden)]
@@ -121,7 +123,7 @@ impl Handleable<(), wlr_subsurface> for Subsurface {
     fn weak_reference(&self) -> Handle {
         Handle { ptr: self.subsurface,
                  handle: Rc::downgrade(&self.liveliness),
-                 data: (),
+                 data: Some(()),
                  _marker: std::marker::PhantomData
         }
     }

--- a/src/types/surface/surface.rs
+++ b/src/types/surface/surface.rs
@@ -292,6 +292,9 @@ impl Surface {
 impl Handleable<Weak<Box<SubsurfaceManager>>, wlr_surface> for Surface {
     #[doc(hidden)]
     unsafe fn from_ptr(surface: *mut wlr_surface) -> Self {
+        if (*surface).data.is_null() {
+            panic!("Internal was null")
+        }
         let data = (*surface).data as *mut InternalState;
         let liveliness = (*data).handle.upgrade().unwrap();
         let subsurfaces_manager = (*data).subsurfaces_manager.clone().upgrade().unwrap();
@@ -344,6 +347,7 @@ impl Drop for Surface {
         }
         unsafe {
             Box::from_raw((*self.surface).data as *mut InternalState);
+            (*self.surface).data = ptr::null_mut();
         }
     }
 }

--- a/src/xwayland/manager.rs
+++ b/src/xwayland/manager.rs
@@ -7,6 +7,8 @@
 //! Pass that function to the [`xwayland::Builder`](./struct.Builder.html)
 //! which is then passed to the `compositor::Builder`.
 
+use std::ptr::NonNull;
+
 use libc;
 use wayland_sys::server::signal::wl_signal_add;
 use wlroots_sys::wlr_xwayland_surface;
@@ -78,7 +80,7 @@ wayland_listener_static! {
             wl_signal_add(&mut (*surface_ptr).events.ping_timeout as *mut _ as _,
                           shell.ping_timeout_listener() as *mut _ as _);
             let shell_data = (*surface_ptr).data as *mut xwayland::surface::State;
-            (*shell_data).shell = Box::into_raw(shell);
+            (*shell_data).shell = NonNull::new(Box::into_raw(shell));
             // TODO Pass in the new surface from the data
         };
     ]

--- a/src/xwayland/surface.rs
+++ b/src/xwayland/surface.rs
@@ -582,10 +582,13 @@ impl Drop for Surface {
 
 impl Handleable<(), wlr_xwayland_surface> for Surface {
     #[doc(hidden)]
-    unsafe fn from_ptr(shell_surface: *mut wlr_xwayland_surface) -> Self {
+    unsafe fn from_ptr(shell_surface: *mut wlr_xwayland_surface) -> Option<Self> {
+        if (*shell_surface).data.is_null() {
+            return None
+        }
         let data = (*shell_surface).data as *mut State;
         let liveliness = (*data).handle.upgrade().unwrap();
-        Surface { liveliness, shell_surface }
+        Some(Surface { liveliness, shell_surface })
     }
 
     #[doc(hidden)]
@@ -607,7 +610,7 @@ impl Handleable<(), wlr_xwayland_surface> for Surface {
         Handle { ptr: self.shell_surface,
                  handle: Rc::downgrade(&self.liveliness),
                  _marker: std::marker::PhantomData,
-                 data: () }
+                 data: Some(()) }
     }
 }
 


### PR DESCRIPTION
There was a use-after-free if `yad --entry` was ran in a compositor and then killed with `SIGTERM` (e.g. with ^C). This was because it was using the internal resource again when it upgraded the data. 

The first commit of this patch series is a naive fix. The rest of the commits are doing it better by changing how `Handle` stores its data. It now stores a `Option<D>`. This was done because we needed a default for `D` but `Default` isn't implemented for raw pointers (which most `D`s were).

However, since `D` was always a pointer it could have been null this would have added overhead. To keep the cost down, and because it was a big change already, I also switched all the internal pointers over to NonNulls. This added some noise in the code, but makes it much more difficult to have these sort of errors hopefully.